### PR TITLE
FIX inline rules YAML sample description is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,8 @@ metadata:
     app.kubernetes.io/name: falco-operator
   name: falco-rules
 spec:
- ociArtifact:
-   inline: |-
-     [rules body]
+ inlineRules: |-
+   [rules body]
 ```
 
 ### Managing Plugins


### PR DESCRIPTION
FIX inline rules YAML sample description is incorrect according to "rulesFiles" CRDs fields.

**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**


/area docs

**What this PR does / why we need it**:

This PR fix 2 typo errors in the README.md regarding "inline rules" sample syntax.

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falco-operator/issues/211

**Special notes for your reviewer**:

CRDs schema and fields references: https://raw.githubusercontent.com/falcosecurity/falco-operator/refs/heads/main/config/dist/install.yaml