### PR TITLE
fix: add RBAC patch verb for artifacts and K8s 1.32+ schema compatibility

### DIFF
--- a/controllers/falco/role.go
+++ b/controllers/falco/role.go
@@ -50,7 +50,7 @@ func generateRole(cl client.Client, falco *instancev1alpha1.Falco) (*unstructure
 					{
 						APIGroups: []string{artifactv1alpha1.GroupVersion.Group},
 						Resources: []string{"configs", "rulesfiles", "plugins"},
-						Verbs:     []string{"get", "update", "list", "watch"},
+						Verbs:     []string{"get", "update", "patch", "list", "watch"},
 					},
 				},
 			}

--- a/controllers/falco/role_test.go
+++ b/controllers/falco/role_test.go
@@ -97,7 +97,7 @@ func TestGenerateRole(t *testing.T) {
 			assert.Contains(t, role.Rules, rbacv1.PolicyRule{
 				APIGroups: []string{artifactv1alpha1.GroupVersion.Group},
 				Resources: []string{"configs", "rulesfiles", "plugins"},
-				Verbs:     []string{"get", "update", "list", "watch"},
+				Verbs:     []string{"get", "update", "patch", "list", "watch"},
 			})
 		})
 	}

--- a/internal/pkg/scheme/parser.go
+++ b/internal/pkg/scheme/parser.go
@@ -1671,6 +1671,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: updatedReplicas
       type:
         scalar: numeric
+    - name: terminatingReplicas
+      type:
+        scalar: numeric
 - name: io.k8s.api.apps.v1.DeploymentStrategy
   map:
     fields:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-operator

/area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

Fixes two bugs discovered during e2e testing:

1. **RBAC**: Adds `patch` verb to the Role generated for the artifact-operator sidecar (`controllers/falco/role.go`). The artifact-operator uses `client.MergeFrom` + `Patch` to add finalizers on Config/Rulesfile/Plugin CRs, which requires the `patch` permission.

2. **Schema**: Adds `terminatingReplicas` to the embedded `DeploymentStatus` schema (`internal/pkg/scheme/parser.go`). Kubernetes 1.32+ added this field to `apps/v1/Deployment` status, causing `structured-merge-diff` to reject Deployment objects when parsing managed fields. The addition is backward compatible with older K8s versions.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #233 

**Special notes for your reviewer**:
