### PR TITLE
feat(falco): support DaemonSet/Deployment update strategy configuration

### DIFF
--- a/api/instance/v1alpha1/falco_types.go
+++ b/api/instance/v1alpha1/falco_types.go
@@ -17,6 +17,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -54,6 +55,16 @@ type FalcoSpec struct {
 	// Users can customize metadata, initContainers, containers, volumes, tolerations, etc.
 	// +optional
 	PodTemplateSpec *corev1.PodTemplateSpec `json:"podTemplateSpec,omitempty"`
+
+	// UpdateStrategy specifies the update strategy for the DaemonSet.
+	// Only applicable when type is "DaemonSet".
+	// +optional
+	UpdateStrategy *appsv1.DaemonSetUpdateStrategy `json:"updateStrategy,omitempty"`
+
+	// Strategy specifies the deployment strategy for the Deployment.
+	// Only applicable when type is "Deployment".
+	// +optional
+	Strategy *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
 // FalcoStatus defines the observed state of Falco.

--- a/api/instance/v1alpha1/zz_generated.deepcopy.go
+++ b/api/instance/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -98,6 +99,16 @@ func (in *FalcoSpec) DeepCopyInto(out *FalcoSpec) {
 	if in.PodTemplateSpec != nil {
 		in, out := &in.PodTemplateSpec, &out.PodTemplateSpec
 		*out = new(v1.PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.UpdateStrategy != nil {
+		in, out := &in.UpdateStrategy, &out.UpdateStrategy
+		*out = new(appsv1.DaemonSetUpdateStrategy)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(appsv1.DeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/instance.falcosecurity.dev_falcos.yaml
+++ b/config/crd/bases/instance.falcosecurity.dev_falcos.yaml
@@ -8582,6 +8582,55 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              strategy:
+                description: |-
+                  Strategy specifies the deployment strategy for the Deployment.
+                  Only applicable when type is "Deployment".
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
               type:
                 default: DaemonSet
                 description: |-
@@ -8591,6 +8640,65 @@ spec:
                 - DaemonSet
                 - Deployment
                 type: string
+              updateStrategy:
+                description: |-
+                  UpdateStrategy specifies the update strategy for the DaemonSet.
+                  Only applicable when type is "DaemonSet".
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if type
+                      = "RollingUpdate".
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of nodes with an existing available DaemonSet pod that
+                          can have an updated DaemonSet pod during during an update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                          Default value is 0.
+                          Example: when this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked as deleted.
+                          The update starts by launching new pods on 30% of nodes. Once an updated
+                          pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                          on that node is marked deleted. If the old pod becomes unavailable for any
+                          reason (Ready transitions to false, is evicted, or is drained) an updated
+                          pod is immediately created on that node without considering surge limits.
+                          Allowing surge implies the possibility that the resources consumed by the
+                          daemonset on any given node can double if the readiness check fails, and
+                          so resource intensive daemonsets should take into account that they may
+                          cause evictions during disruption.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of DaemonSet pods that can be unavailable during the
+                          update. Value can be an absolute number (ex: 5) or a percentage of total
+                          number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                          number is calculated from percentage by rounding up.
+                          This cannot be 0 if MaxSurge is 0
+                          Default value is 1.
+                          Example: when this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time. The update
+                          starts by stopping at most 30% of those DaemonSet pods and then brings
+                          up new DaemonSet pods in their place. Once the new pods are available,
+                          it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                          70% of original number of DaemonSet pods are available at all times during
+                          the update.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
+                    type: string
+                type: object
               version:
                 description: |-
                   Version specifies the version of Falco to deploy.

--- a/config/samples/instance_v1alpha1_falco.yaml
+++ b/config/samples/instance_v1alpha1_falco.yaml
@@ -6,4 +6,15 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: falco-sample
 spec:
-  # TODO(user): Add fields here
+  # type: DaemonSet
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 1
+  # type: Deployment
+  # replicas: 2
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 1
+  #     maxSurge: 1

--- a/controllers/falco/controller_unit_test.go
+++ b/controllers/falco/controller_unit_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -116,6 +117,25 @@ func withLabels(labels map[string]string) func(*instancev1alpha1.Falco) {
 	return func(f *instancev1alpha1.Falco) {
 		f.Labels = labels
 	}
+}
+
+// withStrategy sets the Deployment strategy.
+func withStrategy(s appsv1.DeploymentStrategy) func(*instancev1alpha1.Falco) {
+	return func(f *instancev1alpha1.Falco) {
+		f.Spec.Strategy = &s
+	}
+}
+
+// withUpdateStrategy sets the DaemonSet update strategy.
+func withUpdateStrategy(s appsv1.DaemonSetUpdateStrategy) func(*instancev1alpha1.Falco) {
+	return func(f *instancev1alpha1.Falco) {
+		f.Spec.UpdateStrategy = &s
+	}
+}
+
+func intstrPtr(val int) *intstr.IntOrString {
+	v := intstr.FromInt32(int32(val))
+	return &v
 }
 
 func TestEnsureResource(t *testing.T) {
@@ -321,6 +341,80 @@ func TestEnsureResource(t *testing.T) {
 					}
 				}
 				assert.True(t, foundConfigMapRule, "Role should have configmaps rule after update")
+			},
+		},
+		{
+			name: "creates Deployment with custom Recreate strategy",
+			falco: newFalco("test-falco", withType(resourceTypeDeployment), withReplicas(1),
+				withStrategy(appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType})),
+			generator: func(cl client.Client, falco *instancev1alpha1.Falco) (*unstructured.Unstructured, error) {
+				return generateApplyConfiguration(cl, falco, false)
+			},
+			validateResult: func(t *testing.T, cl client.Client, falco *instancev1alpha1.Falco) {
+				dep := &appsv1.Deployment{}
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(falco), dep)
+				require.NoError(t, err)
+				assert.Equal(t, appsv1.RecreateDeploymentStrategyType, dep.Spec.Strategy.Type)
+			},
+		},
+		{
+			name:  "creates Deployment with default RollingUpdate strategy",
+			falco: newFalco("test-falco", withType(resourceTypeDeployment), withReplicas(1)),
+			generator: func(cl client.Client, falco *instancev1alpha1.Falco) (*unstructured.Unstructured, error) {
+				return generateApplyConfiguration(cl, falco, false)
+			},
+			validateResult: func(t *testing.T, cl client.Client, falco *instancev1alpha1.Falco) {
+				dep := &appsv1.Deployment{}
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(falco), dep)
+				require.NoError(t, err)
+				assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, dep.Spec.Strategy.Type)
+			},
+		},
+		{
+			name: "creates DaemonSet with custom OnDelete update strategy",
+			falco: newFalco("test-falco", withType(resourceTypeDaemonSet),
+				withUpdateStrategy(appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType})),
+			generator: func(cl client.Client, falco *instancev1alpha1.Falco) (*unstructured.Unstructured, error) {
+				return generateApplyConfiguration(cl, falco, false)
+			},
+			validateResult: func(t *testing.T, cl client.Client, falco *instancev1alpha1.Falco) {
+				ds := &appsv1.DaemonSet{}
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(falco), ds)
+				require.NoError(t, err)
+				assert.Equal(t, appsv1.OnDeleteDaemonSetStrategyType, ds.Spec.UpdateStrategy.Type)
+			},
+		},
+		{
+			name:  "creates DaemonSet with default RollingUpdate update strategy",
+			falco: newFalco("test-falco", withType(resourceTypeDaemonSet)),
+			generator: func(cl client.Client, falco *instancev1alpha1.Falco) (*unstructured.Unstructured, error) {
+				return generateApplyConfiguration(cl, falco, false)
+			},
+			validateResult: func(t *testing.T, cl client.Client, falco *instancev1alpha1.Falco) {
+				ds := &appsv1.DaemonSet{}
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(falco), ds)
+				require.NoError(t, err)
+				assert.Equal(t, appsv1.RollingUpdateDaemonSetStrategyType, ds.Spec.UpdateStrategy.Type)
+			},
+		},
+		{
+			name: "creates DaemonSet with RollingUpdate maxUnavailable",
+			falco: newFalco("test-falco", withType(resourceTypeDaemonSet), withUpdateStrategy(appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: intstrPtr(3),
+				},
+			})),
+			generator: func(cl client.Client, falco *instancev1alpha1.Falco) (*unstructured.Unstructured, error) {
+				return generateApplyConfiguration(cl, falco, false)
+			},
+			validateResult: func(t *testing.T, cl client.Client, falco *instancev1alpha1.Falco) {
+				ds := &appsv1.DaemonSet{}
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(falco), ds)
+				require.NoError(t, err)
+				assert.Equal(t, appsv1.RollingUpdateDaemonSetStrategyType, ds.Spec.UpdateStrategy.Type)
+				require.NotNil(t, ds.Spec.UpdateStrategy.RollingUpdate)
+				assert.Equal(t, 3, ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntValue())
 			},
 		},
 		{

--- a/controllers/falco/resourceApplyConfiguration.go
+++ b/controllers/falco/resourceApplyConfiguration.go
@@ -155,9 +155,7 @@ func baseDeployment(nativeSidecar bool, falco *v1alpha1.Falco) *appsv1.Deploymen
 					},
 				},
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-			},
+			Strategy: deploymentStrategy(falco),
 		},
 	}
 
@@ -188,6 +186,7 @@ func baseDaemonSet(nativeSidecar bool, falco *v1alpha1.Falco) *appsv1.DaemonSet 
 					"app.kubernetes.io/instance": falco.Name,
 				},
 			},
+			UpdateStrategy: daemonSetUpdateStrategy(falco),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: podTemplateSpecLabels(falco.Name, falco.Labels),
@@ -231,6 +230,26 @@ func baseDaemonSet(nativeSidecar bool, falco *v1alpha1.Falco) *appsv1.DaemonSet 
 	return ds
 }
 
+// deploymentStrategy returns the deployment strategy from the Falco CR or the default RollingUpdate.
+func deploymentStrategy(falco *v1alpha1.Falco) appsv1.DeploymentStrategy {
+	if falco.Spec.Strategy != nil {
+		return *falco.Spec.Strategy
+	}
+	return appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+	}
+}
+
+// daemonSetUpdateStrategy returns the update strategy from the Falco CR or the default RollingUpdate.
+func daemonSetUpdateStrategy(falco *v1alpha1.Falco) appsv1.DaemonSetUpdateStrategy {
+	if falco.Spec.UpdateStrategy != nil {
+		return *falco.Spec.UpdateStrategy
+	}
+	return appsv1.DaemonSetUpdateStrategy{
+		Type: appsv1.RollingUpdateDaemonSetStrategyType,
+	}
+}
+
 // generateUserDefinedResource generates a user-defined resource from the falco CR.
 func generateUserDefinedResource(nativeSidecar bool, falco *v1alpha1.Falco) (*unstructured.Unstructured, error) {
 	// Build the default resource from the base one.
@@ -256,11 +275,17 @@ func generateUserDefinedResource(nativeSidecar bool, falco *v1alpha1.Falco) (*un
 		} else {
 			res.Spec.Template = corev1.PodTemplateSpec{}
 		}
+		if falco.Spec.Strategy != nil {
+			res.Spec.Strategy = *falco.Spec.Strategy
+		}
 	case *appsv1.DaemonSet:
 		if falco.Spec.PodTemplateSpec != nil {
 			res.Spec.Template = *falco.Spec.PodTemplateSpec
 		} else {
 			res.Spec.Template = corev1.PodTemplateSpec{}
+		}
+		if falco.Spec.UpdateStrategy != nil {
+			res.Spec.UpdateStrategy = *falco.Spec.UpdateStrategy
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area falco-operator

> /area artifact-operator

> /area pkg

/area api

> /area docs

**What this PR does / why we need it**:

Adds `updateStrategy` (DaemonSet) and `strategy` (Deployment) optional fields to `FalcoSpec`, allowing users to configure the workload update strategy directly from the Falco CR. Default behavior is unchanged (`RollingUpdate` for both resource types).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #246 

**Special notes for your reviewer**:
