### PR TITLE
feat(artifact): extend recorded Kubernetes events for all store operations

### DIFF
--- a/controllers/artifact/config/controller.go
+++ b/controllers/artifact/config/controller.go
@@ -205,8 +205,7 @@ func (r *ConfigReconciler) enforceReferenceResolution(ctx context.Context, confi
 		err := r.artifactManager.CheckReferenceResolution(ctx, config.Namespace, config.Spec.ConfigMapRef.Name, &corev1.ConfigMap{})
 		if err != nil {
 			logger.Error(err, "ConfigMap reference resolution failed", "configMap", config.Spec.ConfigMapRef.Name)
-			r.recorder.Eventf(config, nil, corev1.EventTypeWarning, artifact.ReasonReferenceResolutionFailed,
-				artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
+			artifact.RecordWarning(r.recorder, config, artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
 			apimeta.SetStatusCondition(&config.Status.Conditions, common.NewResolvedRefsCondition(
 				metav1.ConditionFalse, artifact.ReasonReferenceResolutionFailed,
 				fmt.Sprintf(artifact.MessageFormatReferenceResolutionFailed, config.Spec.ConfigMapRef.Name), config.GetGeneration()))
@@ -217,8 +216,7 @@ func (r *ConfigReconciler) enforceReferenceResolution(ctx context.Context, confi
 			return err
 		}
 
-		r.recorder.Eventf(config, nil, corev1.EventTypeNormal, artifact.ReasonReferenceResolved,
-			artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
+		artifact.RecordNormal(r.recorder, config, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
 		apimeta.SetStatusCondition(&config.Status.Conditions, common.NewResolvedRefsCondition(
 			metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, config.GetGeneration(),
 		))
@@ -245,39 +243,32 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 		return fmt.Errorf("converting inline config to YAML: %w", err)
 	}
 
-	if err := r.artifactManager.StoreFromInLineYaml(ctx, config.Name, p, configData, artifact.TypeConfig); err != nil {
+	inlineAction, err := r.artifactManager.StoreFromInLineYaml(ctx, config.Name, p, configData, artifact.TypeConfig)
+	if err != nil {
 		logger.Error(err, "unable to store inline config")
-		r.recorder.Eventf(config, nil, corev1.EventTypeWarning, artifact.ReasonInlineConfigStoreFailed,
-			artifact.ReasonInlineConfigStoreFailed, artifact.MessageFormatConfigStoreFailed, err.Error())
+		artifact.RecordWarning(r.recorder, config, artifact.ReasonInlineConfigStoreFailed, artifact.MessageFormatConfigStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&config.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonInlineConfigStoreFailed,
 			fmt.Sprintf(artifact.MessageFormatConfigStoreFailed, err.Error()), gen,
 		))
 		return err
 	}
-
-	if configData != nil {
-		r.recorder.Eventf(config, nil, corev1.EventTypeNormal, artifact.ReasonInlineConfigStored,
-			artifact.ReasonInlineConfigStored, artifact.MessageInlineConfigStored)
-	}
+	artifact.RecordStoreEvent(r.recorder, config, inlineAction, artifact.MediumInline)
 
 	// Store ConfigMap config if specified.
-	if config.Spec.ConfigMapRef != nil {
-		if err := r.artifactManager.StoreFromConfigMap(
-			ctx, config.Name, config.Namespace, p, config.Spec.ConfigMapRef, artifact.TypeConfig,
-		); err != nil {
-			logger.Error(err, "unable to store config from ConfigMap reference")
-			r.recorder.Eventf(config, nil, corev1.EventTypeWarning, artifact.ReasonConfigMapConfigStoreFailed,
-				artifact.ReasonConfigMapConfigStoreFailed, artifact.MessageFormatConfigMapConfigStoreFailed, err.Error())
-			apimeta.SetStatusCondition(&config.Status.Conditions, common.NewProgrammedCondition(
-				metav1.ConditionFalse, artifact.ReasonConfigMapConfigStoreFailed,
-				fmt.Sprintf(artifact.MessageFormatConfigMapConfigStoreFailed, err.Error()), gen,
-			))
-			return err
-		}
-		r.recorder.Eventf(config, nil, corev1.EventTypeNormal, artifact.ReasonConfigMapConfigStored,
-			artifact.ReasonConfigMapConfigStored, artifact.MessageConfigMapConfigStored)
+	cmAction, err := r.artifactManager.StoreFromConfigMap(
+		ctx, config.Name, config.Namespace, p, config.Spec.ConfigMapRef, artifact.TypeConfig,
+	)
+	if err != nil {
+		logger.Error(err, "unable to store config from ConfigMap reference")
+		artifact.RecordWarning(r.recorder, config, artifact.ReasonConfigMapConfigStoreFailed, artifact.MessageFormatConfigMapConfigStoreFailed, err.Error())
+		apimeta.SetStatusCondition(&config.Status.Conditions, common.NewProgrammedCondition(
+			metav1.ConditionFalse, artifact.ReasonConfigMapConfigStoreFailed,
+			fmt.Sprintf(artifact.MessageFormatConfigMapConfigStoreFailed, err.Error()), gen,
+		))
+		return err
 	}
+	artifact.RecordStoreEvent(r.recorder, config, cmAction, artifact.MediumConfigMap)
 
 	apimeta.SetStatusCondition(&config.Status.Conditions, common.NewProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed, gen,

--- a/controllers/artifact/config/controller_test.go
+++ b/controllers/artifact/config/controller_test.go
@@ -561,6 +561,7 @@ func TestEnsureConfig(t *testing.T) {
 		wantErr        bool
 		wantConditions []testutil.ConditionExpect
 		wantFiles      []string
+		wantEvents     []string
 	}{
 		{
 			name: "success stores inline config and sets conditions",
@@ -578,7 +579,8 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{testConfigYAML},
+			wantFiles:  []string{testConfigYAML},
+			wantEvents: []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "no sources sets Programmed true",
@@ -595,6 +597,7 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
+			wantEvents: []string{},
 		},
 		{
 			name: "non-nil config with empty Raw is treated as no inline config",
@@ -612,6 +615,7 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
+			wantEvents: []string{},
 		},
 		{
 			name: "success stores configmap config and sets conditions",
@@ -640,7 +644,8 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{testConfigData},
+			wantFiles:  []string{testConfigData},
+			wantEvents: []string{"Normal ConfigMapArtifactStored ConfigMap artifact stored successfully"},
 		},
 		{
 			name: "both inline and configmap sources write two files",
@@ -671,6 +676,10 @@ func TestEnsureConfig(t *testing.T) {
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
 			wantFiles: []string{testConfigYAML, testConfigData},
+			wantEvents: []string{
+				"Normal InlineArtifactStored Inline artifact stored successfully",
+				"Normal ConfigMapArtifactStored ConfigMap artifact stored successfully",
+			},
 		},
 		{
 			name: "malformed YAML in inline config returns error",
@@ -685,7 +694,8 @@ func TestEnsureConfig(t *testing.T) {
 					Priority: 50,
 				},
 			},
-			wantErr: true,
+			wantErr:    true,
+			wantEvents: []string{},
 		},
 		{
 			name: "failure sets error condition on inline content",
@@ -705,6 +715,7 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonInlineConfigStoreFailed},
 			},
+			wantEvents: []string{"Warning InlineConfigStoreFailed Failed to store config: disk full"},
 		},
 		{
 			name: "failure on configmap store sets error condition",
@@ -735,6 +746,7 @@ func TestEnsureConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonConfigMapConfigStoreFailed},
 			},
+			wantEvents: []string{"Warning ConfigMapConfigStoreFailed Failed to store ConfigMap config: disk full"},
 		},
 	}
 
@@ -759,6 +771,7 @@ func TestEnsureConfig(t *testing.T) {
 			}
 
 			testutil.RequireConditions(t, tt.config.Status.Conditions, tt.wantConditions)
+			testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events, tt.wantEvents)
 
 			if len(tt.wantFiles) > 0 {
 				require.Len(t, mockFS.Files, len(tt.wantFiles), "unexpected number of files written")

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -192,19 +192,17 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 
 	apimeta.RemoveStatusCondition(&plugin.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
 
-	if err = r.artifactManager.StoreFromOCI(ctx, plugin.Name, priority.DefaultPriority, artifact.TypePlugin, plugin.Spec.OCIArtifact); err != nil {
+	ociAction, err := r.artifactManager.StoreFromOCI(ctx, plugin.Name, priority.DefaultPriority, artifact.TypePlugin, plugin.Spec.OCIArtifact)
+	if err != nil {
 		logger.Error(err, "unable to store plugin artifact")
-		r.recorder.Eventf(plugin, nil, corev1.EventTypeWarning, artifact.ReasonOCIArtifactStoreFailed,
-			artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
+		artifact.RecordWarning(r.recorder, plugin, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonOCIArtifactStoreFailed,
 			fmt.Sprintf(artifact.MessageFormatOCIArtifactStoreFailed, err.Error()), gen,
 		))
 		return err
 	}
-
-	r.recorder.Eventf(plugin, nil, corev1.EventTypeNormal, artifact.ReasonOCIArtifactStored,
-		artifact.ReasonOCIArtifactStored, artifact.MessageOCIArtifactStored)
+	artifact.RecordStoreEvent(r.recorder, plugin, ociAction, artifact.MediumOCI)
 	apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed, gen,
 	))
@@ -224,8 +222,7 @@ func (r *PluginReconciler) enforceReferenceResolution(ctx context.Context, plugi
 			err := r.artifactManager.CheckReferenceResolution(ctx, plugin.Namespace, secretName, &corev1.Secret{})
 			if err != nil {
 				logger.Error(err, "OCIArtifact auth secret reference resolution failed", "secret", secretName)
-				r.recorder.Eventf(plugin, nil, corev1.EventTypeWarning, artifact.ReasonReferenceResolutionFailed,
-					artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
+				artifact.RecordWarning(r.recorder, plugin, artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
 				apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewResolvedRefsCondition(
 					metav1.ConditionFalse, artifact.ReasonReferenceResolutionFailed,
 					fmt.Sprintf(artifact.MessageFormatReferenceResolutionFailed, secretName), plugin.GetGeneration()))
@@ -239,8 +236,7 @@ func (r *PluginReconciler) enforceReferenceResolution(ctx context.Context, plugi
 	}
 
 	if hasRefs {
-		r.recorder.Eventf(plugin, nil, corev1.EventTypeNormal, artifact.ReasonReferenceResolved,
-			artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
+		artifact.RecordNormal(r.recorder, plugin, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewResolvedRefsCondition(
 			metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, plugin.GetGeneration(),
 		))
@@ -259,8 +255,7 @@ func (r *PluginReconciler) handleDeletion(ctx context.Context, plugin *artifactv
 		if controllerutil.ContainsFinalizer(plugin, r.finalizer) {
 			logger.Info("Plugin instance marked for deletion, cleaning up")
 			if err := r.artifactManager.RemoveAll(ctx, plugin.Name); err != nil {
-				r.recorder.Eventf(plugin, nil, corev1.EventTypeWarning, artifact.ReasonArtifactRemoveFailed,
-					artifact.ReasonArtifactRemoveFailed, artifact.MessageFormatPluginArtifactsRemoveFailed, err.Error())
+				artifact.RecordWarning(r.recorder, plugin, artifact.ReasonArtifactRemoveFailed, artifact.MessageFormatPluginArtifactsRemoveFailed, err.Error())
 				return false, err
 			}
 
@@ -274,8 +269,7 @@ func (r *PluginReconciler) handleDeletion(ctx context.Context, plugin *artifactv
 				return false, err
 			}
 
-			r.recorder.Eventf(plugin, nil, corev1.EventTypeNormal, artifact.ReasonArtifactRemoved,
-				artifact.ReasonArtifactRemoved, artifact.MessagePluginArtifactsRemoved)
+			artifact.RecordNormal(r.recorder, plugin, artifact.ReasonPluginArtifactsRemoved, artifact.MessagePluginArtifactsRemoved)
 
 			// Remove the finalizer.
 			logger.V(3).Info("Removing finalizer", "finalizer", r.finalizer)
@@ -314,7 +308,7 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 	pluginConfigString, err := r.PluginsConfig.toString()
 	if err != nil {
 		logger.Error(err, "unable to convert plugin config to string")
-		r.recorder.Eventf(plugin, nil, corev1.EventTypeWarning, artifact.ReasonInlinePluginConfigStoreFailed,
+		artifact.RecordWarning(r.recorder, plugin,
 			artifact.ReasonInlinePluginConfigStoreFailed, artifact.MessageFormatInlinePluginConfigStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonInlinePluginConfigStoreFailed,
@@ -323,10 +317,11 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 		return err
 	}
 
-	if err = r.artifactManager.StoreFromInLineYaml(ctx, pluginConfigFileName, priority.MaxPriority,
-		&pluginConfigString, artifact.TypeConfig); err != nil {
+	configAction, err := r.artifactManager.StoreFromInLineYaml(ctx, pluginConfigFileName, priority.MaxPriority,
+		&pluginConfigString, artifact.TypeConfig)
+	if err != nil {
 		logger.Error(err, "unable to store plugin config", "filename", pluginConfigFileName)
-		r.recorder.Eventf(plugin, nil, corev1.EventTypeWarning, artifact.ReasonInlinePluginConfigStoreFailed,
+		artifact.RecordWarning(r.recorder, plugin,
 			artifact.ReasonInlinePluginConfigStoreFailed, artifact.MessageFormatInlinePluginConfigStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonInlinePluginConfigStoreFailed,
@@ -334,9 +329,7 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 		))
 		return err
 	}
-
-	r.recorder.Eventf(plugin, nil, corev1.EventTypeNormal, artifact.ReasonInlinePluginConfigStored,
-		artifact.ReasonInlinePluginConfigStored, artifact.MessageInlinePluginConfigStored)
+	artifact.RecordStoreEvent(r.recorder, plugin, configAction, artifact.MediumInline)
 	apimeta.SetStatusCondition(&plugin.Status.Conditions, common.NewProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed, gen,
 	))
@@ -364,7 +357,7 @@ func (r *PluginReconciler) removePluginConfig(ctx context.Context, plugin *artif
 		return err
 	}
 
-	if err := r.artifactManager.StoreFromInLineYaml(ctx, pluginConfigFileName, priority.MaxPriority,
+	if _, err := r.artifactManager.StoreFromInLineYaml(ctx, pluginConfigFileName, priority.MaxPriority,
 		&pluginConfigString, artifact.TypeConfig); err != nil {
 		logger.Error(err, "unable to store plugin config", "filename", pluginConfigFileName)
 		return err

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -592,6 +592,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 		wantCRTrackKey    string
 		wantCRTrackValue  string
 		wantConditions    []testutil.ConditionExpect
+		wantEvents        []string
 	}{
 		{
 			name: "writes config for basic plugin",
@@ -604,6 +605,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			wantConfigName:   "json",
 			wantCRTrackKey:   "json",
 			wantCRTrackValue: "json",
+			wantEvents:       []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "writes config with initConfig",
@@ -621,6 +623,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			initialConfig:     &PluginsConfig{},
 			wantConfigCount:   1,
 			wantHasInitConfig: true,
+			wantEvents:        []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "removes stale entry on config name change",
@@ -643,6 +646,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			wantConfigName:   "new-name",
 			wantCRTrackKey:   "my-plugin",
 			wantCRTrackValue: "new-name",
+			wantEvents:       []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "same config name does not remove entry",
@@ -656,6 +660,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			},
 			wantConfigCount: 1,
 			wantConfigName:  "json",
+			wantEvents:      []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "store inline yaml fails sets error conditions",
@@ -673,6 +678,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonInlinePluginConfigStoreFailed},
 			},
+			wantEvents: []string{"Warning InlinePluginConfigStoreFailed Failed to store inline plugin config: disk full"},
 		},
 	}
 
@@ -715,6 +721,7 @@ func TestEnsurePluginConfig(t *testing.T) {
 			if len(tt.wantConditions) > 0 {
 				testutil.RequireConditions(t, tt.plugin.Status.Conditions, tt.wantConditions)
 			}
+			testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events, tt.wantEvents)
 		})
 	}
 }

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -210,20 +210,17 @@ func (r *RulesfileReconciler) ensureRulesfile(ctx context.Context, rulesfile *ar
 	apimeta.RemoveStatusCondition(&rulesfile.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
 
 	// Store OCI artifact if specified; passing nil removes any previously stored OCI artifact.
-	if err = r.artifactManager.StoreFromOCI(ctx, rulesfile.Name, p, artifact.TypeRulesfile, rulesfile.Spec.OCIArtifact); err != nil {
+	ociAction, err := r.artifactManager.StoreFromOCI(ctx, rulesfile.Name, p, artifact.TypeRulesfile, rulesfile.Spec.OCIArtifact)
+	if err != nil {
 		logger.Error(err, "unable to store Rulesfile OCI artifact")
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeWarning, artifact.ReasonOCIArtifactStoreFailed,
-			artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
+		artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonOCIArtifactStoreFailed,
 			fmt.Sprintf(artifact.MessageFormatOCIArtifactStoreFailed, err.Error()), gen,
 		))
 		return err
 	}
-	if rulesfile.Spec.OCIArtifact != nil {
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeNormal, artifact.ReasonOCIArtifactStored,
-			artifact.ReasonOCIArtifactStored, artifact.MessageOCIArtifactStored)
-	}
+	artifact.RecordStoreEvent(r.recorder, rulesfile, ociAction, artifact.MediumOCI)
 
 	// Store inline rules if specified.
 	// spec.inlineRules is stored as JSON by the API server; convert to YAML before writing to disk.
@@ -233,28 +230,25 @@ func (r *RulesfileReconciler) ensureRulesfile(ctx context.Context, rulesfile *ar
 		return fmt.Errorf("converting inline rules to YAML: %w", err)
 	}
 
-	if err = r.artifactManager.StoreFromInLineYaml(ctx, rulesfile.Name, p, inlineRulesData, artifact.TypeRulesfile); err != nil {
+	inlineAction, err := r.artifactManager.StoreFromInLineYaml(ctx, rulesfile.Name, p, inlineRulesData, artifact.TypeRulesfile)
+	if err != nil {
 		logger.Error(err, "unable to store Rulesfile inline rules")
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeWarning, artifact.ReasonInlineRulesStoreFailed,
-			artifact.ReasonInlineRulesStoreFailed, artifact.MessageFormatInlineRulesStoreFailed, err.Error())
+		artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonInlineRulesStoreFailed, artifact.MessageFormatInlineRulesStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonInlineRulesStoreFailed,
 			fmt.Sprintf(artifact.MessageFormatInlineRulesStoreFailed, err.Error()), gen,
 		))
 		return err
 	}
-
-	if inlineRulesData != nil {
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeNormal, artifact.ReasonInlineRulesStored,
-			artifact.ReasonInlineRulesStored, artifact.MessageInlineRulesStored)
-	}
+	artifact.RecordStoreEvent(r.recorder, rulesfile, inlineAction, artifact.MediumInline)
 
 	// Store or remove ConfigMap rules. Passing nil cleans up a previously stored file.
-	if err = r.artifactManager.StoreFromConfigMap(
+	cmAction, err := r.artifactManager.StoreFromConfigMap(
 		ctx, rulesfile.Name, rulesfile.Namespace, p, rulesfile.Spec.ConfigMapRef, artifact.TypeRulesfile,
-	); err != nil {
+	)
+	if err != nil {
 		logger.Error(err, "unable to store Rulesfile from ConfigMap reference")
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeWarning, artifact.ReasonConfigMapRulesStoreFailed,
+		artifact.RecordWarning(r.recorder, rulesfile,
 			artifact.ReasonConfigMapRulesStoreFailed, artifact.MessageFormatConfigMapRulesStoreFailed, err.Error())
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewProgrammedCondition(
 			metav1.ConditionFalse, artifact.ReasonConfigMapRulesStoreFailed,
@@ -262,10 +256,7 @@ func (r *RulesfileReconciler) ensureRulesfile(ctx context.Context, rulesfile *ar
 		))
 		return err
 	}
-	if rulesfile.Spec.ConfigMapRef != nil {
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeNormal, artifact.ReasonConfigMapRulesStored,
-			artifact.ReasonConfigMapRulesStored, artifact.MessageConfigMapRulesStored)
-	}
+	artifact.RecordStoreEvent(r.recorder, rulesfile, cmAction, artifact.MediumConfigMap)
 
 	apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed, gen,
@@ -283,7 +274,7 @@ func (r *RulesfileReconciler) enforceReferenceResolution(ctx context.Context, ru
 		err := r.artifactManager.CheckReferenceResolution(ctx, rulesfile.Namespace, rulesfile.Spec.ConfigMapRef.Name, &corev1.ConfigMap{})
 		if err != nil {
 			logger.Error(err, "ConfigMap reference resolution failed", "configMap", rulesfile.Spec.ConfigMapRef.Name)
-			r.recorder.Eventf(rulesfile, nil, corev1.EventTypeWarning, artifact.ReasonReferenceResolutionFailed,
+			artifact.RecordWarning(r.recorder, rulesfile,
 				artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
 			apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewResolvedRefsCondition(
 				metav1.ConditionFalse, artifact.ReasonReferenceResolutionFailed,
@@ -305,7 +296,7 @@ func (r *RulesfileReconciler) enforceReferenceResolution(ctx context.Context, ru
 			err := r.artifactManager.CheckReferenceResolution(ctx, rulesfile.Namespace, secretName, &corev1.Secret{})
 			if err != nil {
 				logger.Error(err, "OCIArtifact auth secret reference resolution failed", "secret", secretName)
-				r.recorder.Eventf(rulesfile, nil, corev1.EventTypeWarning, artifact.ReasonReferenceResolutionFailed,
+				artifact.RecordWarning(r.recorder, rulesfile,
 					artifact.ReasonReferenceResolutionFailed, artifact.MessageFormatReferenceResolutionFailed, err.Error())
 				apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewResolvedRefsCondition(
 					metav1.ConditionFalse, artifact.ReasonReferenceResolutionFailed,
@@ -320,8 +311,7 @@ func (r *RulesfileReconciler) enforceReferenceResolution(ctx context.Context, ru
 	}
 
 	if hasRefs {
-		r.recorder.Eventf(rulesfile, nil, corev1.EventTypeNormal, artifact.ReasonReferenceResolved,
-			artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
+		artifact.RecordNormal(r.recorder, rulesfile, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved)
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewResolvedRefsCondition(
 			metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, rulesfile.GetGeneration(),
 		))

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -465,6 +465,8 @@ func TestEnsureRulesfile(t *testing.T) {
 		wantFiles []string
 		// wantDirEmpty asserts the rulesfile temp dir is empty after the test (real FS only).
 		wantDirEmpty bool
+		// wantEvents is nil to skip the check; otherwise asserts the exact set of events recorded during the main call.
+		wantEvents []string
 	}{
 		{
 			name: "OCI pull error sets failure condition",
@@ -484,6 +486,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonOCIArtifactStoreFailed},
 			},
+			wantEvents: []string{"Warning OCIArtifactStoreFailed Failed to store OCI artifact: mock pull error"},
 		},
 		{
 			name: "stores inline rules successfully",
@@ -496,7 +499,8 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{testInlineRulesYAML},
+			wantFiles:  []string{testInlineRulesYAML},
+			wantEvents: []string{"Normal InlineArtifactStored Inline artifact stored successfully"},
 		},
 		{
 			name: "stores configmap ref successfully",
@@ -522,7 +526,8 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{testRulesData},
+			wantFiles:  []string{testRulesData},
+			wantEvents: []string{"Normal ConfigMapArtifactStored ConfigMap artifact stored successfully"},
 		},
 		{
 			name: "both inline and configmap sources write two files",
@@ -548,6 +553,10 @@ func TestEnsureRulesfile(t *testing.T) {
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
 			wantFiles: []string{testInlineRulesYAML, testRulesData},
+			wantEvents: []string{
+				"Normal InlineArtifactStored Inline artifact stored successfully",
+				"Normal ConfigMapArtifactStored ConfigMap artifact stored successfully",
+			},
 		},
 		{
 			name: "malformed YAML in inline rules returns error",
@@ -557,7 +566,8 @@ func TestEnsureRulesfile(t *testing.T) {
 					InlineRules: &apiextensionsv1.JSON{Raw: []byte("\t")},
 				},
 			},
-			wantErr: true,
+			wantErr:    true,
+			wantEvents: []string{},
 		},
 		{
 			name: "inline rules store failure sets condition",
@@ -572,6 +582,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonInlineRulesStoreFailed},
 			},
+			wantEvents: []string{"Warning InlineRulesStoreFailed Failed to store inline rules: mock write error"},
 		},
 		{
 			name: "configmap ref store fails on filesystem write error",
@@ -599,6 +610,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonConfigMapRulesStoreFailed},
 			},
+			wantEvents: []string{"Warning ConfigMapRulesStoreFailed Failed to store ConfigMap rules: mock write error"},
 		},
 		{
 			name: "no sources sets programmed without touching resolved refs",
@@ -609,6 +621,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
+			wantEvents: []string{},
 		},
 		{
 			name: "non-nil InlineRules with empty Raw is treated as no inline rules",
@@ -622,6 +635,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
+			wantEvents: []string{},
 		},
 		{
 			name: "removing inline rules deletes previously written file",
@@ -638,7 +652,8 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{},
+			wantFiles:  []string{},
+			wantEvents: []string{"Normal InlineArtifactRemoved Inline artifact removed from filesystem"},
 		},
 		{
 			name: "removing configmap ref deletes previously written file",
@@ -666,7 +681,8 @@ func TestEnsureRulesfile(t *testing.T) {
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
-			wantFiles: []string{},
+			wantFiles:  []string{},
+			wantEvents: []string{"Normal ConfigMapArtifactRemoved ConfigMap artifact removed from filesystem"},
 		},
 		{
 			name: "removing OCI artifact deletes previously stored file",
@@ -688,6 +704,7 @@ func TestEnsureRulesfile(t *testing.T) {
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
 			},
 			wantDirEmpty: true,
+			wantEvents:   []string{"Normal OCIArtifactRemoved OCI artifact removed from filesystem"},
 		},
 	}
 
@@ -727,6 +744,7 @@ func TestEnsureRulesfile(t *testing.T) {
 
 			if tt.preRf != nil {
 				require.NoError(t, r.ensureRulesfile(context.Background(), tt.preRf), "preRf setup failed")
+				testutil.DrainEvents(r.recorder.(*events.FakeRecorder).Events)
 			}
 
 			err := r.ensureRulesfile(context.Background(), tt.rf)
@@ -738,6 +756,7 @@ func TestEnsureRulesfile(t *testing.T) {
 			}
 
 			testutil.RequireConditions(t, tt.rf.Status.Conditions, tt.wantConditions)
+			testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events, tt.wantEvents)
 
 			if tt.wantFiles != nil {
 				require.Len(t, mockFS.Files, len(tt.wantFiles), "unexpected number of files written")

--- a/controllers/artifact/testutil/helpers.go
+++ b/controllers/artifact/testutil/helpers.go
@@ -84,3 +84,39 @@ func RequireConditions(t *testing.T, actual []metav1.Condition, expected []Condi
 		RequireCondition(t, actual, exp.Type, exp.Status, exp.Reason)
 	}
 }
+
+// CollectEvents drains all currently buffered events from the FakeRecorder channel and returns them.
+// It reads until the channel is empty (non-blocking).
+func CollectEvents(ch chan string) []string {
+	var events []string
+	for {
+		select {
+		case e := <-ch:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// DrainEvents discards all currently buffered events from the FakeRecorder channel.
+func DrainEvents(ch chan string) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+// RequireEvents asserts that the collected events from ch exactly match wantEvents (order-independent).
+// If wantEvents is nil the check is skipped.
+func RequireEvents(t *testing.T, ch chan string, wantEvents []string) {
+	t.Helper()
+	if wantEvents == nil {
+		return
+	}
+	got := CollectEvents(ch)
+	assert.ElementsMatch(t, wantEvents, got)
+}

--- a/internal/pkg/artifact/conditions.go
+++ b/internal/pkg/artifact/conditions.go
@@ -18,36 +18,48 @@ package artifact
 
 // Condition reasons.
 const (
-	// ReasonArtifactRemoved indicates the artifact was successfully removed.
-	ReasonArtifactRemoved = "ArtifactRemoved"
 	// ReasonArtifactRemoveFailed indicates the artifact failed to be removed.
 	ReasonArtifactRemoveFailed = "ArtifactRemoveFailed"
+	// ReasonPluginArtifactsRemoved indicates all plugin artifacts (OCI files and config) were removed successfully.
+	ReasonPluginArtifactsRemoved = "PluginArtifactsRemoved"
 	// ReasonReferenceResolved indicates the reference was resolved successfully.
 	ReasonReferenceResolved = "ReferenceResolved"
 	// ReasonReferenceResolutionFailed indicates the reference failed to resolve.
 	ReasonReferenceResolutionFailed = "ReferenceResolutionFailed"
 	// ReasonOCIArtifactStored indicates the OCI artifact was stored successfully.
 	ReasonOCIArtifactStored = "OCIArtifactStored"
+	// ReasonOCIArtifactUpdated indicates the OCI artifact was updated successfully.
+	ReasonOCIArtifactUpdated = "OCIArtifactUpdated"
+	// ReasonOCIArtifactRemoved indicates the OCI artifact was removed from the filesystem.
+	ReasonOCIArtifactRemoved = "OCIArtifactRemoved"
+	// ReasonOCIArtifactPriorityChanged indicates the OCI artifact priority changed and the file was renamed.
+	ReasonOCIArtifactPriorityChanged = "OCIArtifactPriorityChanged"
 	// ReasonOCIArtifactStoreFailed indicates the OCI artifact failed to store.
 	ReasonOCIArtifactStoreFailed = "OCIArtifactStoreFailed"
-	// ReasonInlineRulesStored indicates inline rules were stored successfully.
-	ReasonInlineRulesStored = "InlineRulesStored"
+	// ReasonInlineArtifactStored indicates an inline artifact was stored successfully.
+	ReasonInlineArtifactStored = "InlineArtifactStored"
+	// ReasonInlineArtifactUpdated indicates an inline artifact was updated successfully.
+	ReasonInlineArtifactUpdated = "InlineArtifactUpdated"
+	// ReasonInlineArtifactRemoved indicates an inline artifact was removed from the filesystem.
+	ReasonInlineArtifactRemoved = "InlineArtifactRemoved"
+	// ReasonInlineArtifactPriorityChanged indicates an inline artifact priority changed and the file was renamed.
+	ReasonInlineArtifactPriorityChanged = "InlineArtifactPriorityChanged"
 	// ReasonInlineRulesStoreFailed indicates inline rules failed to store.
 	ReasonInlineRulesStoreFailed = "InlineRulesStoreFailed"
-	// ReasonConfigMapRulesStored indicates rules from a ConfigMap were stored successfully.
-	ReasonConfigMapRulesStored = "ConfigMapRulesStored"
+	// ReasonConfigMapArtifactStored indicates a ConfigMap artifact was stored successfully.
+	ReasonConfigMapArtifactStored = "ConfigMapArtifactStored"
+	// ReasonConfigMapArtifactUpdated indicates a ConfigMap artifact was updated successfully.
+	ReasonConfigMapArtifactUpdated = "ConfigMapArtifactUpdated"
+	// ReasonConfigMapArtifactRemoved indicates a ConfigMap artifact was removed from the filesystem.
+	ReasonConfigMapArtifactRemoved = "ConfigMapArtifactRemoved"
+	// ReasonConfigMapArtifactPriorityChanged indicates a ConfigMap artifact priority changed and the file was renamed.
+	ReasonConfigMapArtifactPriorityChanged = "ConfigMapArtifactPriorityChanged"
 	// ReasonConfigMapRulesStoreFailed indicates rules from a ConfigMap failed to store.
 	ReasonConfigMapRulesStoreFailed = "ConfigMapRulesStoreFailed"
-	// ReasonInlineConfigStored indicates inline configuration was stored successfully.
-	ReasonInlineConfigStored = "InlineConfigStored"
 	// ReasonInlineConfigStoreFailed indicates inline configuration failed to store.
 	ReasonInlineConfigStoreFailed = "InlineConfigStoreFailed"
-	// ReasonConfigMapConfigStored indicates configuration from a ConfigMap was stored successfully.
-	ReasonConfigMapConfigStored = "ConfigMapConfigStored"
 	// ReasonConfigMapConfigStoreFailed indicates configuration from a ConfigMap failed to store.
 	ReasonConfigMapConfigStoreFailed = "ConfigMapConfigStoreFailed"
-	// ReasonInlinePluginConfigStored indicates the plugin configuration was stored successfully.
-	ReasonInlinePluginConfigStored = "InlinePluginConfigStored"
 	// ReasonInlinePluginConfigStoreFailed indicates the plugin configuration failed to store.
 	ReasonInlinePluginConfigStoreFailed = "InlinePluginConfigStoreFailed"
 	// ReasonReconciled indicates the artifact was reconciled successfully.
@@ -62,6 +74,12 @@ const (
 
 // Condition messages.
 const (
+	// MessageOCIArtifactPriorityChanged is the message when an OCI artifact priority changed and the file was renamed.
+	MessageOCIArtifactPriorityChanged = "OCI artifact priority changed, file renamed"
+	// MessageInlineArtifactPriorityChanged is the message when an inline artifact priority changed and the file was renamed.
+	MessageInlineArtifactPriorityChanged = "Inline artifact priority changed, file renamed"
+	// MessageConfigMapArtifactPriorityChanged is the message when a ConfigMap artifact priority changed and the file was renamed.
+	MessageConfigMapArtifactPriorityChanged = "ConfigMap artifact priority changed, file renamed"
 	// MessageConfigReconciled is the message when config is reconciled successfully.
 	MessageConfigReconciled = "Config reconciled successfully"
 	// MessagePluginReconciled is the message when plugin is reconciled successfully.
@@ -72,16 +90,22 @@ const (
 	MessagePluginArtifactsRemoved = "Plugin artifacts removed successfully"
 	// MessageOCIArtifactStored is the message when OCI artifact is stored successfully.
 	MessageOCIArtifactStored = "OCI artifact stored successfully"
-	// MessageInlineRulesStored is the message when inline rules are stored successfully.
-	MessageInlineRulesStored = "Inline rules stored successfully"
-	// MessageConfigMapRulesStored is the message when rules from a ConfigMap are stored successfully.
-	MessageConfigMapRulesStored = "ConfigMap rules stored successfully"
-	// MessageConfigMapConfigStored is the message when configuration from a ConfigMap is stored successfully.
-	MessageConfigMapConfigStored = "ConfigMap config stored successfully"
-	// MessageInlineConfigStored is the message when inline configuration is stored successfully.
-	MessageInlineConfigStored = "Inline config content stored successfully"
-	// MessageInlinePluginConfigStored is the message when inline plugin configuration is stored successfully.
-	MessageInlinePluginConfigStored = "Inline plugin configuration stored successfully"
+	// MessageOCIArtifactUpdated is the message when OCI artifact is updated successfully.
+	MessageOCIArtifactUpdated = "OCI artifact updated successfully"
+	// MessageOCIArtifactRemoved is the message when OCI artifact is removed from the filesystem.
+	MessageOCIArtifactRemoved = "OCI artifact removed from filesystem"
+	// MessageInlineArtifactStored is the message when an inline artifact is stored successfully.
+	MessageInlineArtifactStored = "Inline artifact stored successfully"
+	// MessageInlineArtifactUpdated is the message when an inline artifact is updated successfully.
+	MessageInlineArtifactUpdated = "Inline artifact updated successfully"
+	// MessageInlineArtifactRemoved is the message when an inline artifact is removed from the filesystem.
+	MessageInlineArtifactRemoved = "Inline artifact removed from filesystem"
+	// MessageConfigMapArtifactStored is the message when a ConfigMap artifact is stored successfully.
+	MessageConfigMapArtifactStored = "ConfigMap artifact stored successfully"
+	// MessageConfigMapArtifactUpdated is the message when a ConfigMap artifact is updated successfully.
+	MessageConfigMapArtifactUpdated = "ConfigMap artifact updated successfully"
+	// MessageConfigMapArtifactRemoved is the message when a ConfigMap artifact is removed from the filesystem.
+	MessageConfigMapArtifactRemoved = "ConfigMap artifact removed from filesystem"
 	// MessageProgrammed is the message when the artifact is programmed successfully.
 	MessageProgrammed = "All artifacts sources were programmed successfully"
 	// MessageReferencesResolved is the message when all references are resolved successfully.

--- a/internal/pkg/artifact/events.go
+++ b/internal/pkg/artifact/events.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+)
+
+// RecordWarning records a Warning event on obj with the given reason and formatted message.
+func RecordWarning(r events.EventRecorder, obj runtime.Object, reason, messageFmt string, args ...any) {
+	r.Eventf(obj, nil, corev1.EventTypeWarning, reason, reason, messageFmt, args...)
+}
+
+// RecordNormal records a Normal event on obj with the given reason and message.
+func RecordNormal(r events.EventRecorder, obj runtime.Object, reason, message string) {
+	r.Eventf(obj, nil, corev1.EventTypeNormal, reason, reason, message)
+}
+
+// RecordStoreEvent records a Normal event for a store operation based on the action and medium.
+// No event is recorded for StoreActionNone or StoreActionUnchanged.
+func RecordStoreEvent(r events.EventRecorder, obj runtime.Object, action StoreAction, medium Medium) {
+	var reason, message string
+	switch {
+	case action == StoreActionRemoved && medium == MediumOCI:
+		reason, message = ReasonOCIArtifactRemoved, MessageOCIArtifactRemoved
+	case action == StoreActionRemoved && medium == MediumInline:
+		reason, message = ReasonInlineArtifactRemoved, MessageInlineArtifactRemoved
+	case action == StoreActionRemoved && medium == MediumConfigMap:
+		reason, message = ReasonConfigMapArtifactRemoved, MessageConfigMapArtifactRemoved
+	case action == StoreActionPriorityChanged && medium == MediumOCI:
+		reason, message = ReasonOCIArtifactPriorityChanged, MessageOCIArtifactPriorityChanged
+	case action == StoreActionPriorityChanged && medium == MediumInline:
+		reason, message = ReasonInlineArtifactPriorityChanged, MessageInlineArtifactPriorityChanged
+	case action == StoreActionPriorityChanged && medium == MediumConfigMap:
+		reason, message = ReasonConfigMapArtifactPriorityChanged, MessageConfigMapArtifactPriorityChanged
+	case action == StoreActionAdded && medium == MediumOCI:
+		reason, message = ReasonOCIArtifactStored, MessageOCIArtifactStored
+	case action == StoreActionUpdated && medium == MediumOCI:
+		reason, message = ReasonOCIArtifactUpdated, MessageOCIArtifactUpdated
+	case action == StoreActionAdded && medium == MediumInline:
+		reason, message = ReasonInlineArtifactStored, MessageInlineArtifactStored
+	case action == StoreActionUpdated && medium == MediumInline:
+		reason, message = ReasonInlineArtifactUpdated, MessageInlineArtifactUpdated
+	case action == StoreActionAdded && medium == MediumConfigMap:
+		reason, message = ReasonConfigMapArtifactStored, MessageConfigMapArtifactStored
+	case action == StoreActionUpdated && medium == MediumConfigMap:
+		reason, message = ReasonConfigMapArtifactUpdated, MessageConfigMapArtifactUpdated
+	default:
+		return
+	}
+	RecordNormal(r, obj, reason, message)
+}

--- a/internal/pkg/artifact/manager.go
+++ b/internal/pkg/artifact/manager.go
@@ -171,7 +171,7 @@ func (am *Manager) Path(name string, artifactPriority int32, medium Medium, arti
 }
 
 // StoreFromInLineYaml stores an artifact from an inline YAML to the local filesystem.
-func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifactPriority int32, data *string, artifactType Type) error {
+func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifactPriority int32, data *string, artifactType Type) (StoreAction, error) {
 	logger := log.FromContext(ctx)
 
 	// If the data is nil, we remove the artifact from the manager and from filesystem.
@@ -182,10 +182,11 @@ func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifac
 			logger.Info("Removing artifact from filesystem", "artifact", file.Path)
 			if err := am.removeArtifact(ctx, name, MediumInline); err != nil {
 				logger.Error(err, "Failed to remove artifact from filesystem", "artifact", file.Path)
-				return err
+				return StoreActionNone, err
 			}
+			return StoreActionRemoved, nil
 		}
-		return nil
+		return StoreActionNone, nil
 	}
 
 	newFile := File{
@@ -194,6 +195,11 @@ func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifac
 		Priority: artifactPriority,
 	}
 
+	// wasUpdate tracks whether we replaced an existing file (vs writing a brand-new one).
+	wasUpdate := false
+	// priorityOnlyChange tracks whether only the priority changed (content is the same).
+	priorityOnlyChange := false
+
 	// Check if the artifact is already stored.
 	if file := am.getArtifactFile(name, MediumInline); file != nil {
 		logger.V(4).Info("Artifact already stored", "artifact", file)
@@ -201,7 +207,7 @@ func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifac
 		ok, err := am.fs.Exists(file.Path)
 		if err != nil {
 			logger.Error(err, "Failed to check if file exists", "file", file.Path)
-			return err
+			return StoreActionNone, err
 		}
 		// If the file exists we check if the priority has changed or the content has been updated.
 		if ok {
@@ -210,27 +216,31 @@ func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifac
 			content, err := am.fs.ReadFile(file.Path)
 			if err != nil {
 				logger.Error(err, "unable to read file", "file", file.Path)
-				return err
+				return StoreActionNone, err
 			}
+			contentSame := string(content) == *data
 			// Check if the content is the same and the priority has not changed.
-			if string(content) == *data && file.Priority == artifactPriority {
+			if contentSame && file.Priority == artifactPriority {
 				logger.V(3).Info("file is up to date", "file", file.Path)
-				return nil
+				return StoreActionUnchanged, nil
 			}
 
-			if file.Priority != artifactPriority {
+			priorityOnlyChange = contentSame && file.Priority != artifactPriority
+			if priorityOnlyChange {
 				logger.Info("Updating artifact file due to priority change",
 					"oldPriority", file.Priority, "newPriority", artifactPriority, "oldFile", file.Path, "newFile", newFile.Path)
+			} else {
+				logger.Info("File is outdated, updating", "file", file.Path)
 			}
 
-			logger.Info("File is outdated, updating", "file", file.Path)
-			// The content is different, remove the file.
+			// Remove the old file before writing the new one.
 			if err := am.fs.Remove(file.Path); err != nil {
 				logger.Error(err, "unable to remove rulesfile", "file", file.Path)
-				return err
+				return StoreActionNone, err
 			}
 			// Remove the file from the manager.
 			am.removeArtifactFile(name, MediumInline)
+			wasUpdate = true
 		} else {
 			// The file is registered in the manager but missing from disk.
 			// Clear the stale registration so addArtifactFile below does not create a duplicate entry.
@@ -241,17 +251,23 @@ func (am *Manager) StoreFromInLineYaml(ctx context.Context, name string, artifac
 	// Write the raw YAML to the filesystem.
 	if err := am.fs.WriteFile(newFile.Path, []byte(*data), 0o600); err != nil {
 		logger.Error(err, "unable to write file", "file", newFile.Path)
-		return err
+		return StoreActionNone, err
 	}
 
 	// Add the artifact to the manager.
 	am.addArtifactFile(name, newFile)
 	logger.Info("file correctly written to filesystem", "file", newFile.Path)
-	return nil
+	if wasUpdate {
+		if priorityOnlyChange {
+			return StoreActionPriorityChanged, nil
+		}
+		return StoreActionUpdated, nil
+	}
+	return StoreActionAdded, nil
 }
 
 // StoreFromOCI stores an artifact from an OCI registry to the local filesystem.
-func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriority int32, artifactType Type, artifact *commonv1alpha1.OCIArtifact) error {
+func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriority int32, artifactType Type, artifact *commonv1alpha1.OCIArtifact) (StoreAction, error) {
 	logger := log.FromContext(ctx)
 
 	// If the artifact is nil, we remove the artifact from the manager and from filesystem.
@@ -262,10 +278,11 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 			logger.Info("Removing artifact from filesystem", "artifact", file.Path)
 			if err := am.removeArtifact(ctx, name, MediumOCI); err != nil {
 				logger.Error(err, "Failed to remove artifact from filesystem", "artifact", file.Path)
-				return err
+				return StoreActionNone, err
 			}
+			return StoreActionRemoved, nil
 		}
-		return nil
+		return StoreActionNone, nil
 	}
 	newFile := File{
 		Path:     am.Path(name, artifactPriority, MediumOCI, artifactType),
@@ -280,7 +297,7 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 		ok, err := am.fs.Exists(file.Path)
 		if err != nil {
 			logger.Error(err, "Failed to check if file exists", "file", file.Path)
-			return err
+			return StoreActionNone, err
 		}
 		// If the file exists and the priority has changed, we rename the file reflecting the new priority.
 		if ok && file.Priority != artifactPriority {
@@ -288,8 +305,11 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 				"oldPriority", file.Priority, "newPriority", artifactPriority, "oldFile", file.Path, "newFile", newFile.Path)
 			if err := am.fs.Rename(file.Path, newFile.Path); err != nil {
 				logger.Error(err, "Failed to rename file", "oldFile", file.Path, "newFile", newFile.Path)
-				return err
+				return StoreActionNone, err
 			}
+			am.removeArtifactFile(name, MediumOCI)
+			am.addArtifactFile(name, newFile)
+			return StoreActionPriorityChanged, nil
 		}
 		// If the file does not exist on the filesystem, we remove it from the manager and return an error.
 		// Next time the artifact is requested, it will be fetched from the OCI registry.
@@ -297,10 +317,10 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 			am.removeArtifactFile(name, MediumOCI)
 			err := fmt.Errorf("artifact %q not found on filesystem", file.Path)
 			logger.Error(err, "Failed to find file on filesystem", "file", newFile.Path)
-			return err
+			return StoreActionNone, err
 		}
 
-		return nil
+		return StoreActionUnchanged, nil
 	}
 
 	var dstDir string
@@ -323,7 +343,7 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 	creds, err := credentials.GetCredentialsFromSecret(ctx, am.client, am.namespace, authSecretRef)
 	if err != nil {
 		logger.Error(err, "unable to get credentials for the OCI artifact", "authSecretRef", authSecretRef)
-		return err
+		return StoreActionNone, err
 	}
 
 	// Resolve registry TLS options.
@@ -334,10 +354,10 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 	res, err := am.ociPuller.Pull(ctx, ref, dstDir, runtime.GOOS, runtime.GOARCH, creds, registryOpts)
 	if err != nil {
 		logger.Error(err, "unable to pull artifact", "reference", ref)
-		return err
+		return StoreActionNone, err
 	}
 	if res == nil {
-		return fmt.Errorf("puller returned nil result for reference %q", ref)
+		return StoreActionNone, fmt.Errorf("puller returned nil result for reference %q", ref)
 	}
 
 	archiveFile := filepath.Clean(filepath.Join(dstDir, res.Filename))
@@ -345,7 +365,7 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 	// Extract the rulesfile from the archive.
 	f, err := am.fs.Open(archiveFile)
 	if err != nil {
-		return err
+		return StoreActionNone, err
 	}
 
 	logger.V(4).Info("Extracting OCI artifact", "archive", archiveFile)
@@ -354,32 +374,32 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 	files, err := common.ExtractTarGz(ctx, f, dstDir, 0)
 	if err != nil {
 		logger.Error(err, "unable to extract OCI artifact", "filename", archiveFile)
-		return err
+		return StoreActionNone, err
 	}
 
 	// Clean up the archive.
 	if err = am.fs.Remove(archiveFile); err != nil {
 		logger.Error(err, "unable to remove OCI artifact", "filename", archiveFile)
-		return err
+		return StoreActionNone, err
 	}
 
 	logger.V(4).Info("Writing OCI artifact", "filename", newFile.Path)
 	// Rename the artifact to the generated name.
 	if err = am.fs.Rename(files[0], newFile.Path); err != nil {
 		logger.Error(err, "unable to rename artifact", "source", files[0], "destination", newFile.Path)
-		return err
+		return StoreActionNone, err
 	}
 	logger.Info("OCI artifact downloaded and saved", "artifact", newFile.Path)
 
 	// Add the artifact to the manager.
 	am.files[name] = append(am.files[name], newFile)
 
-	return nil
+	return StoreActionAdded, nil
 }
 
 // StoreFromConfigMap stores an artifact from a ConfigMap to the local filesystem.
 // The ConfigMap is fetched from the specified namespace (typically the same namespace as the Rulesfile CR).
-func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace string, artifactPriority int32, configMapRef *commonv1alpha1.ConfigMapRef, artifactType Type) error {
+func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace string, artifactPriority int32, configMapRef *commonv1alpha1.ConfigMapRef, artifactType Type) (StoreAction, error) {
 	logger := log.FromContext(ctx)
 
 	// If the configMapRef is nil, we remove the artifact from the manager and from filesystem.
@@ -390,10 +410,11 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 			logger.Info("Removing artifact from filesystem", "artifact", file.Path)
 			if err := am.removeArtifact(ctx, name, MediumConfigMap); err != nil {
 				logger.Error(err, "Failed to remove artifact from filesystem", "artifact", file.Path)
-				return err
+				return StoreActionNone, err
 			}
+			return StoreActionRemoved, nil
 		}
-		return nil
+		return StoreActionNone, nil
 	}
 
 	newFile := File{
@@ -413,23 +434,28 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 		// If ConfigMap not found, remove the artifact file from filesystem if it exists.
 		// This is an expected state when user deletes the ConfigMap or the ConfigMap is in a different namespace, not a failure.
 		filePath := am.Path(name, artifactPriority, MediumConfigMap, artifactType)
+		removed := false
 		if exists, _ := am.fs.Exists(filePath); exists {
 			logger.Info("ConfigMap not found, removing artifact from filesystem", "configMap", configMapRef.Name, "artifact", filePath)
 			if removeErr := am.fs.Remove(filePath); removeErr != nil {
 				logger.Error(removeErr, "Failed to remove artifact from filesystem", "artifact", filePath)
-				return removeErr
+				return StoreActionNone, removeErr
 			}
 			am.removeArtifactFile(name, MediumConfigMap)
+			removed = true
 		}
 		// Don't return error for "not found" - the ConfigMap was likely deleted intentionally.
 		// The watch will trigger reconciliation when it's recreated.
 		if k8serrors.IsNotFound(err) {
 			logger.V(3).Info("ConfigMap not found, artifact cleaned up", "configMap", configMapRef.Name)
-			return nil
+			if removed {
+				return StoreActionRemoved, nil
+			}
+			return StoreActionNone, nil
 		}
 		// Return other errors (network issues, permission errors, etc.)
 		logger.Error(err, "Failed to get ConfigMap", "configMap", configMapRef.Name)
-		return err
+		return StoreActionNone, err
 	}
 
 	// Get the data from the ConfigMap using the key appropriate for the artifact type.
@@ -440,7 +466,7 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 	case TypeRulesfile:
 		dataKey = commonv1alpha1.ConfigMapRulesKey
 	default:
-		return fmt.Errorf("unsupported artifact type for ConfigMap store: %q", artifactType)
+		return StoreActionNone, fmt.Errorf("unsupported artifact type for ConfigMap store: %q", artifactType)
 	}
 	data, ok := configMap.Data[dataKey]
 	if !ok {
@@ -452,17 +478,22 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 				"configMap", configMapRef.Name, "expectedKey", dataKey, "artifact", filePath)
 			if removeErr := am.fs.Remove(filePath); removeErr != nil {
 				logger.Error(removeErr, "Failed to remove artifact from filesystem", "artifact", filePath)
-				return removeErr
+				return StoreActionNone, removeErr
 			}
 			am.removeArtifactFile(name, MediumConfigMap)
-		} else {
-			logger.Info("ConfigMap missing expected key",
-				"configMap", configMapRef.Name, "expectedKey", dataKey)
+			// Don't return error - user needs to fix the ConfigMap, retrying won't help.
+			// The watch will trigger reconciliation when ConfigMap is updated.
+			return StoreActionRemoved, nil
 		}
-		// Don't return error - user needs to fix the ConfigMap, retrying won't help.
-		// The watch will trigger reconciliation when ConfigMap is updated.
-		return nil
+		logger.Info("ConfigMap missing expected key",
+			"configMap", configMapRef.Name, "expectedKey", dataKey)
+		return StoreActionNone, nil
 	}
+
+	// wasUpdate tracks whether we replaced an existing file (vs writing a brand-new one).
+	wasUpdate := false
+	// priorityOnlyChange tracks whether only the priority changed (content is the same).
+	priorityOnlyChange := false
 
 	// Check if the artifact is already stored.
 	if file := am.getArtifactFile(name, MediumConfigMap); file != nil {
@@ -471,7 +502,7 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 		ok, err := am.fs.Exists(file.Path)
 		if err != nil {
 			logger.Error(err, "Failed to check if file exists", "file", file.Path)
-			return err
+			return StoreActionNone, err
 		}
 		// If the file exists we check if the priority has changed or the content has been updated.
 		if ok {
@@ -480,27 +511,31 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 			content, err := am.fs.ReadFile(file.Path)
 			if err != nil {
 				logger.Error(err, "unable to read file", "file", file.Path)
-				return err
+				return StoreActionNone, err
 			}
+			contentSame := string(content) == data
 			// Check if the content is the same and the priority has not changed.
-			if string(content) == data && file.Priority == artifactPriority {
+			if contentSame && file.Priority == artifactPriority {
 				logger.V(3).Info("file is up to date", "file", file.Path)
-				return nil
+				return StoreActionUnchanged, nil
 			}
 
-			if file.Priority != artifactPriority {
+			priorityOnlyChange = contentSame && file.Priority != artifactPriority
+			if priorityOnlyChange {
 				logger.Info("Updating artifact file due to priority change",
 					"oldPriority", file.Priority, "newPriority", artifactPriority, "oldFile", file.Path, "newFile", newFile.Path)
+			} else {
+				logger.Info("File is outdated, updating", "file", file.Path)
 			}
 
-			logger.Info("File is outdated, updating", "file", file.Path)
-			// The content is different, remove the file.
+			// Remove the old file before writing the new one.
 			if err := am.fs.Remove(file.Path); err != nil {
 				logger.Error(err, "unable to remove file", "file", file.Path)
-				return err
+				return StoreActionNone, err
 			}
 			// Remove the file from the manager.
 			am.removeArtifactFile(name, MediumConfigMap)
+			wasUpdate = true
 		} else {
 			// The file is registered in the manager but missing from disk.
 			// Clear the stale registration so addArtifactFile below does not create a duplicate entry.
@@ -511,13 +546,19 @@ func (am *Manager) StoreFromConfigMap(ctx context.Context, name, namespace strin
 	// Write the data to the filesystem.
 	if err := am.fs.WriteFile(newFile.Path, []byte(data), 0o600); err != nil {
 		logger.Error(err, "unable to write file", "file", newFile.Path)
-		return err
+		return StoreActionNone, err
 	}
 
 	// Add the artifact to the manager.
 	am.addArtifactFile(name, newFile)
 	logger.Info("ConfigMap data correctly written to filesystem", "file", newFile.Path, "configMap", configMapRef.Name)
-	return nil
+	if wasUpdate {
+		if priorityOnlyChange {
+			return StoreActionPriorityChanged, nil
+		}
+		return StoreActionUpdated, nil
+	}
+	return StoreActionAdded, nil
 }
 
 func (am *Manager) removeArtifact(ctx context.Context, name string, medium Medium) error {

--- a/internal/pkg/artifact/manager_test.go
+++ b/internal/pkg/artifact/manager_test.go
@@ -134,6 +134,8 @@ func TestStoreFromConfigMap(t *testing.T) {
 		wantWriteCalls  int
 		wantRemoveCalls int
 		wantFilesLen    int
+		wantFile        *File
+		wantAction      StoreAction
 	}{
 		{
 			name: "successfully stores new artifact from ConfigMap",
@@ -153,6 +155,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionAdded,
 		},
 		{
 			name:         "removes artifact when configMapRef is nil",
@@ -165,6 +168,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionRemoved,
 		},
 		{
 			name: "returns nil when ConfigMap not found",
@@ -175,6 +179,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns nil when rules.yaml key not found in ConfigMap",
@@ -194,6 +199,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "skips write when file content is unchanged",
@@ -219,6 +225,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionUnchanged,
 		},
 		{
 			name: "updates file when content changes",
@@ -244,6 +251,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionUpdated,
 		},
 		{
 			name: "updates file when priority changes",
@@ -269,6 +277,8 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 1,
+			wantFile:        &File{Path: "/etc/falco/rules.d/60-02-test-artifact-configmap.yaml", Medium: MediumConfigMap, Priority: 60},
+			wantAction:      StoreActionPriorityChanged,
 		},
 		{
 			name: "returns error when write fails",
@@ -290,6 +300,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErrMsg:      "disk full",
 			wantWriteCalls:  1,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when Exists check fails",
@@ -316,6 +327,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErrMsg:      "permission denied",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when ReadFile fails",
@@ -343,6 +355,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErrMsg:      "I/O error",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when Remove fails during update",
@@ -370,6 +383,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErrMsg:      "cannot remove file",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:            "removes existing file when ConfigMap is not found",
@@ -378,6 +392,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			existingFile:    &File{Path: "/etc/falco/rules.d/50-02-test-artifact-configmap.yaml", Medium: MediumConfigMap, Priority: 50},
 			existingData:    testData,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionRemoved,
 		},
 		{
 			name:            "returns error when Remove fails on ConfigMap not found",
@@ -389,6 +404,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "cannot remove",
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:           "returns error on non-NotFound client error",
@@ -396,6 +412,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			priority:       50,
 			noCorev1Scheme: true,
 			wantErr:        true,
+			wantAction:     StoreActionNone,
 		},
 		{
 			name:         "stores artifact using config.yaml key for TypeConfig",
@@ -407,6 +424,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			artifactType:   TypeConfig,
 			priority:       50,
 			wantWriteCalls: 1,
+			wantAction:     StoreActionAdded,
 		},
 		{
 			name:         "returns error for unsupported artifact type",
@@ -419,6 +437,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			priority:     50,
 			wantErr:      true,
 			wantErrMsg:   "unsupported artifact type",
+			wantAction:   StoreActionNone,
 		},
 		{
 			name:         "removes existing file when ConfigMap key is not found",
@@ -431,6 +450,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			existingFile:    &File{Path: "/etc/falco/rules.d/50-02-test-artifact-configmap.yaml", Medium: MediumConfigMap, Priority: 50},
 			existingData:    testData,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionRemoved,
 		},
 		{
 			name:         "returns error when Remove fails on missing ConfigMap key",
@@ -446,6 +466,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "cannot remove",
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:         "clears stale registration when file is registered but missing from disk",
@@ -458,6 +479,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			existingFile:   &File{Path: "/etc/falco/rules.d/50-02-test-artifact-configmap.yaml", Medium: MediumConfigMap, Priority: 50},
 			wantWriteCalls: 1,
 			wantFilesLen:   1,
+			wantAction:     StoreActionAdded,
 		},
 		{
 			name:            "returns error when removeArtifact fails on nil configMapRef",
@@ -469,6 +491,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "remove failed",
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 	}
 
@@ -506,7 +529,7 @@ func TestStoreFromConfigMap(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := manager.StoreFromConfigMap(ctx, testArtifactName, testNamespace, tt.priority, tt.configMapRef, artifactType)
+			action, err := manager.StoreFromConfigMap(ctx, testArtifactName, testNamespace, tt.priority, tt.configMapRef, artifactType)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -515,10 +538,19 @@ func TestStoreFromConfigMap(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			if tt.wantAction != "" {
+				assert.Equal(t, tt.wantAction, action)
+			}
 			assert.Len(t, mockFS.WriteCalls, tt.wantWriteCalls)
 			assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveCalls)
 			if tt.wantFilesLen > 0 {
 				assert.Len(t, manager.files[testArtifactName], tt.wantFilesLen)
+			}
+			if tt.wantFile != nil {
+				file := manager.getArtifactFile(testArtifactName, tt.wantFile.Medium)
+				require.NotNil(t, file)
+				assert.Equal(t, tt.wantFile.Path, file.Path)
+				assert.Equal(t, tt.wantFile.Priority, file.Priority)
 			}
 		})
 	}
@@ -546,6 +578,8 @@ func TestStoreFromInLineYaml(t *testing.T) {
 		wantWriteCalls  int
 		wantRemoveCalls int
 		wantFilesLen    int
+		wantFile        *File
+		wantAction      StoreAction
 	}{
 		{
 			name:            "successfully stores new artifact from inline YAML",
@@ -554,6 +588,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionAdded,
 		},
 		{
 			name: "removes artifact when data is nil",
@@ -566,6 +601,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionRemoved,
 		},
 		{
 			name:            "does nothing when data is nil and no existing file",
@@ -573,6 +609,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "skips write when file content is unchanged",
@@ -587,6 +624,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionUnchanged,
 		},
 		{
 			name:     "updates file when content changes",
@@ -601,6 +639,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionUpdated,
 		},
 		{
 			name:     "updates file when priority changes",
@@ -615,6 +654,8 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         false,
 			wantWriteCalls:  1,
 			wantRemoveCalls: 1,
+			wantFile:        &File{Path: "/etc/falco/rules.d/60-03-test-artifact-inline.yaml", Medium: MediumInline, Priority: 60},
+			wantAction:      StoreActionPriorityChanged,
 		},
 		{
 			name:            "returns error when write fails",
@@ -625,6 +666,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErrMsg:      "disk full",
 			wantWriteCalls:  1,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "returns error when Exists check fails",
@@ -640,6 +682,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErrMsg:      "permission denied",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "returns error when ReadFile fails",
@@ -656,6 +699,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErrMsg:      "I/O error",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "returns error when Remove fails during update",
@@ -672,6 +716,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErrMsg:      "cannot remove file",
 			wantWriteCalls:  0,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "clears stale registration when file is registered but missing from disk",
@@ -684,6 +729,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			},
 			wantWriteCalls: 1,
 			wantFilesLen:   1,
+			wantAction:     StoreActionAdded,
 		},
 		{
 			name: "returns error when removeArtifact fails on nil data",
@@ -697,6 +743,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "remove failed",
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 	}
 
@@ -720,7 +767,7 @@ func TestStoreFromInLineYaml(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := manager.StoreFromInLineYaml(ctx, testArtifactName, tt.priority, tt.data, TypeRulesfile)
+			action, err := manager.StoreFromInLineYaml(ctx, testArtifactName, tt.priority, tt.data, TypeRulesfile)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -729,10 +776,19 @@ func TestStoreFromInLineYaml(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			if tt.wantAction != "" {
+				assert.Equal(t, tt.wantAction, action)
+			}
 			assert.Len(t, mockFS.WriteCalls, tt.wantWriteCalls)
 			assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveCalls)
 			if tt.wantFilesLen > 0 {
 				assert.Len(t, manager.files[testArtifactName], tt.wantFilesLen)
+			}
+			if tt.wantFile != nil {
+				file := manager.getArtifactFile(testArtifactName, tt.wantFile.Medium)
+				require.NotNil(t, file)
+				assert.Equal(t, tt.wantFile.Path, file.Path)
+				assert.Equal(t, tt.wantFile.Priority, file.Priority)
 			}
 		})
 	}
@@ -1225,7 +1281,9 @@ func TestStoreFromOCI(t *testing.T) {
 		wantRenameCalls int
 		wantRemoveCalls int
 		wantFilesLen    int
+		wantFile        *File
 		wantOpts        *puller.RegistryOptions
+		wantAction      StoreAction
 	}{
 		{
 			name:     "removes artifact when artifact is nil",
@@ -1239,6 +1297,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionRemoved,
 		},
 		{
 			name:            "does nothing when artifact is nil and no existing file",
@@ -1247,6 +1306,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when artifact already stored but file not found on filesystem",
@@ -1265,6 +1325,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "renames file when priority changes",
@@ -1283,6 +1344,8 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 1,
 			wantRemoveCalls: 0,
+			wantFile:        &File{Path: "/etc/falco/rules.d/60-01-test-artifact-oci.yaml", Medium: MediumOCI, Priority: 60},
+			wantAction:      StoreActionPriorityChanged,
 		},
 		{
 			name: "skips pull when file already exists with same priority",
@@ -1301,6 +1364,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionUnchanged,
 		},
 		{
 			name: "returns error when credentials getter fails",
@@ -1319,6 +1383,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when puller fails",
@@ -1333,6 +1398,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   1,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when rename fails during priority change",
@@ -1353,6 +1419,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 1,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when Exists check fails",
@@ -1372,6 +1439,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   0,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "returns error when Open fails after successful pull",
@@ -1389,6 +1457,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   1,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "uses plugin directory for plugin artifact type",
@@ -1406,6 +1475,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   1,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "uses empty directory for unknown artifact type",
@@ -1423,6 +1493,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   1,
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "passes plainHTTP option to puller",
@@ -1444,6 +1515,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
 			wantOpts:        &puller.RegistryOptions{PlainHTTP: true},
+			wantAction:      StoreActionNone,
 		},
 		{
 			name: "passes TLS insecureSkipVerify option to puller",
@@ -1467,6 +1539,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantRenameCalls: 0,
 			wantRemoveCalls: 0,
 			wantOpts:        &puller.RegistryOptions{InsecureSkipVerify: true},
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:         "puller returns nil result",
@@ -1476,6 +1549,7 @@ func TestStoreFromOCI(t *testing.T) {
 			customPuller: nilResultPuller{},
 			wantErr:      true,
 			wantErrMsg:   "nil result",
+			wantAction:   StoreActionNone,
 		},
 		{
 			name:         "successfully pulls, extracts and stores artifact",
@@ -1484,6 +1558,7 @@ func TestStoreFromOCI(t *testing.T) {
 			artifactType: TypeRulesfile,
 			useRealFS:    true,
 			wantFilesLen: 1,
+			wantAction:   StoreActionAdded,
 		},
 		{
 			name:           "returns error when ExtractTarGz fails due to invalid archive content",
@@ -1493,6 +1568,7 @@ func TestStoreFromOCI(t *testing.T) {
 			archiveContent: []byte("not-a-valid-gzip"),
 			wantErr:        true,
 			wantPullCalls:  1,
+			wantAction:     StoreActionNone,
 		},
 		{
 			name:         "returns error when Remove of archive fails after successful extraction",
@@ -1508,6 +1584,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantErrMsg:      "cannot remove archive",
 			wantPullCalls:   1,
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:         "returns error when Rename fails after successful extraction",
@@ -1524,6 +1601,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantPullCalls:   1,
 			wantRemoveCalls: 1,
 			wantRenameCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 		{
 			name:     "returns error when removeArtifact fails on nil artifact",
@@ -1537,6 +1615,7 @@ func TestStoreFromOCI(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "remove failed",
 			wantRemoveCalls: 1,
+			wantAction:      StoreActionNone,
 		},
 	}
 
@@ -1592,7 +1671,7 @@ func TestStoreFromOCI(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := manager.StoreFromOCI(ctx, testArtifactName, tt.priority, tt.artifactType, tt.artifact)
+			action, err := manager.StoreFromOCI(ctx, testArtifactName, tt.priority, tt.artifactType, tt.artifact)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1601,6 +1680,9 @@ func TestStoreFromOCI(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			if tt.wantAction != "" {
+				assert.Equal(t, tt.wantAction, action)
+			}
 			if !tt.useRealFS && tt.customPuller == nil {
 				assert.Len(t, mockPuller.PullCalls, tt.wantPullCalls)
 				assert.Len(t, mockFS.RenameCalls, tt.wantRenameCalls)
@@ -1612,6 +1694,12 @@ func TestStoreFromOCI(t *testing.T) {
 
 			if tt.wantFilesLen > 0 {
 				assert.Len(t, manager.files[testArtifactName], tt.wantFilesLen)
+			}
+			if tt.wantFile != nil {
+				file := manager.getArtifactFile(testArtifactName, tt.wantFile.Medium)
+				require.NotNil(t, file)
+				assert.Equal(t, filepath.Base(tt.wantFile.Path), filepath.Base(file.Path))
+				assert.Equal(t, tt.wantFile.Priority, file.Priority)
 			}
 		})
 	}

--- a/internal/pkg/artifact/types.go
+++ b/internal/pkg/artifact/types.go
@@ -28,6 +28,25 @@ const (
 	MediumConfigMap Medium = "configmap"
 )
 
+// StoreAction represents the operation performed by a Store method.
+type StoreAction string
+
+const (
+	// StoreActionNone means the input was absent and no existing artifact was found; no filesystem change occurred.
+	StoreActionNone StoreAction = "None"
+	// StoreActionRemoved means a previously stored artifact was removed from the filesystem.
+	StoreActionRemoved StoreAction = "Removed"
+	// StoreActionAdded means a new artifact was written to the filesystem for the first time.
+	StoreActionAdded StoreAction = "Added"
+	// StoreActionUpdated means an existing artifact was replaced because its content changed.
+	StoreActionUpdated StoreAction = "Updated"
+	// StoreActionUnchanged means the artifact already existed and was up-to-date; nothing was written.
+	StoreActionUnchanged StoreAction = "Unchanged"
+	// StoreActionPriorityChanged means the artifact content is unchanged but the priority changed;
+	// the file was moved/renamed to reflect the new load order.
+	StoreActionPriorityChanged StoreAction = "PriorityChanged"
+)
+
 // File represents a tracked file for any artifact type.
 type File struct {
 	Path     string // Full Path on filesystem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

Add per-medium, per-action event reason and message constants for every outcome of the three Store methods (Added, Updated, Removed, PriorityChanged) in conditions.go, and introduce RecordNormal, RecordWarning, and RecordStoreEvent helpers in a new events.go to centralise event emission.

Refactor all three artifact controllers to call the new helpers instead of open-coding recorder.Eventf, and update controller tests to assert on the expected events via a new wantEvents field.

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-operator

 /area artifact-operator

 /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
