### PR TITLE
refactor(controllerhelper): extract EnsureFinalizer into a shared helper

### DIFF
--- a/controllers/artifact/config/controller.go
+++ b/controllers/artifact/config/controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -175,26 +174,7 @@ func (r *ConfigReconciler) findConfigsForConfigMap(ctx context.Context, configMa
 
 // ensureFinalizer ensures the finalizer is set.
 func (r *ConfigReconciler) ensureFinalizer(ctx context.Context, config *artifactv1alpha1.Config) (bool, error) {
-	if !controllerutil.ContainsFinalizer(config, r.finalizer) {
-		logger := log.FromContext(ctx)
-		logger.V(3).Info("Setting finalizer", "finalizer", r.finalizer)
-
-		patch := client.MergeFrom(config.DeepCopy())
-		controllerutil.AddFinalizer(config, r.finalizer)
-		if err := r.Patch(ctx, config, patch); err != nil {
-			if k8serrors.IsConflict(err) {
-				logger.V(3).Info("Conflict while setting finalizer, will retry")
-				return false, err
-			}
-			logger.Error(err, "unable to set finalizer", "finalizer", r.finalizer)
-			return false, err
-		}
-
-		logger.V(3).Info("Finalizer set", "finalizer", r.finalizer)
-		return true, nil
-	}
-
-	return false, nil
+	return controllerhelper.EnsureFinalizer(ctx, r.Client, r.finalizer, config)
 }
 
 // enforceReferenceResolution checks that all referenced resources exist.

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -162,26 +162,7 @@ func (r *PluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // ensureFinalizers ensures that the finalizer is set on the Plugin instance.
 func (r *PluginReconciler) ensureFinalizers(ctx context.Context, plugin *artifactv1alpha1.Plugin) (bool, error) {
-	if !controllerutil.ContainsFinalizer(plugin, r.finalizer) {
-		logger := log.FromContext(ctx)
-		logger.V(3).Info("Setting finalizer", "finalizer", r.finalizer)
-
-		patch := client.MergeFrom(plugin.DeepCopy())
-		controllerutil.AddFinalizer(plugin, r.finalizer)
-		if err := r.Patch(ctx, plugin, patch); err != nil {
-			if k8serrors.IsConflict(err) {
-				logger.V(3).Info("Conflict while setting finalizer, will retry")
-				return false, err
-			}
-			logger.Error(err, "unable to set finalizer", "finalizer", r.finalizer)
-			return false, err
-		}
-
-		logger.V(3).Info("Finalizer set", "finalizer", r.finalizer)
-		return true, nil
-	}
-
-	return false, nil
+	return controllerhelper.EnsureFinalizer(ctx, r.Client, r.finalizer, plugin)
 }
 
 // ensurePlugin ensures that the Plugin artifact is stored correctly.

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -177,26 +176,7 @@ func (r *RulesfileReconciler) findRulesfilesForConfigMap(ctx context.Context, co
 
 // ensureFinalizer ensures the finalizer is set.
 func (r *RulesfileReconciler) ensureFinalizer(ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile) (bool, error) {
-	if !controllerutil.ContainsFinalizer(rulesfile, r.finalizer) {
-		logger := log.FromContext(ctx)
-		logger.V(3).Info("Setting finalizer", "finalizer", r.finalizer)
-
-		patch := client.MergeFrom(rulesfile.DeepCopy())
-		controllerutil.AddFinalizer(rulesfile, r.finalizer)
-		if err := r.Patch(ctx, rulesfile, patch); err != nil {
-			if k8serrors.IsConflict(err) {
-				logger.V(3).Info("Conflict while setting finalizer, will retry")
-				return false, err
-			}
-			logger.Error(err, "unable to set finalizer", "finalizer", r.finalizer)
-			return false, err
-		}
-
-		logger.V(3).Info("Finalizer set", "finalizer", r.finalizer)
-		return true, nil
-	}
-
-	return false, nil
+	return controllerhelper.EnsureFinalizer(ctx, r.Client, r.finalizer, rulesfile)
 }
 
 // ensureRulesfile ensures the rulesfile artifacts are stored on the filesystem.

--- a/internal/pkg/controllerhelper/finalizer.go
+++ b/internal/pkg/controllerhelper/finalizer.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper
+
+import (
+	"context"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// EnsureFinalizer adds the given finalizer to obj if not already present.
+// Returns (true, nil) when the finalizer was just added, (false, nil) if already present,
+// or (false, err) on patch failure.
+func EnsureFinalizer(ctx context.Context, cl client.Client, finalizer string, obj client.Object) (bool, error) {
+	if controllerutil.ContainsFinalizer(obj, finalizer) {
+		return false, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.V(3).Info("Setting finalizer", "finalizer", finalizer)
+
+	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
+	controllerutil.AddFinalizer(obj, finalizer)
+	if err := cl.Patch(ctx, obj, patch); err != nil {
+		if k8serrors.IsConflict(err) {
+			logger.V(3).Info("Conflict while setting finalizer, will retry")
+			return false, err
+		}
+		logger.Error(err, "unable to set finalizer", "finalizer", finalizer)
+		return false, err
+	}
+
+	logger.V(3).Info("Finalizer set", "finalizer", finalizer)
+	return true, nil
+}

--- a/internal/pkg/controllerhelper/finalizer_test.go
+++ b/internal/pkg/controllerhelper/finalizer_test.go
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+)
+
+const testFinalizer = "test.example.com/finalizer"
+
+func newFinalizerScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+func newConfigMap(finalizers ...string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cm",
+			Namespace:  "default",
+			Finalizers: finalizers,
+		},
+	}
+}
+
+func TestEnsureFinalizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		obj        *corev1.ConfigMap
+		patchErr   error
+		wantAdded  bool
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:      "finalizer already present returns false without patching",
+			obj:       newConfigMap(testFinalizer),
+			wantAdded: false,
+			wantErr:   false,
+		},
+		{
+			name:      "finalizer not present is added successfully",
+			obj:       newConfigMap(),
+			wantAdded: true,
+			wantErr:   false,
+		},
+		{
+			name:       "patch returns conflict error",
+			obj:        newConfigMap(),
+			patchErr:   k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "cm", fmt.Errorf("conflict")),
+			wantAdded:  false,
+			wantErr:    true,
+			wantErrMsg: "conflict",
+		},
+		{
+			name:       "patch returns non-conflict error",
+			obj:        newConfigMap(),
+			patchErr:   fmt.Errorf("server unavailable"),
+			wantAdded:  false,
+			wantErr:    true,
+			wantErrMsg: "server unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newFinalizerScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.obj)
+			if tt.patchErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						return tt.patchErr
+					},
+				})
+			}
+			cl := builder.Build()
+
+			added, err := controllerhelper.EnsureFinalizer(context.Background(), cl, testFinalizer, tt.obj)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantAdded, added)
+
+			if tt.wantAdded {
+				// Verify the finalizer was actually persisted.
+				got := &corev1.ConfigMap{}
+				require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(tt.obj), got))
+				assert.True(t, controllerutil.ContainsFinalizer(got, testFinalizer))
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

The three artifact controllers (rulesfile, config, plugin) contained identical ensureFinalizer implementations differing only in the concrete object type. Extract the logic into controllerhelper.EnsureFinalizer, which accepts a client.Object, and reduce each controller method to a single delegating call.

The helper lives in a new finalizer.go file, keeping finalizer addition and deletion concerns in separate files.

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area falco-operator

> /area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
