### PR TITLE
feat: enforce Secret reference finalizer

### DIFF
--- a/cmd/falco/main.go
+++ b/cmd/falco/main.go
@@ -38,6 +38,7 @@ import (
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 	"github.com/falcosecurity/falco-operator/controllers/falco"
 	configmapctr "github.com/falcosecurity/falco-operator/controllers/reference/configmap"
+	secretctr "github.com/falcosecurity/falco-operator/controllers/reference/secret"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/version"
@@ -233,6 +234,13 @@ func main() {
 		mgr.GetClient(), mgr.GetScheme(),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", configmapctr.ControllerName)
+		os.Exit(1)
+	}
+
+	if err := secretctr.NewSecretReconciler(
+		mgr.GetClient(), mgr.GetScheme(),
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", secretctr.ControllerName)
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/controllers/reference/secret/controller.go
+++ b/controllers/reference/secret/controller.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+)
+
+// ControllerName is the name of the Secret controller. It is also used as the field manager name for finalizer updates.
+const ControllerName = "secret-in-use-finalizer"
+
+// NewSecretReconciler returns a new SecretReconciler.
+func NewSecretReconciler(cl client.Client, scheme *runtime.Scheme) *SecretReconciler {
+	return &SecretReconciler{
+		Client: cl,
+		Scheme: scheme,
+	}
+}
+
+// SecretReconciler protects Secrets that are referenced by Rulesfile or Plugin resources
+// via spec.ociArtifact.registry.auth.secretRef.
+type SecretReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// Reconcile ensures the in-use finalizer is present on referenced Secrets and absent otherwise.
+func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "unable to fetch Secret")
+		return ctrl.Result{}, err
+	}
+
+	referenced, err := r.isReferenced(ctx, secret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If the Secret is being deleted and still referenced, log a warning and do nothing.
+	// The finalizer already blocks the deletion; waiting for references to be cleared.
+	if !secret.DeletionTimestamp.IsZero() && referenced {
+		logger.Info("Secret marked for deletion but still referenced; blocking until references are cleared")
+		return ctrl.Result{}, nil
+	}
+
+	if err := controllerhelper.EnsureInUseFinalizer(
+		ctx, r.Client, r.Scheme, common.SecretInUseFinalizer, ControllerName, secret, referenced); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the controller with the Manager.
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		Watches(
+			&artifactv1alpha1.Rulesfile{},
+			handler.EnqueueRequestsFromMapFunc(r.findSecretsForRulesfile),
+		).
+		Watches(
+			&artifactv1alpha1.Plugin{},
+			handler.EnqueueRequestsFromMapFunc(r.findSecretsForPlugin),
+		).
+		Named(ControllerName).
+		Complete(r)
+}
+
+// isReferenced returns true when at least one Rulesfile or Plugin references the given Secret.
+func (r *SecretReconciler) isReferenced(ctx context.Context, secret client.Object) (bool, error) {
+	indexKey := secret.GetNamespace() + "/" + secret.GetName()
+
+	rfList := &artifactv1alpha1.RulesfileList{}
+	if err := r.List(ctx, rfList, client.MatchingFields{index.SecretOnRulesfile: indexKey}); err != nil {
+		return false, err
+	}
+	if len(rfList.Items) > 0 {
+		return true, nil
+	}
+
+	plList := &artifactv1alpha1.PluginList{}
+	if err := r.List(ctx, plList, client.MatchingFields{index.SecretOnPlugin: indexKey}); err != nil {
+		return false, err
+	}
+	return len(plList.Items) > 0, nil
+}
+
+// findSecretsForRulesfile enqueues the Secret named in a Rulesfile's
+// spec.ociArtifact.registry.auth.secretRef.
+func (r *SecretReconciler) findSecretsForRulesfile(_ context.Context, obj client.Object) []reconcile.Request {
+	rf, ok := obj.(*artifactv1alpha1.Rulesfile)
+	if !ok {
+		return nil
+	}
+	if rf.Spec.OCIArtifact == nil || rf.Spec.OCIArtifact.Registry == nil ||
+		rf.Spec.OCIArtifact.Registry.Auth == nil || rf.Spec.OCIArtifact.Registry.Auth.SecretRef == nil {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: client.ObjectKey{Namespace: rf.Namespace, Name: rf.Spec.OCIArtifact.Registry.Auth.SecretRef.Name}},
+	}
+}
+
+// findSecretsForPlugin enqueues the Secret named in a Plugin's
+// spec.ociArtifact.registry.auth.secretRef.
+func (r *SecretReconciler) findSecretsForPlugin(_ context.Context, obj client.Object) []reconcile.Request {
+	pl, ok := obj.(*artifactv1alpha1.Plugin)
+	if !ok {
+		return nil
+	}
+	if pl.Spec.OCIArtifact == nil || pl.Spec.OCIArtifact.Registry == nil ||
+		pl.Spec.OCIArtifact.Registry.Auth == nil || pl.Spec.OCIArtifact.Registry.Auth.SecretRef == nil {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: client.ObjectKey{Namespace: pl.Namespace, Name: pl.Spec.OCIArtifact.Registry.Auth.SecretRef.Name}},
+	}
+}

--- a/controllers/reference/secret/controller_test.go
+++ b/controllers/reference/secret/controller_test.go
@@ -1,0 +1,449 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, artifactv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newSecret(name string, finalizers ...string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  "default",
+			Finalizers: finalizers,
+		},
+	}
+}
+
+// ociWithSecret builds a minimal OCIArtifact that references the given Secret name.
+func ociWithSecret(secretName string) *commonv1alpha1.OCIArtifact {
+	return &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "test/repo"},
+		Registry: &commonv1alpha1.RegistryConfig{
+			Auth: &commonv1alpha1.RegistryAuth{
+				SecretRef: &commonv1alpha1.SecretRef{Name: secretName},
+			},
+		},
+	}
+}
+
+func TestSecretReconciler_Reconcile(t *testing.T) {
+	s := newScheme(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name                 string
+		objects              []client.Object
+		intercept            interceptor.Funcs
+		setup                func(cl client.Client)
+		request              ctrl.Request
+		wantErr              string
+		wantFinalizer        string
+		finalizerShouldExist bool
+	}{
+		{
+			name:    "Secret not found",
+			objects: nil,
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "missing"}},
+		},
+		{
+			name:    "List error for Rulesfile",
+			objects: []client.Object{newSecret("sec1")},
+			intercept: interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+						return errors.New("rulesfile list error")
+					}
+					return nil
+				},
+			},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec1"}},
+			wantErr: "rulesfile list error",
+		},
+		{
+			name:    "List error for Plugin",
+			objects: []client.Object{newSecret("sec2")},
+			intercept: interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*artifactv1alpha1.PluginList); ok {
+						return errors.New("plugin list error")
+					}
+					return nil
+				},
+			},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec2"}},
+			wantErr: "plugin list error",
+		},
+		{
+			name: "Referenced via Rulesfile, not deleting, adds finalizer",
+			objects: []client.Object{newSecret("sec3"), &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf1"},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec3")},
+			}},
+			request:              ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec3"}},
+			wantFinalizer:        common.SecretInUseFinalizer,
+			finalizerShouldExist: true,
+		},
+		{
+			name: "Referenced via Plugin, not deleting, adds finalizer",
+			objects: []client.Object{newSecret("sec4"), &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pl1"},
+				Spec:       artifactv1alpha1.PluginSpec{OCIArtifact: ociWithSecret("sec4")},
+			}},
+			request:              ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec4"}},
+			wantFinalizer:        common.SecretInUseFinalizer,
+			finalizerShouldExist: true,
+		},
+		{
+			name: "Not referenced, removes finalizer",
+			objects: []client.Object{newSecret("sec5"), &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf-sec5"},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec5")},
+			}},
+			setup: func(cl client.Client) {
+				rf := &artifactv1alpha1.Rulesfile{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf-sec5"},
+				}
+				_ = cl.Delete(ctx, rf)
+			},
+			request:              ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec5"}},
+			wantFinalizer:        common.SecretInUseFinalizer,
+			finalizerShouldExist: false,
+		},
+		{
+			name: "Referenced, deleting, blocks deletion",
+			objects: []client.Object{func() *corev1.Secret {
+				sec := newSecret("sec6", common.SecretInUseFinalizer)
+				sec.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+				return sec
+			}(), &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf2"},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec6")},
+			}},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec6"}},
+		},
+		{
+			name: "Apply error propagates",
+			objects: []client.Object{newSecret("sec7"), &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf3"},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec7")},
+			}},
+			intercept: interceptor.Funcs{
+				Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+					return errors.New("apply failed")
+				},
+			},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec7"}},
+			wantErr: "apply failed",
+		},
+		{
+			name:    "Get error (not NotFound)",
+			objects: nil,
+			intercept: interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return errors.New("generic get error")
+				},
+			},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec-error"}},
+			wantErr: "generic get error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if tt.objects != nil {
+				builder = builder.WithObjects(tt.objects...)
+			}
+			for _, e := range index.All {
+				builder = builder.WithIndex(e.Object, e.Field, e.ExtractValueFn)
+			}
+			if tt.intercept.Get != nil || tt.intercept.List != nil || tt.intercept.Apply != nil || tt.intercept.Delete != nil {
+				builder = builder.WithInterceptorFuncs(tt.intercept)
+			}
+			cl := builder.Build()
+			if tt.setup != nil {
+				tt.setup(cl)
+			}
+			r := NewSecretReconciler(cl, s)
+			res, err := r.Reconcile(ctx, tt.request)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, res)
+				if tt.wantFinalizer != "" {
+					secOut := &corev1.Secret{}
+					require.NoError(t, cl.Get(ctx, types.NamespacedName{Namespace: tt.request.Namespace, Name: tt.request.Name}, secOut))
+					if tt.finalizerShouldExist {
+						assert.Contains(t, secOut.Finalizers, tt.wantFinalizer)
+					} else {
+						assert.NotContains(t, secOut.Finalizers, tt.wantFinalizer)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSecretReconciler_isReferenced(t *testing.T) {
+	s := newScheme(t)
+	ctx := t.Context()
+	sec := newSecret("secX")
+
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		listError func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error
+		want      bool
+		wantErr   string
+	}{
+		{
+			name:    "no references",
+			objects: []client.Object{sec},
+			want:    false,
+		},
+		{
+			name: "rulesfile reference",
+			objects: []client.Object{sec, &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfX"},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("secX")},
+			}},
+			want: true,
+		},
+		{
+			name: "plugin reference",
+			objects: []client.Object{sec, &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plX"},
+				Spec:       artifactv1alpha1.PluginSpec{OCIArtifact: ociWithSecret("secX")},
+			}},
+			want: true,
+		},
+		{
+			name:    "rulesfile list error",
+			objects: []client.Object{sec},
+			listError: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+					return errors.New("rulesfile list error")
+				}
+				return nil
+			},
+			wantErr: "rulesfile list error",
+		},
+		{
+			name:    "plugin list error",
+			objects: []client.Object{sec},
+			listError: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.PluginList); ok {
+					return errors.New("plugin list error")
+				}
+				return nil
+			},
+			wantErr: "plugin list error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.objects...)
+			for _, e := range index.All {
+				builder = builder.WithIndex(e.Object, e.Field, e.ExtractValueFn)
+			}
+			if tt.listError != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					List: tt.listError,
+				})
+			}
+			cl := builder.Build()
+			r := NewSecretReconciler(cl, s)
+			ref, err := r.isReferenced(ctx, sec)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, ref)
+			}
+		})
+	}
+}
+
+func TestSecretReconciler_findSecretsFor(t *testing.T) {
+	s := newScheme(t)
+	r := NewSecretReconciler(nil, s)
+
+	type findCase struct {
+		name string
+		obj  client.Object
+		want []ctrl.Request
+	}
+
+	mappers := []struct {
+		name  string
+		fn    func(context.Context, client.Object) []ctrl.Request
+		cases []findCase
+	}{
+		{
+			name: "Rulesfile",
+			fn:   r.findSecretsForRulesfile,
+			cases: []findCase{
+				{name: "not a Rulesfile", obj: newSecret("secX"), want: nil},
+				{
+					name: "nil OCIArtifact",
+					obj:  &artifactv1alpha1.Rulesfile{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfX"}},
+					want: nil,
+				},
+				{
+					name: "nil Registry",
+					obj: &artifactv1alpha1.Rulesfile{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfX"},
+						Spec: artifactv1alpha1.RulesfileSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "test/repo"}},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "nil Auth",
+					obj: &artifactv1alpha1.Rulesfile{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfX"},
+						Spec: artifactv1alpha1.RulesfileSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{
+								Image:    commonv1alpha1.ImageSpec{Repository: "test/repo"},
+								Registry: &commonv1alpha1.RegistryConfig{},
+							},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "nil SecretRef",
+					obj: &artifactv1alpha1.Rulesfile{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfX"},
+						Spec: artifactv1alpha1.RulesfileSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{
+								Image:    commonv1alpha1.ImageSpec{Repository: "test/repo"},
+								Registry: &commonv1alpha1.RegistryConfig{Auth: &commonv1alpha1.RegistryAuth{}},
+							},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "valid SecretRef",
+					obj: &artifactv1alpha1.Rulesfile{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rfY"},
+						Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("secY")},
+					},
+					want: []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: "default", Name: "secY"}}},
+				},
+			},
+		},
+		{
+			name: "Plugin",
+			fn:   r.findSecretsForPlugin,
+			cases: []findCase{
+				{name: "not a Plugin", obj: newSecret("secX"), want: nil},
+				{
+					name: "nil OCIArtifact",
+					obj:  &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plX"}},
+					want: nil,
+				},
+				{
+					name: "nil Registry",
+					obj: &artifactv1alpha1.Plugin{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plX"},
+						Spec: artifactv1alpha1.PluginSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "test/repo"}},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "nil Auth",
+					obj: &artifactv1alpha1.Plugin{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plX"},
+						Spec: artifactv1alpha1.PluginSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{
+								Image:    commonv1alpha1.ImageSpec{Repository: "test/repo"},
+								Registry: &commonv1alpha1.RegistryConfig{},
+							},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "nil SecretRef",
+					obj: &artifactv1alpha1.Plugin{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plX"},
+						Spec: artifactv1alpha1.PluginSpec{
+							OCIArtifact: &commonv1alpha1.OCIArtifact{
+								Image:    commonv1alpha1.ImageSpec{Repository: "test/repo"},
+								Registry: &commonv1alpha1.RegistryConfig{Auth: &commonv1alpha1.RegistryAuth{}},
+							},
+						},
+					},
+					want: nil,
+				},
+				{
+					name: "valid SecretRef",
+					obj: &artifactv1alpha1.Plugin{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "plY"},
+						Spec:       artifactv1alpha1.PluginSpec{OCIArtifact: ociWithSecret("secY")},
+					},
+					want: []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: "default", Name: "secY"}}},
+				},
+			},
+		},
+	}
+
+	for _, m := range mappers {
+		t.Run(m.name, func(t *testing.T) {
+			for _, tt := range m.cases {
+				t.Run(tt.name, func(t *testing.T) {
+					assert.Equal(t, tt.want, m.fn(context.Background(), tt.obj))
+				})
+			}
+		})
+	}
+}

--- a/controllers/reference/secret/controller_test.go
+++ b/controllers/reference/secret/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,13 +48,31 @@ func newScheme(t *testing.T) *runtime.Scheme {
 }
 
 func newSecret(name string, finalizers ...string) *corev1.Secret {
-	return &corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
 			Namespace:  "default",
 			Finalizers: finalizers,
 		},
 	}
+
+	// If finalizers are provided, simulate managed fields as if they were applied by our controller
+	if len(finalizers) > 0 {
+		secret.ManagedFields = []metav1.ManagedFieldsEntry{
+			{
+				Manager:    ControllerName,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: "v1",
+				Time:       &metav1.Time{Time: metav1.Now().Time},
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{
+					Raw: []byte(`{"f:metadata":{"f:finalizers":{".":{},"v:\"` + common.SecretInUseFinalizer + `\"":{}}}}`),
+				},
+			},
+		}
+	}
+
+	return secret
 }
 
 // ociWithSecret builds a minimal OCIArtifact that references the given Secret name.
@@ -81,6 +100,7 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 		wantErr              string
 		wantFinalizer        string
 		finalizerShouldExist bool
+		shouldNotExist       bool
 	}{
 		{
 			name:    "Secret not found",
@@ -137,7 +157,7 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 		},
 		{
 			name: "Not referenced, removes finalizer",
-			objects: []client.Object{newSecret("sec5"), &artifactv1alpha1.Rulesfile{
+			objects: []client.Object{newSecret("sec5", common.SecretInUseFinalizer), &artifactv1alpha1.Rulesfile{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf-sec5"},
 				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec5")},
 			}},
@@ -152,16 +172,28 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 			finalizerShouldExist: false,
 		},
 		{
-			name: "Referenced, deleting, blocks deletion",
+			name: "Deleting + not referenced, removes finalizer",
 			objects: []client.Object{func() *corev1.Secret {
 				sec := newSecret("sec6", common.SecretInUseFinalizer)
 				sec.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
 				return sec
+			}()},
+			request:              ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec6"}},
+			wantFinalizer:        common.SecretInUseFinalizer,
+			finalizerShouldExist: false,
+			shouldNotExist:       true,
+		},
+		{
+			name: "Referenced, deleting, blocks deletion",
+			objects: []client.Object{func() *corev1.Secret {
+				sec := newSecret("sec7", common.SecretInUseFinalizer)
+				sec.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+				return sec
 			}(), &artifactv1alpha1.Rulesfile{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf2"},
-				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec6")},
+				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec7")},
 			}},
-			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec6"}},
+			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec7"}},
 		},
 		{
 			name: "Apply error propagates",
@@ -213,9 +245,14 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, ctrl.Result{}, res)
-				if tt.wantFinalizer != "" {
+				if tt.shouldNotExist {
 					secOut := &corev1.Secret{}
-					require.NoError(t, cl.Get(ctx, types.NamespacedName{Namespace: tt.request.Namespace, Name: tt.request.Name}, secOut))
+					err := cl.Get(ctx, types.NamespacedName{Namespace: tt.request.Namespace, Name: tt.request.Name}, secOut)
+					assert.True(t, k8serrors.IsNotFound(err), "Expected secret to not exist after finalizer removal during deletion")
+				} else if tt.wantFinalizer != "" {
+					secOut := &corev1.Secret{}
+					err := cl.Get(ctx, types.NamespacedName{Namespace: tt.request.Namespace, Name: tt.request.Name}, secOut)
+					assert.NoError(t, err)
 					if tt.finalizerShouldExist {
 						assert.Contains(t, secOut.Finalizers, tt.wantFinalizer)
 					} else {

--- a/controllers/reference/secret/doc.go
+++ b/controllers/reference/secret/doc.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package secret implements the Secret in-use protection controller.
+// It runs in the main falco operator (Deployment) and ensures that Secrets
+// referenced by Rulesfile or Plugin artifact resources via
+// spec.ociArtifact.registry.auth.secretRef cannot be deleted until
+// all references are cleared.
+package secret

--- a/internal/pkg/common/finalizer.go
+++ b/internal/pkg/common/finalizer.go
@@ -23,6 +23,11 @@ const (
 	// by at least one Rulesfile or Config artifact resource.
 	// Its presence blocks ConfigMap deletion until all references are cleared.
 	ConfigmapInUseFinalizer = "artifact.falcosecurity.dev/configmap-in-use"
+
+	// SecretInUseFinalizer is the finalizer placed on Secrets that are referenced
+	// by at least one Rulesfile or Plugin artifact resource via spec.ociArtifact.registry.auth.secretRef.
+	// Its presence blocks Secret deletion until all references are cleared.
+	SecretInUseFinalizer = "artifact.falcosecurity.dev/secret-in-use"
 )
 
 // FormatFinalizerName creates a finalizer name by combining a prefix and suffix with a hyphen.

--- a/internal/pkg/index/index.go
+++ b/internal/pkg/index/index.go
@@ -36,11 +36,27 @@ type Entry struct {
 }
 
 // All aggregates all field indexes defined in this package.
-var All []Entry = append(ConfigIndexes, RulesfileIndexes...)
+var All []Entry = append(append(ConfigIndexes, RulesfileIndexes...), PluginIndexes...)
 
 // IndexByConfigMapRef returns a client.IndexerFunc that indexes objects by their ConfigMapRef name.
 // The getRef function extracts the ConfigMapRef from the typed object; return nil when not set.
 func IndexByConfigMapRef[T client.Object](getRef func(T) *commonv1alpha1.ConfigMapRef) client.IndexerFunc {
+	return func(obj client.Object) []string {
+		typed, ok := obj.(T)
+		if !ok {
+			return nil
+		}
+		ref := getRef(typed)
+		if ref == nil {
+			return nil
+		}
+		return []string{typed.GetNamespace() + "/" + ref.Name}
+	}
+}
+
+// IndexBySecretRef returns a client.IndexerFunc that indexes objects by their nested SecretRef name.
+// The getRef function extracts the SecretRef from the typed object; return nil when not set.
+func IndexBySecretRef[T client.Object](getRef func(T) *commonv1alpha1.SecretRef) client.IndexerFunc {
 	return func(obj client.Object) []string {
 		typed, ok := obj.(T)
 		if !ok {

--- a/internal/pkg/index/index_test.go
+++ b/internal/pkg/index/index_test.go
@@ -67,9 +67,10 @@ func TestIndexByConfigMapRef(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	expected := make([]index.Entry, 0, len(index.ConfigIndexes)+len(index.RulesfileIndexes))
+	expected := make([]index.Entry, 0, len(index.ConfigIndexes)+len(index.RulesfileIndexes)+len(index.PluginIndexes))
 	expected = append(expected, index.ConfigIndexes...)
 	expected = append(expected, index.RulesfileIndexes...)
+	expected = append(expected, index.PluginIndexes...)
 	require.Len(t, index.All, len(expected), "All must contain exactly one entry per resource index")
 
 	for i, entry := range index.All {

--- a/internal/pkg/index/plugin.go
+++ b/internal/pkg/index/plugin.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package index
+
+import (
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+)
+
+// SecretOnPlugin is the index field name for Plugin resources indexed by their SecretRef.
+const SecretOnPlugin = "SecretOnPlugin"
+
+// PluginBySecretRef indexes Plugin resources by their .spec.ociArtifact.registry.auth.secretRef.name.
+var PluginBySecretRef = IndexBySecretRef(
+	func(pl *artifactv1alpha1.Plugin) *commonv1alpha1.SecretRef {
+		if pl.Spec.OCIArtifact == nil || pl.Spec.OCIArtifact.Registry == nil ||
+			pl.Spec.OCIArtifact.Registry.Auth == nil {
+			return nil
+		}
+		return pl.Spec.OCIArtifact.Registry.Auth.SecretRef
+	},
+)
+
+// PluginIndexes holds all field indexes for Plugin resources.
+var PluginIndexes = []Entry{
+	{
+		Object:         &artifactv1alpha1.Plugin{},
+		Field:          SecretOnPlugin,
+		ExtractValueFn: PluginBySecretRef,
+	},
+}

--- a/internal/pkg/index/plugin_test.go
+++ b/internal/pkg/index/plugin_test.go
@@ -27,56 +27,24 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 )
 
-func TestRulesfileByConfigMapRef(t *testing.T) {
+func TestPluginBySecretRef(t *testing.T) {
 	tests := []struct {
-		name      string
-		rulesfile *artifactv1alpha1.Rulesfile
-		want      []string
-	}{
-		{
-			name: "no configmap ref returns nil",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-			},
-			want: nil,
-		},
-		{
-			name: "with configmap ref returns index key",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-				Spec: artifactv1alpha1.RulesfileSpec{
-					ConfigMapRef: &commonv1alpha1.ConfigMapRef{Name: "my-rules-cm"},
-				},
-			},
-			want: []string{testNamespace + "/my-rules-cm"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, index.RulesfileByConfigMapRef(tt.rulesfile))
-		})
-	}
-}
-
-func TestRulesfileBySecretRef(t *testing.T) {
-	tests := []struct {
-		name      string
-		rulesfile *artifactv1alpha1.Rulesfile
-		want      []string
+		name   string
+		plugin *artifactv1alpha1.Plugin
+		want   []string
 	}{
 		{
 			name: "nil OCIArtifact returns nil",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
+			plugin: &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
 			},
 			want: nil,
 		},
 		{
 			name: "nil Registry returns nil",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-				Spec: artifactv1alpha1.RulesfileSpec{
+			plugin: &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+				Spec: artifactv1alpha1.PluginSpec{
 					OCIArtifact: &commonv1alpha1.OCIArtifact{
 						Image: commonv1alpha1.ImageSpec{Repository: "my-repo"},
 					},
@@ -86,9 +54,9 @@ func TestRulesfileBySecretRef(t *testing.T) {
 		},
 		{
 			name: "nil Auth returns nil",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-				Spec: artifactv1alpha1.RulesfileSpec{
+			plugin: &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+				Spec: artifactv1alpha1.PluginSpec{
 					OCIArtifact: &commonv1alpha1.OCIArtifact{
 						Image:    commonv1alpha1.ImageSpec{Repository: "my-repo"},
 						Registry: &commonv1alpha1.RegistryConfig{Name: "ghcr.io"},
@@ -99,9 +67,9 @@ func TestRulesfileBySecretRef(t *testing.T) {
 		},
 		{
 			name: "nil SecretRef returns nil",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-				Spec: artifactv1alpha1.RulesfileSpec{
+			plugin: &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+				Spec: artifactv1alpha1.PluginSpec{
 					OCIArtifact: &commonv1alpha1.OCIArtifact{
 						Image: commonv1alpha1.ImageSpec{Repository: "my-repo"},
 						Registry: &commonv1alpha1.RegistryConfig{
@@ -115,9 +83,9 @@ func TestRulesfileBySecretRef(t *testing.T) {
 		},
 		{
 			name: "with secret ref returns index key",
-			rulesfile: &artifactv1alpha1.Rulesfile{
-				ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
-				Spec: artifactv1alpha1.RulesfileSpec{
+			plugin: &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+				Spec: artifactv1alpha1.PluginSpec{
 					OCIArtifact: &commonv1alpha1.OCIArtifact{
 						Image: commonv1alpha1.ImageSpec{Repository: "my-repo"},
 						Registry: &commonv1alpha1.RegistryConfig{
@@ -135,14 +103,14 @@ func TestRulesfileBySecretRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, index.RulesfileBySecretRef(tt.rulesfile))
+			assert.Equal(t, tt.want, index.PluginBySecretRef(tt.plugin))
 		})
 	}
 }
 
-func TestRulesfileBySecretRef_WrongType(t *testing.T) {
-	plugin := &artifactv1alpha1.Plugin{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+func TestPluginBySecretRef_WrongType(t *testing.T) {
+	rulesfile := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rulesfile", Namespace: testNamespace},
 	}
-	assert.Nil(t, index.RulesfileBySecretRef(plugin))
+	assert.Nil(t, index.PluginBySecretRef(rulesfile))
 }

--- a/internal/pkg/index/rulesfile.go
+++ b/internal/pkg/index/rulesfile.go
@@ -21,13 +21,28 @@ import (
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 )
 
-// ConfigMapOnRulesfile is the index field name for Rulesfile resources indexed by their ConfigMapRef.
-const ConfigMapOnRulesfile = "ConfigMapOnRulesfile"
+const (
+	// ConfigMapOnRulesfile is the index field name for Rulesfile resources indexed by their ConfigMapRef.
+	ConfigMapOnRulesfile = "ConfigMapOnRulesfile"
+	// SecretOnRulesfile is the index field name for Rulesfile resources indexed by their SecretRef.
+	SecretOnRulesfile = "SecretOnRulesfile"
+)
 
 // RulesfileByConfigMapRef indexes Rulesfile resources by their .spec.configMapRef.name.
 var RulesfileByConfigMapRef = IndexByConfigMapRef(
 	func(rf *artifactv1alpha1.Rulesfile) *commonv1alpha1.ConfigMapRef {
 		return rf.Spec.ConfigMapRef
+	},
+)
+
+// RulesfileBySecretRef indexes Rulesfile resources by their .spec.ociArtifact.registry.auth.secretRef.name.
+var RulesfileBySecretRef = IndexBySecretRef(
+	func(rf *artifactv1alpha1.Rulesfile) *commonv1alpha1.SecretRef {
+		if rf.Spec.OCIArtifact == nil || rf.Spec.OCIArtifact.Registry == nil ||
+			rf.Spec.OCIArtifact.Registry.Auth == nil {
+			return nil
+		}
+		return rf.Spec.OCIArtifact.Registry.Auth.SecretRef
 	},
 )
 
@@ -37,5 +52,10 @@ var RulesfileIndexes = []Entry{
 		Object:         &artifactv1alpha1.Rulesfile{},
 		Field:          ConfigMapOnRulesfile,
 		ExtractValueFn: RulesfileByConfigMapRef,
+	},
+	{
+		Object:         &artifactv1alpha1.Rulesfile{},
+		Field:          SecretOnRulesfile,
+		ExtractValueFn: RulesfileBySecretRef,
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

Prevents deletion of Secrets referenced by Rulesfile or Plugin artifact
resources via spec.ociArtifact.registry.auth.secretRef by managing an
artifact.falcosecurity.dev/secret-in-use finalizer.

- Add SecretInUseFinalizer constant to internal/pkg/common
- Add IndexBySecretRef generic helper to internal/pkg/index
- Index Rulesfile and Plugin resources by their secretRef (SecretOnRulesfile,
  SecretOnPlugin) and extend All to include PluginIndexes
- Implement controllers/reference/secret with SecretReconciler that watches
  Secrets, Rulesfiles, and Plugins; adds/removes the finalizer based on
  live reference count
- Add unit tests for all new index functions and the secret controller

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area falco-operator

 /area artifact-operator

 /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
