### PR TITLE
fix(ci): align Docker build and release workflows with cmd/falco → cmd/instance rename

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -21,7 +21,7 @@ jobs:
           echo "commit=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
-  falco-operator:
+  instance-operator:
     if: ${{ github.event_name == 'push' }}
     needs: docker-configure
     uses: ./.github/workflows/docker-image.yml
@@ -31,7 +31,7 @@ jobs:
       commit: ${{ needs.docker-configure.outputs.commit }}
       build_date: ${{ needs.docker-configure.outputs.build_date }}
       image_name: ${{ vars.FALCO_OPERATOR_IMAGE_NAME }}
-      component_name: "falco"
+      component_name: "instance"
 
   artifact-operator:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ on:
         default: false
         type: boolean
       artifact_operator_image:
-        description: "The artifact-operator image to inject as sidecar (only for falco-operator)"
+        description: "The artifact-operator image to inject as sidecar (only for instance-operator)"
         required: false
         default: ""
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       image_name: ${{ vars.ARTIFACT_OPERATOR_IMAGE_NAME }}
       component_name: "artifact"
 
-  falco-operator-image:
+  instance-operator-image:
     if: ${{ github.event_name == 'push' }}
     needs: [docker-configure, artifact-operator-image]
     uses: ./.github/workflows/docker-image.yml
@@ -127,7 +127,7 @@ jobs:
       commit: ${{ needs.docker-configure.outputs.commit }}
       build_date: ${{ needs.docker-configure.outputs.build_date }}
       image_name: ${{ vars.FALCO_OPERATOR_IMAGE_NAME }}
-      component_name: "falco"
+      component_name: "instance"
       artifact_operator_image: "${{ vars.ARTIFACT_OPERATOR_IMAGE_NAME }}:${{ needs.docker-configure.outputs.release }}"
 
   provenance-for-images-artifact:
@@ -147,8 +147,8 @@ jobs:
       registry-username: ${{ secrets.DOCKERHUB_USER }}
       registry-password: ${{ secrets.DOCKERHUB_SECRET }}
 
-  provenance-for-images-falco:
-    needs: [docker-configure, falco-operator-image]
+  provenance-for-images-instance:
+    needs: [docker-configure, instance-operator-image]
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.
@@ -159,14 +159,14 @@ jobs:
       # The image digest is used to prevent TOCTOU issues.
       # This is an output of the docker/build-push-action
       # See: https://github.com/slsa-framework/slsa-verifier#toctou-attacks
-      digest: ${{ needs.falco-operator-image.outputs.digest }}
+      digest: ${{ needs.instance-operator-image.outputs.digest }}
     secrets:
       registry-username: ${{ secrets.DOCKERHUB_USER }}
       registry-password: ${{ secrets.DOCKERHUB_SECRET }}
 
   # Generate install.yaml with properly tagged images and attach to release
   generate-install-yaml:
-    needs: [docker-configure, falco-operator-image]
+    needs: [docker-configure, instance-operator-image]
     runs-on: ubuntu-22.04
     permissions:
       contents: write # To upload assets to the release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

The recent reorganization (8f94eb8) renamed `cmd/falco/` to `cmd/instance/`, but the CI workflows were not updated accordingly. This causes the `Docker Image Build` workflow to fail on `main` with:

```
stat cmd/falco/main.go: directory not found
```

This PR updates all three workflow files to align with the new directory structure

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
