### PR TITLE
feat: add falcosidekick and falcosidekick-ui component types and align Falco defaults

### DIFF
--- a/api/instance/v1alpha1/component_types.go
+++ b/api/instance/v1alpha1/component_types.go
@@ -23,12 +23,16 @@ import (
 )
 
 // ComponentType defines the type of component to deploy.
-// +kubebuilder:validation:Enum=metacollector
+// +kubebuilder:validation:Enum=metacollector;falcosidekick;"falcosidekick-ui"
 type ComponentType string
 
 const (
 	// ComponentTypeMetacollector represents the k8s-metacollector component.
 	ComponentTypeMetacollector ComponentType = "metacollector"
+	// ComponentTypeFalcosidekick represents the Falcosidekick fan-out daemon.
+	ComponentTypeFalcosidekick ComponentType = "falcosidekick"
+	// ComponentTypeFalcosidekickUI represents the Falcosidekick UI dashboard.
+	ComponentTypeFalcosidekickUI ComponentType = "falcosidekick-ui"
 )
 
 // ComponentInfo identifies which component to deploy and at which version.

--- a/config/crd/bases/instance.falcosecurity.dev_components.yaml
+++ b/config/crd/bases/instance.falcosecurity.dev_components.yaml
@@ -77,6 +77,8 @@ spec:
                     description: Type specifies which component to deploy.
                     enum:
                     - metacollector
+                    - falcosidekick
+                    - falcosidekick-ui
                     type: string
                   version:
                     description: |-

--- a/config/samples/instance_v1alpha1_component_sidekick.yaml
+++ b/config/samples/instance_v1alpha1_component_sidekick.yaml
@@ -1,0 +1,11 @@
+apiVersion: instance.falcosecurity.dev/v1alpha1
+kind: Component
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: falco-operator
+  name: sidekick
+spec:
+  component:
+    type: falcosidekick
+    version: "2.32.0"
+  replicas: 2

--- a/config/samples/instance_v1alpha1_component_sidekick_ui.yaml
+++ b/config/samples/instance_v1alpha1_component_sidekick_ui.yaml
@@ -1,0 +1,29 @@
+# Falcosidekick UI requires a Redis instance.
+# This sample shows how to point to your own Redis using podTemplateSpec.
+# The wait-redis init container will block until Redis is reachable.
+# If Redis is not available, the pod stays in Init:0/1 state.
+apiVersion: instance.falcosecurity.dev/v1alpha1
+kind: Component
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: falco-operator
+  name: sidekick-ui
+spec:
+  component:
+    type: falcosidekick-ui
+    version: "2.2.0"
+  replicas: 2
+  podTemplateSpec:
+    spec:
+      # Override the init container to point to your Redis instance.
+      initContainers:
+        - name: wait-redis
+          env:
+            - name: REDIS_ADDR
+              value: "my-redis-service:6379"  # <-- replace with your Redis address
+      # Override the main container args to point to your Redis instance.
+      containers:
+        - name: falcosidekick-ui
+          args:
+            - "-r"
+            - "my-redis-service:6379"  # <-- replace with your Redis address

--- a/config/samples/instance_v1alpha1_component_sidekick_ui_with_redis.yaml
+++ b/config/samples/instance_v1alpha1_component_sidekick_ui_with_redis.yaml
@@ -1,0 +1,80 @@
+# Complete example: Falcosidekick UI with a bundled Redis instance.
+# This deploys a Redis StatefulSet + Service, then the UI Component.
+---
+# Redis StatefulSet (persistent storage for event data)
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: falcosidekick-ui-redis
+  labels:
+    app.kubernetes.io/name: falcosidekick-ui-redis
+spec:
+  serviceName: falcosidekick-ui-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: falcosidekick-ui-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: falcosidekick-ui-redis
+    spec:
+      containers:
+        - name: redis
+          image: docker.io/redis/redis-stack:7.2.0-v11
+          ports:
+            - containerPort: 6379
+              name: redis
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# Redis headless Service (matches the default address: falcosidekick-ui-redis:6379)
+apiVersion: v1
+kind: Service
+metadata:
+  name: falcosidekick-ui-redis
+  labels:
+    app.kubernetes.io/name: falcosidekick-ui-redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  selector:
+    app.kubernetes.io/name: falcosidekick-ui-redis
+---
+# Falcosidekick UI Component (uses default Redis address: falcosidekick-ui-redis:6379)
+apiVersion: instance.falcosecurity.dev/v1alpha1
+kind: Component
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: falco-operator
+  name: sidekick-ui
+spec:
+  component:
+    type: falcosidekick-ui
+    version: "2.2.0"
+  replicas: 2

--- a/internal/pkg/image/const.go
+++ b/internal/pkg/image/const.go
@@ -31,4 +31,23 @@ const (
 	MetacollectorImage = "k8s-metacollector"
 	// MetacollectorTag the default tag used for k8s-metacollector.
 	MetacollectorTag = "0.1.1"
+
+	// FalcosidekickImage the default image name used for Falcosidekick.
+	FalcosidekickImage = "falcosidekick"
+	// FalcosidekickTag the default tag used for Falcosidekick.
+	FalcosidekickTag = "2.32.0"
+
+	// FalcosidekickUIImage the default image name used for Falcosidekick UI.
+	FalcosidekickUIImage = "falcosidekick-ui"
+	// FalcosidekickUITag the default tag used for Falcosidekick UI.
+	FalcosidekickUITag = "2.2.0"
+
+	// RedisRegistry the default registry used for Redis.
+	RedisRegistry = "docker.io"
+	// RedisRepository the default repository used for Redis.
+	RedisRepository = "redis"
+	// RedisImage the default image name used for Redis.
+	RedisImage = "redis-stack"
+	// RedisTag the default tag used for Redis.
+	RedisTag = "7.2.0-v11"
 )

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -51,6 +51,19 @@ var FalcoDefaults = &InstanceDefaults{
 	DefaultPorts: []corev1.ContainerPort{
 		{ContainerPort: 8765, Name: "web", Protocol: corev1.ProtocolTCP},
 	},
+	StartupProbe: &corev1.Probe{
+		InitialDelaySeconds: 3,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       5,
+		FailureThreshold:    20,
+		SuccessThreshold:    1,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/healthz",
+				Port: intstr.FromInt32(8765),
+			},
+		},
+	},
 	DefaultResources: corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1000m"),
@@ -62,7 +75,7 @@ var FalcoDefaults = &InstanceDefaults{
 		},
 	},
 	LivenessProbe: &corev1.Probe{
-		InitialDelaySeconds: 60,
+		InitialDelaySeconds: 0,
 		TimeoutSeconds:      5,
 		PeriodSeconds:       15,
 		FailureThreshold:    3,
@@ -75,7 +88,7 @@ var FalcoDefaults = &InstanceDefaults{
 		},
 	},
 	ReadinessProbe: &corev1.Probe{
-		InitialDelaySeconds: 30,
+		InitialDelaySeconds: 0,
 		TimeoutSeconds:      5,
 		PeriodSeconds:       15,
 		FailureThreshold:    3,
@@ -150,6 +163,7 @@ var FalcoDefaults = &InstanceDefaults{
 		{Name: "docker-socket", MountPath: "/host/var/run/"},
 		{Name: "containerd-socket", MountPath: "/host/run/containerd/"},
 		{Name: "crio-socket", MountPath: "/host/run/crio/"},
+		{Name: "host-containerd-socket", MountPath: "/host/run/host-containerd/"},
 		{Name: mounts.ConfigMountName, MountPath: mounts.ConfigDirPath},
 		{Name: mounts.RulesfileMountName, MountPath: mounts.RulesfileDirPath},
 		{Name: mounts.PluginMountName, MountPath: mounts.PluginDirPath},
@@ -165,6 +179,7 @@ var FalcoDefaults = &InstanceDefaults{
 		{Name: "docker-socket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run"}}},
 		{Name: "containerd-socket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/containerd"}}},
 		{Name: "crio-socket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/crio"}}},
+		{Name: "host-containerd-socket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/host-containerd"}}},
 		{Name: "proc-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 		{Name: mounts.ConfigMountName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: mounts.RulesfileMountName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
@@ -243,7 +258,8 @@ var FalcoDefaults = &InstanceDefaults{
 }
 
 // Falco configuration strings, keyed by workload type.
-var daemonsetFalcoConfig = `append_output: []
+var daemonsetFalcoConfig = `append_output:
+- suggested_output: true
 base_syscalls:
   custom_set: []
   repair: false
@@ -256,8 +272,10 @@ container_engines:
   cri:
     enabled: true
     sockets:
-    - /run/k3s/containerd/containerd.sock
+    - /run/containerd/containerd.sock
     - /run/crio/crio.sock
+    - /run/k3s/containerd/containerd.sock
+    - /run/host-containerd/containerd.sock
   docker:
     enabled: true
   libvirt_lxc:
@@ -281,6 +299,9 @@ engine:
     drop_failed_exit: false
 falco_libs:
   thread_table_size: 262144
+  thread_table_auto_purging_interval_s: 300
+  thread_table_auto_purging_thread_timeout_s: 300
+  snaplen: 80
 file_output:
   enabled: false
   filename: ./events.txt
@@ -306,6 +327,7 @@ http_output:
   url: ""
   user_agent: falcosecurity/falco
 json_include_message_property: false
+json_include_output_fields_property: true
 json_include_output_property: true
 json_include_tags_property: true
 json_output: false
@@ -332,6 +354,7 @@ output_timeout: 2000
 outputs_queue:
   capacity: 0
 plugins: []
+plugins_hostinfo: true
 priority: debug
 program_output:
   enabled: false
@@ -366,7 +389,8 @@ webserver:
   threadiness: 0
 `
 
-var deploymentFalcoConfig = `append_output: []
+var deploymentFalcoConfig = `append_output:
+- suggested_output: true
 base_syscalls:
   custom_set: []
   repair: false
@@ -379,8 +403,10 @@ container_engines:
   cri:
     enabled: false
     sockets:
-    - /run/k3s/containerd/containerd.sock
+    - /run/containerd/containerd.sock
     - /run/crio/crio.sock
+    - /run/k3s/containerd/containerd.sock
+    - /run/host-containerd/containerd.sock
   docker:
     enabled: false
   libvirt_lxc:
@@ -404,6 +430,9 @@ engine:
     drop_failed_exit: false
 falco_libs:
   thread_table_size: 262144
+  thread_table_auto_purging_interval_s: 300
+  thread_table_auto_purging_thread_timeout_s: 300
+  snaplen: 80
 file_output:
   enabled: false
   filename: ./events.txt
@@ -429,6 +458,7 @@ http_output:
   url: ""
   user_agent: falcosecurity/falco
 json_include_message_property: false
+json_include_output_fields_property: true
 json_include_output_property: true
 json_include_tags_property: true
 json_output: false
@@ -455,6 +485,7 @@ output_timeout: 2000
 outputs_queue:
   capacity: 0
 plugins: []
+plugins_hostinfo: true
 priority: debug
 program_output:
   enabled: false

--- a/internal/pkg/resources/forge.go
+++ b/internal/pkg/resources/forge.go
@@ -34,6 +34,7 @@ func forgeMainContainer(defs *InstanceDefaults) *corev1.Container {
 		Args:            defs.DefaultArgs,
 		Env:             defs.EnvVars,
 		VolumeMounts:    forgeVolumeMounts(defs),
+		StartupProbe:    defs.StartupProbe,
 		LivenessProbe:   defs.LivenessProbe,
 		ReadinessProbe:  defs.ReadinessProbe,
 		SecurityContext: defs.SecurityContext,

--- a/internal/pkg/resources/forge_test.go
+++ b/internal/pkg/resources/forge_test.go
@@ -109,6 +109,24 @@ func TestGenerateWorkload(t *testing.T) {
 			wantContainers:     1,
 			wantTolerations:    0,
 		},
+		{
+			name:               "Falcosidekick Deployment",
+			kind:               ResourceTypeDeployment,
+			defs:               FalcosidekickDefaults,
+			nativeSidecar:      false,
+			wantInitContainers: 0,
+			wantContainers:     1,
+			wantTolerations:    0,
+		},
+		{
+			name:               "Falcosidekick UI Deployment has wait-redis init container",
+			kind:               ResourceTypeDeployment,
+			defs:               FalcosidekickUIDefaults,
+			nativeSidecar:      false,
+			wantInitContainers: 1,
+			wantContainers:     1,
+			wantTolerations:    0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -229,6 +247,18 @@ func TestGenerateWorkloadErrors(t *testing.T) {
 			name:         "metacollector does not support DaemonSet",
 			resourceType: ResourceTypeDaemonSet,
 			defs:         MetacollectorDefaults,
+			wantErrMsg:   "not supported",
+		},
+		{
+			name:         "falcosidekick does not support DaemonSet",
+			resourceType: ResourceTypeDaemonSet,
+			defs:         FalcosidekickDefaults,
+			wantErrMsg:   "not supported",
+		},
+		{
+			name:         "falcosidekick-ui does not support DaemonSet",
+			resourceType: ResourceTypeDaemonSet,
+			defs:         FalcosidekickUIDefaults,
 			wantErrMsg:   "not supported",
 		},
 		{
@@ -450,6 +480,14 @@ func TestForgeMainContainer(t *testing.T) {
 			name: "Metacollector main container",
 			defs: MetacollectorDefaults,
 		},
+		{
+			name: "Falcosidekick main container",
+			defs: FalcosidekickDefaults,
+		},
+		{
+			name: "Falcosidekick UI main container",
+			defs: FalcosidekickUIDefaults,
+		},
 	}
 
 	for _, tt := range tests {
@@ -462,6 +500,7 @@ func TestForgeMainContainer(t *testing.T) {
 			assert.Equal(t, tt.defs.DefaultCommand, c.Command)
 			assert.Equal(t, tt.defs.DefaultArgs, c.Args)
 			assert.Equal(t, tt.defs.EnvVars, c.Env)
+			assert.Equal(t, tt.defs.StartupProbe, c.StartupProbe)
 			assert.Equal(t, tt.defs.LivenessProbe, c.LivenessProbe)
 			assert.Equal(t, tt.defs.ReadinessProbe, c.ReadinessProbe)
 			assert.Equal(t, tt.defs.SecurityContext, c.SecurityContext)

--- a/internal/pkg/resources/generator.go
+++ b/internal/pkg/resources/generator.go
@@ -59,6 +59,7 @@ func generateDeployment(meta *metav1.ObjectMeta, defs *InstanceDefaults, nativeS
 		AddContainer(forgeMainContainer(defs)).
 		WithStrategy(forgeDeploymentStrategy(defs.DeploymentStrategy))
 
+	addInitContainers(b, defs)
 	addSidecarContainers(b, nativeSidecar, defs)
 
 	return b.Build()
@@ -78,9 +79,23 @@ func generateDaemonSet(meta *metav1.ObjectMeta, defs *InstanceDefaults, nativeSi
 		AddContainer(forgeMainContainer(defs)).
 		WithUpdateStrategy(forgeDaemonSetUpdateStrategy(defs.DaemonSetUpdateStrategy))
 
+	addInitContainers(b, defs)
 	addSidecarContainers(b, nativeSidecar, defs)
 
 	return b.Build()
+}
+
+// addInitContainers adds true init containers (run to completion) from defaults.
+func addInitContainers(b any, defs *InstanceDefaults) {
+	for i := range defs.InitContainers {
+		initC := defs.InitContainers[i]
+		switch builder := b.(type) {
+		case *builders.DeploymentBuilder:
+			builder.AddInitContainer(&initC)
+		case *builders.DaemonSetBuilder:
+			builder.AddInitContainer(&initC)
+		}
+	}
 }
 
 // addSidecarContainers adds the sidecar containers from defaults to the builder.

--- a/internal/pkg/resources/registry.go
+++ b/internal/pkg/resources/registry.go
@@ -25,6 +25,10 @@ func GetDefaults(typeName string) (*InstanceDefaults, error) {
 		return FalcoDefaults, nil
 	case MetacollectorTypeName:
 		return MetacollectorDefaults, nil
+	case FalcosidekickTypeName:
+		return FalcosidekickDefaults, nil
+	case FalcosidekickUITypeName:
+		return FalcosidekickUIDefaults, nil
 	default:
 		return nil, fmt.Errorf("unknown instance type %q", typeName)
 	}

--- a/internal/pkg/resources/registry_test.go
+++ b/internal/pkg/resources/registry_test.go
@@ -41,6 +41,16 @@ func TestGetDefaults(t *testing.T) {
 			wantDefs: MetacollectorDefaults,
 		},
 		{
+			name:     "returns falcosidekick defaults",
+			typeName: FalcosidekickTypeName,
+			wantDefs: FalcosidekickDefaults,
+		},
+		{
+			name:     "returns falcosidekick-ui defaults",
+			typeName: FalcosidekickUITypeName,
+			wantDefs: FalcosidekickUIDefaults,
+		},
+		{
 			name:     "returns error for unknown type",
 			typeName: "unknown",
 			wantErr:  true,

--- a/internal/pkg/resources/sidekick.go
+++ b/internal/pkg/resources/sidekick.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/image"
+)
+
+const (
+	// FalcosidekickTypeName is the type name for the Falcosidekick component.
+	FalcosidekickTypeName = "falcosidekick"
+)
+
+// FalcosidekickDefaults holds the default configuration for the Falcosidekick component.
+var FalcosidekickDefaults = &InstanceDefaults{
+	ResourceType:    ResourceTypeDeployment,
+	Replicas:        new(int32(2)),
+	ContainerName:   "falcosidekick",
+	ImageRepository: image.Registry + "/" + image.Repository + "/" + image.FalcosidekickImage,
+	ImageTag:        image.FalcosidekickTag,
+	ImagePullPolicy: corev1.PullIfNotPresent,
+	DefaultPorts: []corev1.ContainerPort{
+		{ContainerPort: 2801, Name: "http", Protocol: corev1.ProtocolTCP},
+	},
+	LivenessProbe: &corev1.Probe{
+		InitialDelaySeconds: 10,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/ping",
+				Port: intstr.FromString("http"),
+			},
+		},
+	},
+	ReadinessProbe: &corev1.Probe{
+		InitialDelaySeconds: 10,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/ping",
+				Port: intstr.FromString("http"),
+			},
+		},
+	},
+	PodSecurityContext: &corev1.PodSecurityContext{
+		RunAsUser:  new(int64(1234)),
+		RunAsGroup: new(int64(1234)),
+		FSGroup:    new(int64(1234)),
+	},
+	ServicePorts: []corev1.ServicePort{
+		{Name: "http", Protocol: corev1.ProtocolTCP, Port: 2801, TargetPort: intstr.FromString("http")},
+	},
+	// Falcosidekick needs to get endpoints for service discovery.
+	RoleRules: []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"endpoints"},
+			Verbs:     []string{"get"},
+		},
+	},
+	SupportsDaemonSet: false,
+	DeploymentStrategy: &appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+	},
+}

--- a/internal/pkg/resources/sidekick_ui.go
+++ b/internal/pkg/resources/sidekick_ui.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/image"
+)
+
+const (
+	// FalcosidekickUITypeName is the type name for the Falcosidekick UI component.
+	FalcosidekickUITypeName = "falcosidekick-ui"
+
+	// DefaultRedisAddress is the default Redis service address.
+	// Users must provide a Redis instance at this address, or override via podTemplateSpec.
+	DefaultRedisAddress = "falcosidekick-ui-redis:6379"
+)
+
+// FalcosidekickUIDefaults holds the default configuration for the Falcosidekick UI component.
+// NOTE: This component requires an external Redis instance. The default configuration
+// expects Redis at "falcosidekick-ui-redis:6379". If Redis is not available, the
+// wait-redis init container will block and the pod will stay in Init:0/1 state.
+// Users can override the Redis address via podTemplateSpec.
+var FalcosidekickUIDefaults = &InstanceDefaults{
+	ResourceType:    ResourceTypeDeployment,
+	Replicas:        new(int32(2)),
+	ContainerName:   "falcosidekick-ui",
+	ImageRepository: image.Registry + "/" + image.Repository + "/" + image.FalcosidekickUIImage,
+	ImageTag:        image.FalcosidekickUITag,
+	DefaultArgs:     []string{"-r", DefaultRedisAddress},
+	ImagePullPolicy: corev1.PullIfNotPresent,
+	DefaultPorts: []corev1.ContainerPort{
+		{ContainerPort: 2802, Name: "http", Protocol: corev1.ProtocolTCP},
+	},
+	LivenessProbe: &corev1.Probe{
+		InitialDelaySeconds: 10,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/api/v1/healthz",
+				Port: intstr.FromString("http"),
+			},
+		},
+	},
+	ReadinessProbe: &corev1.Probe{
+		InitialDelaySeconds: 10,
+		TimeoutSeconds:      5,
+		PeriodSeconds:       5,
+		FailureThreshold:    3,
+		SuccessThreshold:    1,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/api/v1/healthz",
+				Port: intstr.FromString("http"),
+			},
+		},
+	},
+	PodSecurityContext: &corev1.PodSecurityContext{
+		RunAsUser:  new(int64(1234)),
+		RunAsGroup: new(int64(1234)),
+		FSGroup:    new(int64(1234)),
+	},
+	// Wait-redis init container: blocks until Redis is reachable.
+	// If Redis is not deployed, the pod stays in Init:0/1, signaling the dependency.
+	InitContainers: []corev1.Container{
+		{
+			Name:            "wait-redis",
+			Image:           image.RedisRegistry + "/" + image.RedisRepository + "/" + image.RedisImage + ":" + image.RedisTag,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"sh", "-c"},
+			Args: []string{
+				`until redis-cli -h "$(echo $REDIS_ADDR | cut -d: -f1)" -p "$(echo $REDIS_ADDR | cut -d: -f2)" ping 2>/dev/null | grep -q PONG; do echo "Waiting for Redis at $REDIS_ADDR..."; sleep 3; done; echo "Redis is ready"`,
+			},
+			Env: []corev1.EnvVar{
+				{Name: "REDIS_ADDR", Value: DefaultRedisAddress},
+			},
+		},
+	},
+	ServicePorts: []corev1.ServicePort{
+		{Name: "http", Protocol: corev1.ProtocolTCP, Port: 2802, TargetPort: intstr.FromString("http")},
+	},
+	SupportsDaemonSet: false,
+	DeploymentStrategy: &appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+	},
+}

--- a/internal/pkg/resources/types.go
+++ b/internal/pkg/resources/types.go
@@ -56,6 +56,7 @@ type InstanceDefaults struct {
 	ImagePullPolicy      corev1.PullPolicy
 	DefaultPorts         []corev1.ContainerPort
 	DefaultResources     corev1.ResourceRequirements
+	StartupProbe         *corev1.Probe
 	LivenessProbe        *corev1.Probe
 	ReadinessProbe       *corev1.Probe
 	SecurityContext      *corev1.SecurityContext
@@ -82,6 +83,9 @@ type InstanceDefaults struct {
 
 	// ConfigMapVolume defines how to mount the instance ConfigMap (nil = no ConfigMap volume).
 	ConfigMapVolume *ConfigMapVolumeConfig
+
+	// InitContainers are added as true init containers (run to completion before main).
+	InitContainers []corev1.Container
 
 	// Sidecar containers (nil = no sidecar).
 	SidecarContainers []corev1.Container


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area pkg

/area api

> /area docs

**What this PR does / why we need it**:

Adds two new component types to the Component CRD:

- **`falcosidekick`** — Fan-out daemon for Falco events (70+ output integrations)
- **`falcosidekick-ui`** — Web dashboard for real-time event visualization
  - **Requires external Redis**: a `wait-redis` init container (using `redis/redis-stack:7.2.0-v11`) blocks until Redis is reachable at the default address `falcosidekick-ui-redis:6379`
  - Users can override the Redis address via `podTemplateSpec`
  - If Redis is not available, pods stay in `Init:0/1` state — this is the intended signal

Three sample manifests are included:
- `instance_v1alpha1_component_sidekick.yaml` — Simple sidekick
- `instance_v1alpha1_component_sidekick_ui.yaml` — UI with placeholder for external Redis
- `instance_v1alpha1_component_sidekick_ui_with_redis.yaml` — Complete example with Redis StatefulSet + Service + UI Component

### Infrastructure changes

- Added `InitContainers` field to `InstanceDefaults` for true init containers (run to completion, distinct from native sidecars)
- Added `StartupProbe` field to `InstanceDefaults` and wired it in `forgeMainContainer()`
- Both are handled in the `generateDeployment`/`generateDaemonSet` builders

### Falco defaults alignment with Helm chart

- Added startup probe (initialDelay 3s, period 5s, 20 failures = ~103s max). Liveness/readiness `initialDelaySeconds` reset to 0 (startup probe handles the wait).
Added `/run/containerd/containerd.sock` (vanilla kubeadm) and `/run/host-containerd/containerd.sock` (GKE). Added `host-containerd-socket` volume + mount. Non-existent paths are silently ignored.
- Config alignment: `append_output: [{suggested_output: true}]` (essential for container/k8s metadata in output), `plugins_hostinfo: true`, `json_include_output_fields_property: true`, `falco_libs` auto-purging (300s interval, 300s timeout) and `snaplen: 80`. Applied to both DaemonSet and Deployment configs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
