### PR TITLE
fix: handle SSA strategy mutual exclusivity and suppress terminal validation error requeue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Released on YYYY-MM-DD
 * Added RBAC `patch` verb for artifacts; fixed Kubernetes 1.32+ schema compatibility. [[`7c7962e`](https://github.com/falcosecurity/falco-operator/commit/7c7962e)]
 * Fixed ConfigMap indexer and restored artifact constants. [[`6936c53`](https://github.com/falcosecurity/falco-operator/commit/6936c53)]
 * Added ConfigMap watch permission to artifact operator. [[`ff5217c`](https://github.com/falcosecurity/falco-operator/commit/ff5217c)]
+* Fixed SSA strategy switch to `Recreate`/`OnDelete` failing due to K8s-defaulted `rollingUpdate` not being owned by the field manager.
+* Fixed invalid user input on SSA apply causing `ERROR` stack traces and infinite requeue instead of setting condition and stopping.
 * Fixed diff error handling in controllers. [[`5fce1c9`](https://github.com/falcosecurity/falco-operator/commit/5fce1c9)]
 * Prevented spurious updates via managed fields comparison. [[`49921ce`](https://github.com/falcosecurity/falco-operator/commit/49921ce)]
 * Fixed RBAC permissions for event recording. [[`a31f127`](https://github.com/falcosecurity/falco-operator/commit/a31f127)]

--- a/controllers/instance/component/controller.go
+++ b/controllers/instance/component/controller.go
@@ -260,7 +260,6 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, comp *instancev1alpha
 
 	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner(fieldManager)}
 	if err = r.Apply(ctx, client.ApplyConfigurationFromUnstructured(applyConfig), applyOpts...); err != nil {
-		logger.Error(err, "unable to apply resource", "type", comp.Spec.Component.Type)
 		if !resourceExists {
 			conditionStatus = metav1.ConditionFalse
 			conditionReason = instance.ReasonApplyPatchErrorOnCreate
@@ -274,6 +273,13 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, comp *instancev1alpha
 			r.recorder.Eventf(comp, nil, corev1.EventTypeWarning, instance.ReasonApplyPatchErrorOnUpdate,
 				instance.ReasonApplyPatchErrorOnUpdate, instance.MessageFormatApplyPatchErrorOnUpdate, err.Error())
 		}
+		// Validation errors are terminal — the user must fix the CR spec.
+		// Don't requeue; the next reconciliation will be triggered by the CR update.
+		if k8serrors.IsInvalid(err) {
+			logger.Info("Apply rejected by API server due to invalid input", "type", comp.Spec.Component.Type, "error", err.Error())
+			return nil
+		}
+		logger.Error(err, "unable to apply resource", "type", comp.Spec.Component.Type)
 		return err
 	}
 

--- a/controllers/instance/component/generateApplyConfiguration_test.go
+++ b/controllers/instance/component/generateApplyConfiguration_test.go
@@ -267,6 +267,12 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 			if tt.wantStrategyType != "" {
 				strategyType, _, _ := unstructured.NestedString(result.Object, "spec", "strategy", "type")
 				assert.Equal(t, tt.wantStrategyType, strategyType)
+
+				// Verify mutually exclusive fields: Recreate must NOT have rollingUpdate.
+				if strategyType == string(appsv1.RecreateDeploymentStrategyType) {
+					_, found, _ := unstructured.NestedMap(result.Object, "spec", "strategy", "rollingUpdate")
+					assert.False(t, found, "rollingUpdate must be absent for Recreate strategy so SSA removes it")
+				}
 			}
 		})
 	}

--- a/controllers/instance/falco/controller.go
+++ b/controllers/instance/falco/controller.go
@@ -301,7 +301,6 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, falco *instancev1alph
 
 	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner(fieldManager)}
 	if err = r.Apply(ctx, client.ApplyConfigurationFromUnstructured(applyConfig), applyOpts...); err != nil {
-		logger.Error(err, "unable to apply resource", "kind", falco.Spec.Type)
 		if !resourceExists {
 			conditionStatus = metav1.ConditionFalse
 			conditionReason = instance.ReasonApplyPatchErrorOnCreate
@@ -315,6 +314,13 @@ func (r *Reconciler) ensureDeployment(ctx context.Context, falco *instancev1alph
 			r.recorder.Eventf(falco, nil, corev1.EventTypeWarning, instance.ReasonApplyPatchErrorOnUpdate,
 				instance.ReasonApplyPatchErrorOnUpdate, instance.MessageFormatApplyPatchErrorOnUpdate, err.Error())
 		}
+		// Validation errors are terminal — the user must fix the CR spec.
+		// Don't requeue; the next reconciliation will be triggered by the CR update.
+		if k8serrors.IsInvalid(err) {
+			logger.Info("Apply rejected by API server due to invalid input", "kind", falco.Spec.Type, "error", err.Error())
+			return nil
+		}
+		logger.Error(err, "unable to apply resource", "kind", falco.Spec.Type)
 		return err
 	}
 

--- a/internal/pkg/instance/ensure.go
+++ b/internal/pkg/instance/ensure.go
@@ -211,6 +211,12 @@ func EnsureResource(ctx context.Context, cl client.Client, recorder events.Event
 	if err := cl.Apply(ctx, client.ApplyConfigurationFromUnstructured(desiredResource), applyOpts...); err != nil {
 		recorder.Eventf(owner, nil, corev1.EventTypeWarning, ReasonResourceApplyError,
 			ReasonResourceApplyError, MessageFormatResourceApplyError, resourceType, err.Error())
+		// Validation errors are terminal — the user must fix the CR spec.
+		// Return nil so controller-runtime does not requeue with stack trace spam.
+		if k8serrors.IsInvalid(err) {
+			logger.Info("Apply rejected by API server due to invalid input", "type", resourceType, "name", desiredResource.GetName(), "error", err.Error())
+			return nil
+		}
 		return fmt.Errorf("unable to apply %s: %w", resourceType, err)
 	}
 

--- a/internal/pkg/instance/merge.go
+++ b/internal/pkg/instance/merge.go
@@ -17,11 +17,14 @@
 package instance
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/falcosecurity/falco-operator/internal/pkg/resources"
 	"github.com/falcosecurity/falco-operator/internal/pkg/scheme"
 )
 
@@ -59,5 +62,33 @@ func MergeApplyConfiguration(kind string, baseResource runtime.Object, userOverr
 		Kind:    kind,
 	})
 
+	if err := enforceStrategyConstraints(result); err != nil {
+		return nil, fmt.Errorf("enforcing strategy constraints: %w", err)
+	}
+
 	return result, nil
+}
+
+// enforceStrategyConstraints enforces Kubernetes strategy field
+// constraints on the merged apply configuration.
+func enforceStrategyConstraints(obj *unstructured.Unstructured) error {
+	switch obj.GetKind() {
+	case resources.ResourceTypeDeployment:
+		strategyType, found, err := unstructured.NestedString(obj.Object, "spec", "strategy", "type")
+		if err != nil {
+			return err
+		}
+		if found && strategyType == string(appsv1.RecreateDeploymentStrategyType) {
+			unstructured.RemoveNestedField(obj.Object, "spec", "strategy", "rollingUpdate")
+		}
+	case resources.ResourceTypeDaemonSet:
+		strategyType, found, err := unstructured.NestedString(obj.Object, "spec", "updateStrategy", "type")
+		if err != nil {
+			return err
+		}
+		if found && strategyType == string(appsv1.OnDeleteDaemonSetStrategyType) {
+			unstructured.RemoveNestedField(obj.Object, "spec", "updateStrategy", "rollingUpdate")
+		}
+	}
+	return nil
 }

--- a/internal/pkg/instance/merge_test.go
+++ b/internal/pkg/instance/merge_test.go
@@ -29,6 +29,141 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/resources"
 )
 
+func TestEnforceStrategyConstraints(t *testing.T) {
+	tests := []struct {
+		name                    string
+		obj                     *unstructured.Unstructured
+		wantRollingUpdateAbsent bool
+		strategyPath            []string
+	}{
+		{
+			name: "Deployment Recreate removes rollingUpdate",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDeployment,
+				"spec": map[string]any{
+					"strategy": map[string]any{
+						"type": "Recreate",
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: true,
+			strategyPath:            []string{"spec", "strategy"},
+		},
+		{
+			name: "Deployment Recreate removes existing rollingUpdate",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDeployment,
+				"spec": map[string]any{
+					"strategy": map[string]any{
+						"type": "Recreate",
+						"rollingUpdate": map[string]any{
+							"maxSurge":       "25%",
+							"maxUnavailable": "25%",
+						},
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: true,
+			strategyPath:            []string{"spec", "strategy"},
+		},
+		{
+			name: "Deployment RollingUpdate does not touch rollingUpdate",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDeployment,
+				"spec": map[string]any{
+					"strategy": map[string]any{
+						"type": "RollingUpdate",
+						"rollingUpdate": map[string]any{
+							"maxSurge": "50%",
+						},
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: false,
+			strategyPath:            []string{"spec", "strategy"},
+		},
+		{
+			name: "Deployment without strategy is a no-op",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDeployment,
+				"spec": map[string]any{},
+			}},
+			wantRollingUpdateAbsent: false,
+			strategyPath:            []string{"spec", "strategy"},
+		},
+		{
+			name: "DaemonSet OnDelete sets rollingUpdate to null",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDaemonSet,
+				"spec": map[string]any{
+					"updateStrategy": map[string]any{
+						"type": "OnDelete",
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: true,
+			strategyPath:            []string{"spec", "updateStrategy"},
+		},
+		{
+			name: "DaemonSet OnDelete removes existing rollingUpdate",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDaemonSet,
+				"spec": map[string]any{
+					"updateStrategy": map[string]any{
+						"type": "OnDelete",
+						"rollingUpdate": map[string]any{
+							"maxUnavailable": 1,
+						},
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: true,
+			strategyPath:            []string{"spec", "updateStrategy"},
+		},
+		{
+			name: "DaemonSet RollingUpdate does not touch rollingUpdate",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": resources.ResourceTypeDaemonSet,
+				"spec": map[string]any{
+					"updateStrategy": map[string]any{
+						"type": "RollingUpdate",
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: false,
+			strategyPath:            []string{"spec", "updateStrategy"},
+		},
+		{
+			name: "unknown kind is a no-op",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"kind": "StatefulSet",
+				"spec": map[string]any{
+					"updateStrategy": map[string]any{
+						"type": "OnDelete",
+					},
+				},
+			}},
+			wantRollingUpdateAbsent: false,
+			strategyPath:            []string{"spec", "updateStrategy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enforceStrategyConstraints(tt.obj)
+			require.NoError(t, err)
+
+			path := make([]string, len(tt.strategyPath)+1)
+			copy(path, tt.strategyPath)
+			path[len(path)-1] = "rollingUpdate"
+			_, found, _ := unstructured.NestedFieldNoCopy(tt.obj.Object, path...)
+			if tt.wantRollingUpdateAbsent {
+				assert.False(t, found, "rollingUpdate must be absent so SSA drops ownership and removes it from the live object")
+			}
+		})
+	}
+}
+
 func TestMergeApplyConfiguration(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/internal/pkg/resources/forge.go
+++ b/internal/pkg/resources/forge.go
@@ -96,7 +96,8 @@ func forgeDeploymentStrategy(strategy *appsv1.DeploymentStrategy) appsv1.Deploym
 		return *strategy
 	}
 	return appsv1.DeploymentStrategy{
-		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		Type:          appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{},
 	}
 }
 
@@ -106,6 +107,7 @@ func forgeDaemonSetUpdateStrategy(strategy *appsv1.DaemonSetUpdateStrategy) apps
 		return *strategy
 	}
 	return appsv1.DaemonSetUpdateStrategy{
-		Type: appsv1.RollingUpdateDaemonSetStrategyType,
+		Type:          appsv1.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDaemonSet{},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

/area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

This PR fixes two related issues in the instance controllers (Falco and Component):

1. **SSA strategy mutual exclusivity**: When a user switches Deployment strategy from `RollingUpdate` to `Recreate`, K8s rejects the SSA apply because the K8s-defaulted `rollingUpdate` field is not owned by our field manager and cannot be removed. Fix: the base defaults now include an explicit empty `rollingUpdate` struct so SSA takes ownership on first apply, and `MergeApplyConfiguration` removes `rollingUpdate` from the apply config when `type` is `Recreate` (Deployment) or `OnDelete` (DaemonSet), causing SSA to drop the field from the live object.

2. **Terminal validation error handling**: When K8s rejects an SSA apply due to invalid user input (`IsInvalid`), the controllers were returning the error to controller-runtime, causing `ERROR Reconciler error` with full stack trace and infinite requeue. Since these errors are terminal (only the user can fix them by updating the CR spec), the controllers now log at `INFO` level, set the appropriate status condition and event, and return `nil` to avoid requeue spam.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
