### PR TITLE
fix: include selector labels in pod template labels

### DIFF
--- a/internal/pkg/resources/overlays.go
+++ b/internal/pkg/resources/overlays.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -142,7 +141,7 @@ func GenerateUserOverlay(resourceType, name string, defs *InstanceDefaults, opts
 			dep.Spec.Template = corev1.PodTemplateSpec{}
 		}
 		if cfg.labels != nil {
-			dep.Spec.Template.Labels = labels.Merge(dep.Spec.Template.Labels, cfg.labels)
+			dep.Spec.Template.Labels = forgePodTemplateSpecLabels(name, cfg.labels)
 		}
 		if cfg.strategy != nil {
 			dep.Spec.Strategy = *cfg.strategy
@@ -164,7 +163,7 @@ func GenerateUserOverlay(resourceType, name string, defs *InstanceDefaults, opts
 			ds.Spec.Template = corev1.PodTemplateSpec{}
 		}
 		if cfg.labels != nil {
-			ds.Spec.Template.Labels = labels.Merge(ds.Spec.Template.Labels, cfg.labels)
+			ds.Spec.Template.Labels = forgePodTemplateSpecLabels(name, cfg.labels)
 		}
 		if cfg.updateStrategy != nil {
 			ds.Spec.UpdateStrategy = *cfg.updateStrategy

--- a/internal/pkg/resources/overlays_test.go
+++ b/internal/pkg/resources/overlays_test.go
@@ -97,6 +97,24 @@ func TestGenerateOverlayOptions(t *testing.T) {
 			wantLabels:   map[string]string{"app": "falco"},
 		},
 		{
+			name: "Falco with conflicting selector labels, selector labels take precedence in pod template",
+			obj: builders.NewFalco().
+				WithName("falco-custom").WithNamespace(testNamespace).
+				WithLabels(map[string]string{
+					"app.kubernetes.io/name":     "falco-operator",
+					"app.kubernetes.io/instance": "instance-1",
+				}).
+				Build(),
+			defs:         FalcoDefaults,
+			resourceType: ResourceTypeDaemonSet,
+			// In pod template, selector labels (name, instance) override user labels.
+			// Non-conflicting user labels (managed-by) are preserved.
+			wantLabels: map[string]string{
+				"app.kubernetes.io/name":     "falco-operator",
+				"app.kubernetes.io/instance": "instance-1",
+			},
+		},
+		{
 			name: "Component with defaults only produces labels option",
 			obj: builders.NewComponent().
 				WithComponentType(instancev1alpha1.ComponentTypeMetacollector).
@@ -164,7 +182,7 @@ func TestGenerateOverlayOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := GenerateOverlayOptions(tt.obj)
-			overlay, err := GenerateUserOverlay(tt.resourceType, "test", tt.defs, opts...)
+			overlay, err := GenerateUserOverlay(tt.resourceType, tt.obj.GetName(), tt.defs, opts...)
 			require.NoError(t, err)
 			require.NotNil(t, overlay)
 
@@ -172,10 +190,11 @@ func TestGenerateOverlayOptions(t *testing.T) {
 			for k, v := range tt.wantLabels {
 				assert.Equal(t, v, overlay.GetLabels()[k], "metadata label %s", k)
 			}
+
+			// Assert that pod template labels include the expected labels (selector labels take precedence over user labels).
 			templateLabels, _, _ := unstructured.NestedStringMap(overlay.Object, "spec", "template", "metadata", "labels")
-			for k, v := range tt.wantLabels {
-				assert.Equal(t, v, templateLabels[k], "pod template label %s", k)
-			}
+			assert.Equal(t, tt.obj.GetName(), templateLabels["app.kubernetes.io/instance"], "pod template label app.kubernetes.io/instance should match object name")
+			assert.Equal(t, tt.obj.GetName(), templateLabels["app.kubernetes.io/name"], "pod template label app.kubernetes.io/name should match object name")
 
 			// Replicas.
 			if tt.wantReplicas > 0 {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

Use forgePodTemplateSpecLabels() to ensure pod template labels always contain the required selector labels, fixing the validation error where selector would not match template labels.

> Uncomment one (or more) `/kind <>` lines:

 /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

 /area instance-operator

> /area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
