### PR TITLE
fix: add Role and RoleBinding support to component controller

### DIFF
--- a/controllers/instance/component/controller.go
+++ b/controllers/instance/component/controller.go
@@ -125,14 +125,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Ensure the clusterrole is created.
-	if err := r.ensureClusterRole(ctx, comp, defs); err != nil {
-		return ctrl.Result{}, err
+	// Ensure namespace-scoped RBAC (Role/RoleBinding) if the component defines RoleRules.
+	if len(defs.RoleRules) > 0 {
+		if err := r.ensureRole(ctx, comp, defs); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.ensureRoleBinding(ctx, comp); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
-	// Ensure the clusterrolebinding is created.
-	if err := r.ensureClusterRoleBinding(ctx, comp); err != nil {
-		return ctrl.Result{}, err
+	// Ensure cluster-scoped RBAC (ClusterRole/ClusterRoleBinding) if the component defines ClusterRoleRules.
+	if len(defs.ClusterRoleRules) > 0 {
+		if err := r.ensureClusterRole(ctx, comp, defs); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.ensureClusterRoleBinding(ctx, comp); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Ensure the service is created.
@@ -343,6 +353,20 @@ func (r *Reconciler) handleDeletion(ctx context.Context, comp *instancev1alpha1.
 func (r *Reconciler) ensureServiceAccount(ctx context.Context, comp *instancev1alpha1.Component) error {
 	return instance.EnsureResource(ctx, r.Client, r.recorder, comp, fieldManager,
 		resources.GenerateServiceAccount(comp),
+		instance.GenerateOptions{SetControllerRef: true, IsClusterScoped: false})
+}
+
+// ensureRole ensures the namespace-scoped Role is created or updated.
+func (r *Reconciler) ensureRole(ctx context.Context, comp *instancev1alpha1.Component, defs *resources.InstanceDefaults) error {
+	return instance.EnsureResource(ctx, r.Client, r.recorder, comp, fieldManager,
+		resources.GenerateRole(comp, defs),
+		instance.GenerateOptions{SetControllerRef: true, IsClusterScoped: false})
+}
+
+// ensureRoleBinding ensures the namespace-scoped RoleBinding is created or updated.
+func (r *Reconciler) ensureRoleBinding(ctx context.Context, comp *instancev1alpha1.Component) error {
+	return instance.EnsureResource(ctx, r.Client, r.recorder, comp, fieldManager,
+		resources.GenerateRoleBinding(comp),
 		instance.GenerateOptions{SetControllerRef: true, IsClusterScoped: false})
 }
 

--- a/controllers/instance/component/controller_integration_test.go
+++ b/controllers/instance/component/controller_integration_test.go
@@ -334,6 +334,53 @@ func TestReconcile_StatusInfo(t *testing.T) {
 	assert.Equal(t, resources.MetacollectorDefaults.ResourceType, fetched.Status.ResourceType)
 }
 
+// TestReconcile_FalcosidekickRoleCreation verifies that components with RoleRules
+// get a namespace-scoped Role and RoleBinding, and components without ClusterRoleRules
+// do NOT get an empty ClusterRole.
+func TestReconcile_FalcosidekickRoleCreation(t *testing.T) {
+	ctx := context.Background()
+	comp := createComponent(t, ctx, builders.NewComponent().
+		WithComponentType(instancev1alpha1.ComponentTypeFalcosidekick).
+		WithName("test-sidekick-rbac").WithNamespace(testutil.TestNamespace).Build())
+
+	reconciler := newTestReconciler()
+	reconcileN(t, ctx, reconciler, comp.Name, 5)
+
+	// Verify Role exists with endpoint get permission.
+	role := &rbacv1.Role{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: comp.Name, Namespace: testutil.TestNamespace}, role)
+	require.NoError(t, err, "Role should exist for falcosidekick")
+	require.NotEmpty(t, role.Rules, "Role should have rules")
+	assert.Contains(t, role.Rules[0].Resources, "endpoints", "Role should grant access to endpoints")
+	assert.Contains(t, role.Rules[0].Verbs, "get", "Role should grant get verb")
+
+	// Verify RoleBinding exists.
+	rb := &rbacv1.RoleBinding{}
+	err = k8sClient.Get(ctx, types.NamespacedName{Name: comp.Name, Namespace: testutil.TestNamespace}, rb)
+	require.NoError(t, err, "RoleBinding should exist for falcosidekick")
+	require.Len(t, rb.Subjects, 1)
+	assert.Equal(t, comp.Name, rb.Subjects[0].Name)
+
+	// Verify ClusterRole does NOT exist (falcosidekick has no ClusterRoleRules).
+	uniqueName := resources.GenerateUniqueName(comp.Name, testutil.TestNamespace)
+	cr := &rbacv1.ClusterRole{}
+	err = k8sClient.Get(ctx, types.NamespacedName{Name: uniqueName}, cr)
+	assert.True(t, errors.IsNotFound(err), "ClusterRole should NOT exist for falcosidekick (no ClusterRoleRules)")
+
+	// Verify Service exists with port 2801.
+	svc := &corev1.Service{}
+	err = k8sClient.Get(ctx, types.NamespacedName{Name: comp.Name, Namespace: testutil.TestNamespace}, svc)
+	require.NoError(t, err)
+	require.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(2801), svc.Spec.Ports[0].Port)
+
+	// Verify Deployment.
+	dep := &appsv1.Deployment{}
+	err = k8sClient.Get(ctx, types.NamespacedName{Name: comp.Name, Namespace: testutil.TestNamespace}, dep)
+	require.NoError(t, err)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Image, image.FalcosidekickImage)
+}
+
 // TestReconcile_RecoveryAfterSubResourceDeletion verifies that the controller
 // recreates a sub-resource (ServiceAccount) that was deleted externally.
 func TestReconcile_RecoveryAfterSubResourceDeletion(t *testing.T) {

--- a/controllers/instance/component/controller_unit_test.go
+++ b/controllers/instance/component/controller_unit_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
@@ -49,6 +50,118 @@ func newMetacollectorComponent(name string) *builders.ComponentBuilder {
 	return builders.NewComponent().
 		WithComponentType(instancev1alpha1.ComponentTypeMetacollector).
 		WithName(name).WithNamespace(testutil.TestNamespace)
+}
+
+func newFalcosidekickComponent(name string) *builders.ComponentBuilder {
+	return builders.NewComponent().
+		WithComponentType(instancev1alpha1.ComponentTypeFalcosidekick).
+		WithName(name).WithNamespace(testutil.TestNamespace)
+}
+
+func TestReconcile_RBACConditionalCreation(t *testing.T) {
+	scheme := testutil.Scheme(t, instancev1alpha1.AddToScheme)
+
+	tests := []struct {
+		name                  string
+		comp                  *instancev1alpha1.Component
+		wantRoleExists        bool
+		wantRoleBindingExists bool
+		wantClusterRoleExists bool
+		wantClusterRBExists   bool
+		wantRoleRules         int
+		wantClusterRoleRules  int
+		wantErr               bool
+		wantErrMsg            string
+	}{
+		{
+			name:                  "metacollector gets ClusterRole but no Role",
+			comp:                  newMetacollectorComponent("test-mc-rbac").Build(),
+			wantRoleExists:        false,
+			wantRoleBindingExists: false,
+			wantClusterRoleExists: true,
+			wantClusterRBExists:   true,
+			wantClusterRoleRules:  3,
+		},
+		{
+			name:                  "falcosidekick gets Role but no ClusterRole",
+			comp:                  newFalcosidekickComponent("test-sk-rbac").Build(),
+			wantRoleExists:        true,
+			wantRoleBindingExists: true,
+			wantClusterRoleExists: false,
+			wantClusterRBExists:   false,
+			wantRoleRules:         1,
+		},
+		{
+			name: "unknown component type returns error",
+			comp: func() *instancev1alpha1.Component {
+				c := newMetacollectorComponent("test-unknown").Build()
+				c.Spec.Component.Type = "nonexistent"
+				return c
+			}(),
+			wantErr:    true,
+			wantErrMsg: "unknown instance type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(tt.comp).WithStatusSubresource(tt.comp).Build()
+			r := NewReconciler(cl, scheme, events.NewFakeRecorder(10))
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(tt.comp),
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify Role.
+			role := &rbacv1.Role{}
+			roleErr := cl.Get(context.Background(), client.ObjectKeyFromObject(tt.comp), role)
+			if tt.wantRoleExists {
+				require.NoError(t, roleErr, "Role should exist")
+				assert.Len(t, role.Rules, tt.wantRoleRules)
+			} else {
+				assert.Error(t, roleErr, "Role should NOT exist")
+			}
+
+			// Verify RoleBinding.
+			rb := &rbacv1.RoleBinding{}
+			rbErr := cl.Get(context.Background(), client.ObjectKeyFromObject(tt.comp), rb)
+			if tt.wantRoleBindingExists {
+				require.NoError(t, rbErr, "RoleBinding should exist")
+				require.Len(t, rb.Subjects, 1)
+				assert.Equal(t, tt.comp.Name, rb.Subjects[0].Name)
+			} else {
+				assert.Error(t, rbErr, "RoleBinding should NOT exist")
+			}
+
+			// Verify ClusterRole.
+			uniqueName := resources.GenerateUniqueName(tt.comp.Name, testutil.TestNamespace)
+			cr := &rbacv1.ClusterRole{}
+			crErr := cl.Get(context.Background(), client.ObjectKey{Name: uniqueName}, cr)
+			if tt.wantClusterRoleExists {
+				require.NoError(t, crErr, "ClusterRole should exist")
+				assert.Len(t, cr.Rules, tt.wantClusterRoleRules)
+			} else {
+				assert.Error(t, crErr, "ClusterRole should NOT exist")
+			}
+
+			// Verify ClusterRoleBinding.
+			crb := &rbacv1.ClusterRoleBinding{}
+			crbErr := cl.Get(context.Background(), client.ObjectKey{Name: uniqueName}, crb)
+			if tt.wantClusterRBExists {
+				require.NoError(t, crbErr, "ClusterRoleBinding should exist")
+			} else {
+				assert.Error(t, crbErr, "ClusterRoleBinding should NOT exist")
+			}
+		})
+	}
 }
 
 func TestEnsureResourceErrors(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

The component controller only created ClusterRole/ClusterRoleBinding but never
namespace-scoped Role/RoleBinding. Components defining RoleRules (e.g.,
falcosidekick with "get" on "endpoints") had their namespace-scoped permissions
silently dropped.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
