### PR TITLE
fix: align goreleaser ldflags and bump default Falco version to 0.43.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       -X github.com/falcosecurity/falco-operator/internal/pkg/version.BuildDate={{ .Date }}
       -X github.com/falcosecurity/falco-operator/internal/pkg/version.GitCommit={{ .Commit }}
       -X github.com/falcosecurity/falco-operator/internal/pkg/version.SemVersion={{ if .IsSnapshot }}{{ .Commit }}{{ else }}{{ .Version }}{{ end }}
+      -X github.com/falcosecurity/falco-operator/internal/pkg/version.ArtifactOperatorImage=docker.io/falcosecurity/artifact-operator:{{ if .IsSnapshot }}latest{{ else }}v{{ .Version }}{{ end }}
       -s
       -w
     main: ./cmd/instance/main.go

--- a/config/samples/instance_v1alpha1_component.yaml
+++ b/config/samples/instance_v1alpha1_component.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   component:
     type: metacollector
-    version: "0.1.1"
+    version: "0.1.2"
   replicas: 1
   # podTemplateSpec: {}
   # strategy:

--- a/controllers/instance/falco/controller_unit_test.go
+++ b/controllers/instance/falco/controller_unit_test.go
@@ -532,7 +532,7 @@ func TestEnsureDeployment(t *testing.T) {
 		wantKind            string
 	}{
 		{
-			name: "creates Deployment with default values",
+			name: "creates Deployment with default values and default Falco version",
 			falco: builders.NewFalco().WithName("test").WithNamespace(testutil.TestNamespace).
 				WithType(resources.ResourceTypeDeployment).Build(),
 			wantConditionStatus: metav1.ConditionTrue,
@@ -600,12 +600,16 @@ func TestEnsureDeployment(t *testing.T) {
 				dep := &appsv1.Deployment{}
 				require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(tt.falco), dep))
 				require.NotEmpty(t, dep.Spec.Template.Spec.Containers)
-				version := ""
+				actualImage := dep.Spec.Template.Spec.Containers[0].Image
 				if tt.falco.Spec.Version != nil {
-					version = *tt.falco.Spec.Version
+					wantImage := image.BuildFalcoImageStringFromVersion(*tt.falco.Spec.Version)
+					assert.Equal(t, wantImage, actualImage)
+				} else {
+					// When no version is specified, the controller must use the default from FalcoDefaults.
+					wantImage := image.BuildImageString(image.Registry, image.Repository, image.FalcoImage, resources.FalcoDefaults.ImageTag)
+					assert.Equal(t, wantImage, actualImage,
+						"default Falco image must use FalcoDefaults.ImageTag when spec.version is nil")
 				}
-				wantImage := image.BuildFalcoImageStringFromVersion(version)
-				assert.Equal(t, wantImage, dep.Spec.Template.Spec.Containers[0].Image)
 				require.Len(t, dep.GetOwnerReferences(), 1)
 				assert.Equal(t, tt.falco.Name, dep.GetOwnerReferences()[0].Name)
 			default:

--- a/internal/pkg/image/const.go
+++ b/internal/pkg/image/const.go
@@ -25,7 +25,7 @@ const (
 	// FalcoImage the default image name used for Falco.
 	FalcoImage = "falco"
 	// FalcoTag the default tag used for Falco.
-	FalcoTag = "0.41.0"
+	FalcoTag = "0.43.0"
 
 	// MetacollectorImage the default image name used for k8s-metacollector.
 	MetacollectorImage = "k8s-metacollector"

--- a/internal/pkg/image/const.go
+++ b/internal/pkg/image/const.go
@@ -30,7 +30,7 @@ const (
 	// MetacollectorImage the default image name used for k8s-metacollector.
 	MetacollectorImage = "k8s-metacollector"
 	// MetacollectorTag the default tag used for k8s-metacollector.
-	MetacollectorTag = "0.1.1"
+	MetacollectorTag = "0.1.2"
 
 	// FalcosidekickImage the default image name used for Falcosidekick.
 	FalcosidekickImage = "falcosidekick"

--- a/internal/pkg/image/image_test.go
+++ b/internal/pkg/image/image_test.go
@@ -132,13 +132,13 @@ func TestVersionFromTag(t *testing.T) {
 	}{
 		{
 			name: "simple version",
-			tag:  "0.41.0",
-			want: "0.41.0",
+			tag:  "0.43.0",
+			want: "0.43.0",
 		},
 		{
 			name: "version with suffix",
-			tag:  "0.41.0-rc1",
-			want: "0.41.0",
+			tag:  "0.43.0-rc1",
+			want: "0.43.0",
 		},
 		{
 			name: "FalcoTag",

--- a/internal/pkg/instance/version_test.go
+++ b/internal/pkg/instance/version_test.go
@@ -172,7 +172,7 @@ func TestResolveVersion(t *testing.T) {
 			name: "empty containers slice falls back to spec.version",
 			obj: &instancev1alpha1.Falco{
 				Spec: instancev1alpha1.FalcoSpec{
-					Version: new("0.41.0"),
+					Version: new("0.43.0"),
 					PodTemplateSpec: &corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{},
@@ -181,7 +181,7 @@ func TestResolveVersion(t *testing.T) {
 				},
 			},
 			defs: resources.FalcoDefaults,
-			want: "0.41.0",
+			want: "0.43.0",
 		},
 		{
 			name: "empty containers slice and nil version falls back to default",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

Two build/config fixes and test improvements found:

1. **goreleaser missing ArtifactOperatorImage ldflag**: The Makefile and CI
   workflow inject `-X version.ArtifactOperatorImage=...` but `.goreleaser.yml`
   did not. Goreleaser-built release binaries would embed the hardcoded default
   instead of the release-specific tagged image.

2. **FalcoTag stale at 0.41.0**: Default Falco image tag was `0.41.0` but the
   current latest version is `0.43.0`. CRs omitting `version` would deploy an outdated Falco.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
