### PR TITLE
chore(api): fix omitempty, optional markers, and doc comments

### DIFF
--- a/api/artifact/v1alpha1/plugin_types.go
+++ b/api/artifact/v1alpha1/plugin_types.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package controller defines controllers' logic.
+// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
 
 package v1alpha1
 

--- a/api/artifact/v1alpha1/rulesfile_types.go
+++ b/api/artifact/v1alpha1/rulesfile_types.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package controller defines controllers' logic.
+// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
 
 package v1alpha1
 
@@ -33,7 +33,7 @@ type RulesfileSpec struct {
 	InlineRules *apiextensionsv1.JSON `json:"inlineRules,omitempty"`
 	// ConfigMapRef specifies a reference to a ConfigMap containing the rules.
 	ConfigMapRef *commonv1alpha1.ConfigMapRef `json:"configMapRef,omitempty"`
-	// Priority specifies the priority of the rulesfile.\
+	// Priority specifies the priority of the rulesfile.
 	// The higher the value, the higher the priority.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=99

--- a/api/common/v1alpha1/types.go
+++ b/api/common/v1alpha1/types.go
@@ -26,7 +26,7 @@ const (
 	// service.
 	// The possible status values for this condition type are:
 	// - True: all pods are running and ready, the service is fully available.
-	// - Degraded: some pods aren't ready, the service is partially available.
+	// - False (reason: Degraded): some pods aren't ready, the service is partially available.
 	// - False: no pods are running, the service is totally unavailable.
 	// - Unknown: the operator couldn't determine the condition status.
 	ConditionAvailable ConditionType = "Available"
@@ -76,6 +76,7 @@ type OCIArtifact struct {
 	Image ImageSpec `json:"image"`
 
 	// Registry contains inline registry configuration for authentication, TLS, and hostname.
+	// +optional
 	Registry *RegistryConfig `json:"registry,omitempty"`
 }
 
@@ -111,6 +112,7 @@ type TLSConfig struct {
 // +kubebuilder:object:generate=true
 type RegistryAuth struct {
 	// SecretRef references a Secret containing registry credentials.
+	// +optional
 	SecretRef *SecretRef `json:"secretRef,omitempty"`
 }
 
@@ -119,17 +121,21 @@ type RegistryAuth struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.plainHTTP) && self.plainHTTP && has(self.tls))",message="plainHTTP and tls are mutually exclusive"
 type RegistryConfig struct {
 	// Name is the registry hostname (e.g. "ghcr.io").
+	// +optional
 	Name string `json:"name,omitempty"`
 
 	// Auth contains authentication configuration.
+	// +optional
 	Auth *RegistryAuth `json:"auth,omitempty"`
 
 	// PlainHTTP allows connections to registries over plain HTTP (no TLS).
 	// Mutually exclusive with tls.
+	// +optional
 	PlainHTTP *bool `json:"plainHTTP,omitempty"`
 
 	// TLS contains TLS transport configuration.
 	// Mutually exclusive with plainHTTP.
+	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
 }
 

--- a/api/instance/v1alpha1/component_types.go
+++ b/api/instance/v1alpha1/component_types.go
@@ -81,7 +81,7 @@ type ComponentStatus struct {
 	DesiredReplicas int32 `json:"desiredReplicas,omitempty" protobuf:"varint,1,opt,name=desiredReplicas"`
 	// Total number of available pods (ready for at least minReadySeconds) targeted by the deployment.
 	// +optional
-	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,2,opt,name=availableReplicas"`
+	AvailableReplicas int32 `json:"availableReplicas,omitempty" protobuf:"varint,2,opt,name=availableReplicas"`
 	// Total number of unavailable pods targeted by the deployment.
 	// +optional
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,3,opt,name=unavailableReplicas"`

--- a/api/instance/v1alpha1/falco_types.go
+++ b/api/instance/v1alpha1/falco_types.go
@@ -82,7 +82,7 @@ type FalcoStatus struct {
 	// Or the number of nodes that should be running the  daemon pod and have one or more of the daemon pod running and
 	// available (ready for at least spec.minReadySeconds)
 	// +optional
-	AvailableReplicas int32 `json:"availableReplicas" protobuf:"varint,11,opt,name=availableReplicas"`
+	AvailableReplicas int32 `json:"availableReplicas,omitempty" protobuf:"varint,11,opt,name=availableReplicas"`
 
 	// Total number of unavailable pods targeted by falco deployment/daemonset. This is the total number of
 	// pods that are still required for the deployment to have 100% available capacity or the number of nodes

--- a/config/crd/bases/artifact.falcosecurity.dev_rulesfiles.yaml
+++ b/config/crd/bases/artifact.falcosecurity.dev_rulesfiles.yaml
@@ -128,7 +128,7 @@ spec:
               priority:
                 default: 50
                 description: |-
-                  Priority specifies the priority of the rulesfile.\
+                  Priority specifies the priority of the rulesfile.
                   The higher the value, the higher the priority.
                 format: int32
                 maximum: 99


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area pkg

/area api

> /area docs

**What this PR does / why we need it**:

API type cleanup:

- Add missing `omitempty` on `AvailableReplicas` in FalcoStatus and ComponentStatus (inconsistent with sibling fields)
- Add `+optional` markers on 6 fields in common types (convention compliance)
- Fix stray backslash in rulesfile Priority doc (leaked into CRD description)
- Fix package doc comments ("Package controller" -> "Package v1alpha1")
- Clarify ConditionAvailable doc re: Degraded as Reason not Status

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
