### PR TITLE
test: add ecosystem component coverage and selector label conflict test

### DIFF
--- a/controllers/instance/component/generateApplyConfiguration_test.go
+++ b/controllers/instance/component/generateApplyConfiguration_test.go
@@ -28,10 +28,27 @@ import (
 
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/builders"
 	"github.com/falcosecurity/falco-operator/internal/pkg/resources"
 )
 
-var mcDefs = resources.MetacollectorDefaults
+var (
+	mcDefs = resources.MetacollectorDefaults
+	skDefs = resources.FalcosidekickDefaults
+	uiDefs = resources.FalcosidekickUIDefaults
+)
+
+func newSidekickComponent(name string) *builders.ComponentBuilder {
+	return builders.NewComponent().
+		WithComponentType(instancev1alpha1.ComponentTypeFalcosidekick).
+		WithName(name).WithNamespace(testutil.TestNamespace)
+}
+
+func newSidekickUIComponent(name string) *builders.ComponentBuilder {
+	return builders.NewComponent().
+		WithComponentType(instancev1alpha1.ComponentTypeFalcosidekickUI).
+		WithName(name).WithNamespace(testutil.TestNamespace)
+}
 
 // mustGetContainers extracts the containers list from an unstructured workload.
 func mustGetContainers(t *testing.T, obj *unstructured.Unstructured) []any {
@@ -59,7 +76,9 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 	tests := []struct {
 		name                string
 		comp                *instancev1alpha1.Component
+		defs                *resources.InstanceDefaults
 		wantContainerCount  int
+		wantInitContainers  int
 		wantMainImage       string
 		wantTolerationCount int
 		wantPodLabels       map[string]string
@@ -70,6 +89,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 	}{
 		{
 			name:                "default metacollector produces expected base",
+			defs:                mcDefs,
 			comp:                newMetacollectorComponent("test-mc").Build(),
 			wantContainerCount:  1,
 			wantMainImage:       mcDefs.ImageRepository + ":" + mcDefs.ImageTag,
@@ -84,6 +104,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name:                "custom version overrides container image",
+			defs:                mcDefs,
 			comp:                newMetacollectorComponent("test-mc").WithVersion("0.2.0").Build(),
 			wantContainerCount:  1,
 			wantMainImage:       fmt.Sprintf("%s:%s", mcDefs.ImageRepository, "0.2.0"),
@@ -98,6 +119,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name:                "custom replicas are propagated",
+			defs:                mcDefs,
 			comp:                newMetacollectorComponent("test-mc").WithReplicas(5).Build(),
 			wantContainerCount:  1,
 			wantMainImage:       mcDefs.ImageRepository + ":" + mcDefs.ImageTag,
@@ -112,6 +134,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name: "Recreate strategy overrides default RollingUpdate",
+			defs: mcDefs,
 			comp: newMetacollectorComponent("test-mc").
 				WithStrategy(appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}).Build(),
 			wantContainerCount:  1,
@@ -127,6 +150,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name: "CR labels propagate to pod template",
+			defs: mcDefs,
 			comp: newMetacollectorComponent("test-mc").
 				WithLabels(map[string]string{"team": "security", "env": "prod"}).Build(),
 			wantContainerCount:  1,
@@ -144,6 +168,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name: "custom PodTemplateSpec merges with base preserving probes",
+			defs: mcDefs,
 			comp: newMetacollectorComponent("test-mc").
 				WithImage(mcDefs.ContainerName, "custom-repo/metacollector:custom").Build(),
 			wantContainerCount:  1,
@@ -159,6 +184,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name: "version is ignored when PodTemplateSpec provides main container",
+			defs: mcDefs,
 			comp: newMetacollectorComponent("test-mc").
 				WithVersion("0.2.0").
 				WithImage(mcDefs.ContainerName, "custom-repo/metacollector:custom").Build(),
@@ -175,6 +201,7 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 		},
 		{
 			name: "version applies when PodTemplateSpec has only pod-level fields",
+			defs: mcDefs,
 			comp: newMetacollectorComponent("test-mc").
 				WithVersion("0.2.0").
 				WithPodTemplateSpec(&corev1.PodTemplateSpec{
@@ -193,11 +220,38 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 			wantStrategyType:   string(appsv1.RollingUpdateDeploymentStrategyType),
 			wantVolumeMinCount: 0,
 		},
+		{
+			name:               "default falcosidekick produces expected base",
+			defs:               skDefs,
+			comp:               newSidekickComponent("test-sk").Build(),
+			wantContainerCount: 1,
+			wantMainImage:      skDefs.ImageRepository + ":" + skDefs.ImageTag,
+			wantPodLabels: map[string]string{
+				"app.kubernetes.io/name":     "test-sk",
+				"app.kubernetes.io/instance": "test-sk",
+			},
+			wantReplicas:     2,
+			wantStrategyType: string(appsv1.RollingUpdateDeploymentStrategyType),
+		},
+		{
+			name:               "falcosidekick-ui has wait-redis init container",
+			defs:               uiDefs,
+			comp:               newSidekickUIComponent("test-ui").Build(),
+			wantContainerCount: 1,
+			wantInitContainers: 1,
+			wantMainImage:      uiDefs.ImageRepository + ":" + uiDefs.ImageTag,
+			wantPodLabels: map[string]string{
+				"app.kubernetes.io/name":     "test-ui",
+				"app.kubernetes.io/instance": "test-ui",
+			},
+			wantReplicas:     2,
+			wantStrategyType: string(appsv1.RollingUpdateDeploymentStrategyType),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := generateApplyConfiguration(tt.comp, mcDefs)
+			result, err := generateApplyConfiguration(tt.comp, tt.defs)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -222,19 +276,27 @@ func TestGenerateApplyConfiguration(t *testing.T) {
 			// Containers.
 			containers := mustGetContainers(t, result)
 			assert.Len(t, containers, tt.wantContainerCount)
-			mainContainer := mustFindContainer(t, containers, mcDefs.ContainerName)
+			mainContainer := mustFindContainer(t, containers, tt.defs.ContainerName)
 			assert.Equal(t, tt.wantMainImage, mainContainer["image"])
+
+			// Init containers.
+			if tt.wantInitContainers > 0 {
+				initContainers, _, _ := unstructured.NestedSlice(result.Object, "spec", "template", "spec", "initContainers")
+				assert.Len(t, initContainers, tt.wantInitContainers)
+			}
 
 			// Probes survive merge.
 			assert.NotNil(t, mainContainer["livenessProbe"], "livenessProbe should survive merge")
 			assert.NotNil(t, mainContainer["readinessProbe"], "readinessProbe should survive merge")
 
-			// SecurityContext survives merge.
-			assert.NotNil(t, mainContainer["securityContext"], "securityContext should survive merge")
+			// SecurityContext survives merge (only when defaults define it).
+			if tt.defs.SecurityContext != nil {
+				assert.NotNil(t, mainContainer["securityContext"], "securityContext should survive merge")
+			}
 
 			// Ports survive merge.
 			ports, _, _ := unstructured.NestedSlice(mainContainer, "ports")
-			assert.Len(t, ports, len(mcDefs.DefaultPorts))
+			assert.Len(t, ports, len(tt.defs.DefaultPorts))
 
 			// Resources survive merge.
 			assert.NotNil(t, mainContainer["resources"], "resources should survive merge")

--- a/internal/pkg/resources/forge_test.go
+++ b/internal/pkg/resources/forge_test.go
@@ -403,6 +403,20 @@ func TestForgePodTemplateSpecLabels(t *testing.T) {
 				"team":                       "security",
 			},
 		},
+		{
+			name:    "selector labels override conflicting user labels",
+			appName: "my-falco",
+			baseLabels: map[string]string{
+				"app.kubernetes.io/name":     "wrong-value",
+				"app.kubernetes.io/instance": "also-wrong",
+				"custom-label":               "preserved",
+			},
+			wantKeys: map[string]string{
+				"app.kubernetes.io/name":     "my-falco",
+				"app.kubernetes.io/instance": "my-falco",
+				"custom-label":               "preserved",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/resources/generator_test.go
+++ b/internal/pkg/resources/generator_test.go
@@ -68,6 +68,16 @@ func TestGenerateService(t *testing.T) {
 			defs:          MetacollectorDefaults,
 			wantPortCount: 3,
 		},
+		{
+			name:          "falcosidekick service has 1 port on 2801",
+			defs:          FalcosidekickDefaults,
+			wantPortCount: 1,
+		},
+		{
+			name:          "falcosidekick-ui service has 1 port on 2802",
+			defs:          FalcosidekickUIDefaults,
+			wantPortCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +124,16 @@ func TestGenerateClusterRole(t *testing.T) {
 			name:          "metacollector cluster role has 3 rules",
 			defs:          MetacollectorDefaults,
 			wantRuleCount: 3,
+		},
+		{
+			name:          "falcosidekick cluster role has 0 rules",
+			defs:          FalcosidekickDefaults,
+			wantRuleCount: 0,
+		},
+		{
+			name:          "falcosidekick-ui cluster role has 0 rules",
+			defs:          FalcosidekickUIDefaults,
+			wantRuleCount: 0,
 		},
 	}
 
@@ -166,6 +186,16 @@ func TestGenerateRole(t *testing.T) {
 		{
 			name:          "metacollector role has no rules",
 			defs:          MetacollectorDefaults,
+			wantRuleCount: 0,
+		},
+		{
+			name:          "falcosidekick role has 1 rule for endpoints",
+			defs:          FalcosidekickDefaults,
+			wantRuleCount: 1,
+		},
+		{
+			name:          "falcosidekick-ui role has no rules",
+			defs:          FalcosidekickUIDefaults,
 			wantRuleCount: 0,
 		},
 	}

--- a/internal/pkg/resources/overlays_test.go
+++ b/internal/pkg/resources/overlays_test.go
@@ -159,6 +159,30 @@ func TestGenerateOverlayOptions(t *testing.T) {
 			wantLabels:   map[string]string{"app": "metacollector"},
 		},
 		{
+			name: "Falcosidekick component with defaults",
+			obj: builders.NewComponent().
+				WithComponentType(instancev1alpha1.ComponentTypeFalcosidekick).
+				WithName("test-sk").WithNamespace(testNamespace).
+				WithLabels(map[string]string{"app": "sidekick"}).
+				Build(),
+			defs:         FalcosidekickDefaults,
+			resourceType: ResourceTypeDeployment,
+			wantLabels:   map[string]string{"app": "sidekick"},
+		},
+		{
+			name: "Falcosidekick-UI component with custom replicas",
+			obj: builders.NewComponent().
+				WithComponentType(instancev1alpha1.ComponentTypeFalcosidekickUI).
+				WithName("test-ui").WithNamespace(testNamespace).
+				WithLabels(map[string]string{"app": "sidekick-ui"}).
+				WithReplicas(3).
+				Build(),
+			defs:         FalcosidekickUIDefaults,
+			resourceType: ResourceTypeDeployment,
+			wantLabels:   map[string]string{"app": "sidekick-ui"},
+			wantReplicas: 3,
+		},
+		{
 			name: "unknown object type produces only labels option",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

/area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

Adds missing test coverage for falcosidekick and falcosidekick-ui component types across 4 test files, and adds a selector label conflict test that verifies the forgePodTemplateSpecLabels contract:
- Generator tests only covered Falco and Metacollector for Service, Role, and ClusterRole generation
- Overlay tests had zero coverage for sidekick component types
- generateApplyConfiguration tests were hardcoded to metacollector only
- No test verified that selector labels win over conflicting user labels in forgePodTemplateSpecLabels

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
