### PR TITLE
feat(chart): add extraObjects with tpl support

### DIFF
--- a/chart/falco-operator/templates/extra-objects.yaml
+++ b/chart/falco-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -107,3 +107,15 @@ affinity: {}
 
 # -- Priority class name
 priorityClassName: ""
+
+# -- Array of extra Kubernetes manifests to deploy alongside the operator. Each
+# entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`)
+# is supported within values.
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: '{{ include "falco-operator.fullname" . }}-extra'
+  #     namespace: '{{ .Release.Namespace }}'
+  #   data:
+  #     example: "value"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

(There is no `/area chart` label in the PR template — this PR only touches `chart/falco-operator/`. Happy to relabel if maintainers prefer.)

**What this PR does / why we need it**:

Adds an `extraObjects` value to the `falco-operator` chart, letting users deploy arbitrary Kubernetes manifests alongside the operator without forking the chart.

Each entry is rendered through `tpl`, so Helm templating works inside values — for example:

```yaml
extraObjects:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: '{{ include "falco-operator.fullname" . }}-extra'
      namespace: '{{ .Release.Namespace }}'
    data:
      example: "value"
```

This is the same pattern used by widely-deployed charts (e.g. external-secrets, kube-prometheus-stack) and is useful for shipping companion resources such as ConfigMaps, NetworkPolicies, or PrometheusRules tied to the operator release.

Implementation:
- `chart/falco-operator/values.yaml`: adds `extraObjects: []` with a documented example.
- `chart/falco-operator/templates/extra-objects.yaml`: renders each entry via `tpl (toYaml .) $`.

Verified with `helm lint` and `helm template` (rendering with `{{ include "falco-operator.fullname" . }}`, `{{ .Release.Name }}`, `{{ .Release.Namespace }}` resolved correctly; empty default produces no extra resources).

Note on chart version: I did not bump `Chart.yaml` since prior chart PRs in this repo have not bumped it and there is no documented version-bump policy. Happy to bump to `0.2.0` if maintainers prefer.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

First-time contribution to falcosecurity/falco-operator. Commits are GPG-signed and DCO signed-off.