### PR TITLE
feat(chart): add resizePolicy support for manager container

### DIFF
--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the falco-operator char
 | rbac.create | bool | `true` | Specifies whether RBAC resources should be created |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"health"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe configuration |
 | replicaCount | int | `1` | Number of replicas for the operator |
+| resizePolicy | list | `[]` | In-place pod resize policy for the manager container |
 | resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container security context |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -64,6 +64,13 @@ resources:
     cpu: 10m
     memory: 64Mi
 
+# -- In-place pod resize policy for the manager container
+resizePolicy: []
+  # - resourceName: cpu
+  #   restartPolicy: NotRequired
+  # - resourceName: memory
+  #   restartPolicy: RestartContainer
+
 # -- Liveness probe configuration
 livenessProbe:
   httpGet:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

Adds container-level `resizePolicy` to the chart's manager Deployment so users on clusters with `InPlacePodVerticalScaling` enabled can resize CPU/memory in place. Defaults to `[]`, which omits the field entirely — no behavior change for existing deployments.

```yaml
resizePolicy:
  - resourceName: cpu
    restartPolicy: NotRequired
  - resourceName: memory
    restartPolicy: RestartContainer
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- `helm lint` passes; default render omits the field.
- README regenerated via `make chart-docs`.

```release-note
chart: add `resizePolicy` value to configure in-place pod resize for the manager container
```