### PR TITLE
fix(chart): strip v prefix from appVersion in image tag

### DIFF
--- a/chart/falco-operator/Chart.yaml
+++ b/chart/falco-operator/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
     email: cncf-falco-dev@lists.cncf.io
 type: application
 version: 0.1.0
-appVersion: "v0.2.1"
+appVersion: "0.2.1"


### PR DESCRIPTION
## Summary

- Adds `| trimPrefix "v"` to the image tag template in `deployment.yaml` so the rendered tag matches Docker Hub (e.g. `0.2.1` instead of `v0.2.1`)
- The Docker image workflow uses `docker/metadata-action` with `type=semver,pattern={{ version }}`, which strips the `v` prefix from git tags before pushing to Docker Hub. The Helm chart's `appVersion` follows the git tag convention (`v0.2.1`), so the template must strip the prefix at render time.
- Users no longer hit `ImagePullBackOff` on a fresh `helm install`

Fixes #318

## Test plan

- [ ] `helm template falco-operator chart/falco-operator` renders `falcosecurity/falco-operator:0.2.1` (no `v` prefix)
- [ ] Setting `image.tag` explicitly (e.g. `--set image.tag=custom`) still works and is not affected by `trimPrefix`
- [ ] Setting `image.digest` bypasses the tag path entirely (existing behavior, unchanged)