### PR TITLE
feat(chart): add topologySpreadConstraints support

### DIFF
--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -76,5 +76,6 @@ The following table lists the configurable parameters of the falco-operator char
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
 | tolerations | list | `[]` | Tolerations |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints |
 | volumeMounts | list | `[]` | Additional volume mounts |
 | volumes | list | `[]` | Additional volumes |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -112,6 +112,15 @@ tolerations: []
 # -- Affinity rules
 affinity: {}
 
+# -- Topology spread constraints
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: falco-operator
+
 # -- Priority class name
 priorityClassName: ""
 


### PR DESCRIPTION
<!-- PR template per .github/PULL_REQUEST_TEMPLATE.md -->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

Adds support for [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) on the operator Deployment, complementing the existing `nodeSelector`, `affinity`, and `tolerations` knobs.

Spreading pods across failure domains (e.g. [zones](https://kubernetes.io/docs/setup/best-practices/multiple-zones/), nodes) is a standard requirement for high-availability operator deployments. Today users have to render the Deployment via `extraObjects` or post-process it just to set this field — it should be a first-class chart value.

Changes:

- `values.yaml`: add `topologySpreadConstraints: []` with a commented example using [`maxSkew`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition), [`topologyKey`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition), [`whenUnsatisfiable`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition), and [`labelSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition).
- `templates/deployment.yaml`: render the [`spec.template.spec.topologySpreadConstraints`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) field only when set, so the default render is unchanged.
- `README.md`: regenerated with `helm-docs` (via `make chart-docs`).

Default value is `[]` so this is fully backward-compatible — existing installs render byte-identical manifests.

Validation:

- `helm lint chart/falco-operator/` passes.
- `helm template` with `topologySpreadConstraints` set renders the field correctly under `spec.template.spec`.
- `helm template` with default values omits the field entirely.
- `make chart-docs` regenerates the README without further drift.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Chart `version`/`appVersion` intentionally not bumped — following the convention of recent chart-only feature PRs (`feat(chart): add resizePolicy support`, `feat(chart): add extraObjects with tpl support`) which were added without a version bump.