### PR TITLE
feat(chart): add revisionHistoryLimit support

### DIFF
--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the falco-operator char
 | replicaCount | int | `1` | Number of replicas for the operator |
 | resizePolicy | list | `[]` | In-place pod resize policy for the manager container |
 | resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests |
+| revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container security context |
 | serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"name":""}` | Service account configuration |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     control-plane: falco-operator
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "falco-operator.selectorLabels" . | nindent 6 }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -5,6 +5,9 @@
 # -- Number of replicas for the operator
 replicaCount: 1
 
+# -- The number of old ReplicaSets to retain to allow rollback
+revisionHistoryLimit: 10
+
 image:
   # -- Repository for the Falco Operator image
   repository: falcosecurity/falco-operator


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

Exposes [spec.revisionHistoryLimit](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit) on the operator Deployment so users can tune how many old [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/) are retained for [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment).

- New value revisionHistoryLimit in values.yaml, defaulting to 10 (matches the Kubernetes default).
- Rendered unconditionally in templates/deployment.yaml.
- chart/falco-operator/README.md regenerated via make chart-docs.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

No behavior change at the default value; rendered field equals the Kubernetes default of 10.