### PR TITLE
feat(chart): add imagePullSecrets for service account

### DIFF
--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -72,10 +72,11 @@ The following table lists the configurable parameters of the falco-operator char
 | resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container security context |
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"name":""}` | Service account configuration |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"imagePullSecrets":[],"name":""}` | Service account configuration |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Automatically mount the ServiceAccount API token into pods using this ServiceAccount |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets attached to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use |
 | tolerations | list | `[]` | Tolerations |
 | topologySpreadConstraints | list | `[]` | Topology spread constraints |

--- a/chart/falco-operator/templates/serviceaccount.yaml
+++ b/chart/falco-operator/templates/serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -36,6 +36,8 @@ serviceAccount:
   annotations: {}
   # -- The name of the service account to use
   name: ""
+  # -- Image pull secrets attached to the service account
+  imagePullSecrets: []
 
 # -- RBAC configuration
 rbac:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

Adds `serviceAccount.imagePullSecrets` to the falco-operator Helm chart so private registry credentials can be attached to the operator ServiceAccount. Rendered via a `with` block so the field is omitted when unset, and kept separate from the existing pod-level `.Values.imagePullSecrets` so each can be configured independently.

Changes:
- `chart/falco-operator/templates/serviceaccount.yaml`: render `imagePullSecrets` from `.Values.serviceAccount.imagePullSecrets` inside a `with` block
- `chart/falco-operator/values.yaml`: add `serviceAccount.imagePullSecrets: []` default
- `chart/falco-operator/README.md`: regenerated via `make chart-docs`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Verified locally with `helm template`:

```yaml
# helm template ... --set 'serviceAccount.imagePullSecrets[0].name=myregcred'
kind: ServiceAccount
metadata:
  name: release-name-falco-operator
  ...
automountServiceAccountToken: true
imagePullSecrets:
  - name: myregcred
```

With the default empty list, the `imagePullSecrets` field is not rendered, preserving the prior behavior.