### PR TITLE
fix(artifact-operator): gate sidecar startup on first local reconcile

### DIFF
--- a/cmd/artifact/main.go
+++ b/cmd/artifact/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -42,6 +43,7 @@ import (
 	"github.com/falcosecurity/falco-operator/controllers/artifact/plugin"
 	"github.com/falcosecurity/falco-operator/controllers/artifact/rulesfile"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 	"github.com/falcosecurity/falco-operator/internal/pkg/version"
 )
 
@@ -226,10 +228,13 @@ func main() {
 		}
 	}
 
+	gate := startupgate.NewGate(mgr.GetClient(), nodeName, namespace)
+
 	if err = config.NewConfigReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorder("config-controller/"+nodeName),
+		gate,
 		nodeName,
 		namespace,
 	).SetupWithManager(mgr); err != nil {
@@ -241,6 +246,7 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorder("rulesfile-controller/"+nodeName),
+		gate,
 		nodeName,
 		namespace,
 	).SetupWithManager(mgr); err != nil {
@@ -252,6 +258,7 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		mgr.GetEventRecorder("plugin-controller/"+nodeName),
+		gate,
 		nodeName,
 		namespace,
 	).SetupWithManager(mgr); err != nil {
@@ -279,7 +286,20 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		if err := gate.MarkCacheSynced(ctx); err != nil {
+			setupLog.Error(err, "unable to initialize startup gate")
+			return err
+		}
+		setupLog.Info("startup gate initialized")
+		<-ctx.Done()
+		return nil
+	})); err != nil {
+		setupLog.Error(err, "unable to add startup gate runnable")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", gate.Check); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/controllers/artifact/config/controller.go
+++ b/controllers/artifact/config/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const (
@@ -51,12 +52,14 @@ func NewConfigReconciler(
 	cl client.Client,
 	scheme *runtime.Scheme,
 	recorder events.EventRecorder,
+	gate startupgate.Recorder,
 	nodeName, namespace string,
 ) *ConfigReconciler {
 	return &ConfigReconciler{
 		Client:          cl,
 		Scheme:          scheme,
 		recorder:        recorder,
+		gate:            gate,
 		finalizer:       common.FormatFinalizerName(configFinalizerPrefix, nodeName),
 		artifactManager: artifact.NewManager(cl, namespace),
 		nodeName:        nodeName,
@@ -69,6 +72,7 @@ type ConfigReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	recorder        events.EventRecorder
+	gate            startupgate.Recorder
 	finalizer       string
 	artifactManager *artifact.Manager
 	nodeName        string
@@ -88,6 +92,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		logger.Error(err, "unable to fetch Config instance")
 		return ctrl.Result{}, err
 	} else if k8serrors.IsNotFound(err) {
+		r.gate.Forget(startupgate.KindConfig, req.Namespace, req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -96,12 +101,17 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, err
 	} else if !ok {
 		logger.Info("Config instance does not match node selector, will remove local resources if any")
+		r.gate.Forget(startupgate.KindConfig, config.Namespace, config.Name)
 
 		// Handle case where config selector no longer matches the node.
 		if ok, err := controllerhelper.RemoveLocalResources(ctx, r.Client, r.artifactManager, r.finalizer, config); ok || err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if !config.DeletionTimestamp.IsZero() {
+		defer r.gate.Forget(startupgate.KindConfig, config.Namespace, config.Name)
 	}
 
 	// Handle deletion.
@@ -113,6 +123,8 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	if ok, err := r.ensureFinalizer(ctx, config); ok || err != nil {
 		return ctrl.Result{}, err
 	}
+
+	defer r.gate.MarkReconciled(startupgate.KindConfig, config.Namespace, config.Name, config.Generation)
 
 	// Patch status via defer to ensure it's always called.
 	defer func() {

--- a/controllers/artifact/config/controller_test.go
+++ b/controllers/artifact/config/controller_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const testConfigName = "test-config"
@@ -80,6 +81,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*ConfigReconciler, 
 		Client:          cl,
 		Scheme:          s,
 		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
 		finalizer:       testFinalizerName(),
 		artifactManager: am,
 		nodeName:        testutil.TestNodeName,
@@ -90,7 +92,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*ConfigReconciler, 
 func TestNewConfigReconciler(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
 	cl := fake.NewClientBuilder().WithScheme(s).Build()
-	r := NewConfigReconciler(cl, s, events.NewFakeRecorder(10), "my-node", "my-namespace")
+	r := NewConfigReconciler(cl, s, events.NewFakeRecorder(10), startupgate.NoopGateRecorder{}, "my-node", "my-namespace")
 
 	require.NotNil(t, r)
 	assert.Equal(t, "my-node", r.nodeName)
@@ -421,6 +423,7 @@ func TestReconcile_GetErrorPropagates(t *testing.T) {
 		Client:          cl,
 		Scheme:          s,
 		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
 		finalizer:       testFinalizerName(),
 		artifactManager: am,
 		nodeName:        testutil.TestNodeName,
@@ -429,6 +432,166 @@ func TestReconcile_GetErrorPropagates(t *testing.T) {
 
 	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
 	require.Error(t, err)
+}
+
+func TestReconcile_GateInteraction(t *testing.T) {
+	const gen int64 = 3
+	workerNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testutil.TestNodeName,
+			Labels: map[string]string{"role": "worker"},
+		},
+	}
+	matching := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testConfigName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.ConfigSpec{
+			Config: &apiextensionsv1.JSON{Raw: []byte(testConfigJSON)},
+		},
+	}
+	mismatched := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testConfigName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.ConfigSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "gpu"}},
+		},
+	}
+	withFinalizer := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testConfigName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+			Finalizers: []string{testFinalizerName()},
+		},
+		Spec: artifactv1alpha1.ConfigSpec{
+			Config: &apiextensionsv1.JSON{Raw: []byte(testConfigJSON)},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		objects         []client.Object
+		triggerDeletion bool
+		writeErr        error
+		req             ctrl.Request
+		wantErr         bool
+		wantReconciled  []startupgate.FakeGateCall
+		wantForgotten   []startupgate.FakeGateCall
+	}{
+		{
+			name:          "NotFound forgets the CR",
+			req:           testutil.Request(testConfigName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName}},
+		},
+		{
+			name:          "selector mismatch forgets the CR",
+			objects:       []client.Object{workerNode, mismatched},
+			req:           testutil.Request(testConfigName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName}},
+		},
+		{
+			name:            "completed deletion forgets the CR",
+			objects:         []client.Object{workerNode, withFinalizer},
+			triggerDeletion: true,
+			req:             testutil.Request(testConfigName),
+			wantForgotten:   []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName}},
+		},
+		{
+			name:    "first reconcile only adds the finalizer and must NOT mark reconciled",
+			objects: []client.Object{workerNode, matching},
+			req:     testutil.Request(testConfigName),
+		},
+		{
+			name:           "successful reconcile marks reconciled with current generation",
+			objects:        []client.Object{workerNode, withFinalizer},
+			req:            testutil.Request(testConfigName),
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName, Generation: gen}},
+		},
+		{
+			name:           "real reconcile failure still marks reconciled after finalizer",
+			objects:        []client.Object{workerNode, withFinalizer},
+			writeErr:       fmt.Errorf("disk full"),
+			req:            testutil.Request(testConfigName),
+			wantErr:        true,
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName, Generation: gen}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, cl := newTestReconciler(t, tt.objects...)
+			rec := &startupgate.FakeGateRecorder{}
+			r.gate = rec
+			if tt.writeErr != nil {
+				r.artifactManager = artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+					artifact.WithFS(&filesystem.MockFileSystem{WriteErr: tt.writeErr}),
+				)
+			}
+			if tt.triggerDeletion {
+				obj := &artifactv1alpha1.Config{}
+				require.NoError(t, cl.Get(context.Background(), tt.req.NamespacedName, obj))
+				require.NoError(t, cl.Delete(context.Background(), obj))
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantReconciled, rec.Reconciled)
+			assert.Equal(t, tt.wantForgotten, rec.Forgotten)
+		})
+	}
+}
+
+func TestReconcile_GateForgetsOnDeletionCleanupFailure(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
+	finalizer := testFinalizerName()
+	config := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testConfigName,
+			Namespace:         testutil.TestNamespace,
+			Generation:        1,
+			Finalizers:        []string{finalizer},
+			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("patch failed: cluster unreachable")
+			},
+		}).
+		Build()
+
+	r := &ConfigReconciler{
+		Client:          cl,
+		Scheme:          s,
+		recorder:        events.NewFakeRecorder(100),
+		gate:            &startupgate.FakeGateRecorder{},
+		finalizer:       finalizer,
+		artifactManager: artifact.NewManagerWithOptions(cl, testutil.TestNamespace, artifact.WithFS(filesystem.NewMockFileSystem())),
+		nodeName:        testutil.TestNodeName,
+		namespace:       testutil.TestNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+
+	rec := r.gate.(*startupgate.FakeGateRecorder)
+	assert.Empty(t, rec.Reconciled)
+	assert.Equal(t, []startupgate.FakeGateCall{{Kind: "Config", Namespace: testutil.TestNamespace, Name: testConfigName}}, rec.Forgotten)
 }
 
 func TestEnsureFinalizer(t *testing.T) {

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/priority"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const (
@@ -61,12 +62,14 @@ func NewPluginReconciler(
 	cl client.Client,
 	scheme *runtime.Scheme,
 	recorder events.EventRecorder,
+	gate startupgate.Recorder,
 	nodeName, namespace string,
 ) *PluginReconciler {
 	return &PluginReconciler{
 		Client:          cl,
 		Scheme:          scheme,
 		recorder:        recorder,
+		gate:            gate,
 		finalizer:       common.FormatFinalizerName(pluginFinalizerPrefix, nodeName),
 		artifactManager: artifact.NewManager(cl, namespace),
 		PluginsConfig:   &PluginsConfig{},
@@ -80,6 +83,7 @@ type PluginReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	recorder        events.EventRecorder
+	gate            startupgate.Recorder
 	finalizer       string
 	artifactManager *artifact.Manager
 	PluginsConfig   *PluginsConfig
@@ -99,6 +103,7 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		logger.Error(err, "Unable to fetch Plugin")
 		return ctrl.Result{}, err
 	} else if k8serrors.IsNotFound(err) {
+		r.gate.Forget(startupgate.KindPlugin, req.Namespace, req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -107,12 +112,17 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		return ctrl.Result{}, err
 	} else if !ok {
 		logger.Info("Plugin instance does not match node selector, will remove local resources if any")
+		r.gate.Forget(startupgate.KindPlugin, plugin.Namespace, plugin.Name)
 
 		// Here we handle the case where the plugin was created with a selector that matched the node, but now it doesn't.
 		if ok, err := controllerhelper.RemoveLocalResources(ctx, r.Client, r.artifactManager, r.finalizer, plugin); ok || err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if !plugin.DeletionTimestamp.IsZero() {
+		defer r.gate.Forget(startupgate.KindPlugin, plugin.Namespace, plugin.Name)
 	}
 
 	// Handle deletion of the Plugin instance.
@@ -124,6 +134,8 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	if ok, err := r.ensureFinalizers(ctx, plugin); ok || err != nil {
 		return ctrl.Result{}, err
 	}
+
+	defer r.gate.MarkReconciled(startupgate.KindPlugin, plugin.Namespace, plugin.Name, plugin.Generation)
 
 	// Patch status via defer to ensure it's always called.
 	defer func() {

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
@@ -42,6 +43,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 	"github.com/falcosecurity/falco-operator/internal/pkg/priority"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const testPluginName = "test-plugin"
@@ -82,6 +84,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*PluginReconciler, 
 		Client:          cl,
 		Scheme:          s,
 		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
 		finalizer:       testFinalizerName(),
 		artifactManager: am,
 		PluginsConfig:   &PluginsConfig{},
@@ -93,7 +96,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*PluginReconciler, 
 func TestNewPluginReconciler(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
 	cl := fake.NewClientBuilder().WithScheme(s).Build()
-	r := NewPluginReconciler(cl, s, events.NewFakeRecorder(10), "my-node", "my-namespace")
+	r := NewPluginReconciler(cl, s, events.NewFakeRecorder(10), startupgate.NoopGateRecorder{}, "my-node", "my-namespace")
 
 	require.NotNil(t, r)
 	assert.Equal(t, "my-node", r.nodeName)
@@ -400,6 +403,185 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_GateInteraction(t *testing.T) {
+	const gen int64 = 5
+	workerNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testutil.TestNodeName,
+			Labels: map[string]string{"role": "worker"},
+		},
+	}
+	matching := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testPluginName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.PluginSpec{},
+	}
+	mismatched := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testPluginName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.PluginSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "gpu"}},
+		},
+	}
+	// withFinalizer simulates a CR that has already received its finalizer in a
+	// previous reconcile; the next reconcile call gets past ensureFinalizers and
+	// reaches the artifact-writing path.
+	withFinalizer := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testPluginName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+			Finalizers: []string{testFinalizerName()},
+		},
+		Spec: artifactv1alpha1.PluginSpec{},
+	}
+	// withFinalizerAndOCI is used to drive the OCI failure path; the mocked
+	// puller returns an error, ensurePlugin fails, and the gate must stay closed.
+	withFinalizerAndOCI := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testPluginName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+			Finalizers: []string{testFinalizerName()},
+		},
+		Spec: artifactv1alpha1.PluginSpec{
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/plugins/test", Tag: "latest"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		objects         []client.Object
+		triggerDeletion bool
+		pullErr         error
+		req             ctrl.Request
+		wantErr         bool
+		wantReconciled  []startupgate.FakeGateCall
+		wantForgotten   []startupgate.FakeGateCall
+	}{
+		{
+			name:          "NotFound forgets the CR",
+			req:           testutil.Request(testPluginName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName}},
+		},
+		{
+			name:          "selector mismatch forgets the CR",
+			objects:       []client.Object{workerNode, mismatched},
+			req:           testutil.Request(testPluginName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName}},
+		},
+		{
+			name:            "completed deletion forgets the CR",
+			objects:         []client.Object{workerNode, withFinalizer},
+			triggerDeletion: true,
+			req:             testutil.Request(testPluginName),
+			wantForgotten:   []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName}},
+		},
+		{
+			name:    "first reconcile only adds the finalizer and must NOT mark reconciled",
+			objects: []client.Object{workerNode, matching},
+			req:     testutil.Request(testPluginName),
+		},
+		{
+			name:           "successful reconcile marks reconciled with current generation",
+			objects:        []client.Object{workerNode, withFinalizer},
+			req:            testutil.Request(testPluginName),
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName, Generation: gen}},
+		},
+		{
+			name:           "real reconcile failure still marks reconciled after finalizer",
+			objects:        []client.Object{workerNode, withFinalizerAndOCI},
+			pullErr:        fmt.Errorf("oci pull failed"),
+			req:            testutil.Request(testPluginName),
+			wantErr:        true,
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName, Generation: gen}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, cl := newTestReconciler(t, tt.objects...)
+			rec := &startupgate.FakeGateRecorder{}
+			r.gate = rec
+			if tt.pullErr != nil {
+				r.artifactManager = artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+					artifact.WithFS(filesystem.NewMockFileSystem()),
+					artifact.WithOCIPuller(&puller.MockOCIPuller{PullErr: tt.pullErr}),
+				)
+			}
+			if tt.triggerDeletion {
+				obj := &artifactv1alpha1.Plugin{}
+				require.NoError(t, cl.Get(context.Background(), tt.req.NamespacedName, obj))
+				require.NoError(t, cl.Delete(context.Background(), obj))
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantReconciled, rec.Reconciled)
+			assert.Equal(t, tt.wantForgotten, rec.Forgotten)
+		})
+	}
+}
+
+func TestReconcile_GateForgetsOnDeletionCleanupFailure(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
+	finalizer := testFinalizerName()
+	plugin := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testPluginName,
+			Namespace:         testutil.TestNamespace,
+			Generation:        1,
+			Finalizers:        []string{finalizer},
+			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("patch failed: cluster unreachable")
+			},
+		}).
+		Build()
+
+	r := &PluginReconciler{
+		Client:    cl,
+		Scheme:    s,
+		recorder:  events.NewFakeRecorder(100),
+		gate:      &startupgate.FakeGateRecorder{},
+		finalizer: finalizer,
+		artifactManager: artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+			artifact.WithFS(filesystem.NewMockFileSystem()),
+			artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+		),
+		PluginsConfig:  &PluginsConfig{},
+		nodeName:       testutil.TestNodeName,
+		crToConfigName: make(map[string]string),
+	}
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+
+	rec := r.gate.(*startupgate.FakeGateRecorder)
+	assert.Empty(t, rec.Reconciled)
+	assert.Equal(t, []startupgate.FakeGateCall{{Kind: "Plugin", Namespace: testutil.TestNamespace, Name: testPluginName}}, rec.Forgotten)
 }
 
 func TestHandleDeletion(t *testing.T) {

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const (
@@ -53,12 +54,14 @@ func NewRulesfileReconciler(
 	cl client.Client,
 	scheme *runtime.Scheme,
 	recorder events.EventRecorder,
+	gate startupgate.Recorder,
 	nodeName, namespace string,
 ) *RulesfileReconciler {
 	return &RulesfileReconciler{
 		Client:          cl,
 		Scheme:          scheme,
 		recorder:        recorder,
+		gate:            gate,
 		finalizer:       common.FormatFinalizerName(rulesfileFinalizerPrefix, nodeName),
 		artifactManager: artifact.NewManager(cl, namespace),
 		nodeName:        nodeName,
@@ -71,6 +74,7 @@ type RulesfileReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	recorder        events.EventRecorder
+	gate            startupgate.Recorder
 	finalizer       string
 	artifactManager *artifact.Manager
 	nodeName        string
@@ -90,6 +94,7 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(err, "unable to fetch Rulesfile")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	} else if k8serrors.IsNotFound(err) {
+		r.gate.Forget(startupgate.KindRulesfile, req.Namespace, req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -98,12 +103,17 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	} else if !ok {
 		logger.Info("Rulesfile instance does not match node selector, will remove local resources if any")
+		r.gate.Forget(startupgate.KindRulesfile, rulesfile.Namespace, rulesfile.Name)
 
 		// Handle case where rulesfile selector no longer matches the node.
 		if ok, err := controllerhelper.RemoveLocalResources(ctx, r.Client, r.artifactManager, r.finalizer, rulesfile); ok || err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if !rulesfile.DeletionTimestamp.IsZero() {
+		defer r.gate.Forget(startupgate.KindRulesfile, rulesfile.Namespace, rulesfile.Name)
 	}
 
 	// Handle deletion.
@@ -115,6 +125,8 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if ok, err := r.ensureFinalizer(ctx, rulesfile); ok || err != nil {
 		return ctrl.Result{}, err
 	}
+
+	defer r.gate.MarkReconciled(startupgate.KindRulesfile, rulesfile.Namespace, rulesfile.Name, rulesfile.Generation)
 
 	// Patch status via defer to ensure it's always called.
 	defer func() {

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
@@ -42,6 +43,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
 
 const testRulesfileName = "test-rulesfile"
@@ -78,6 +80,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*RulesfileReconcile
 		Client:          cl,
 		Scheme:          s,
 		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
 		finalizer:       testFinalizerName(),
 		artifactManager: am,
 		nodeName:        testutil.TestNodeName,
@@ -88,7 +91,7 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*RulesfileReconcile
 func TestNewRulesfileReconciler(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
 	cl := fake.NewClientBuilder().WithScheme(s).Build()
-	r := NewRulesfileReconciler(cl, s, events.NewFakeRecorder(10), "my-node", "my-namespace")
+	r := NewRulesfileReconciler(cl, s, events.NewFakeRecorder(10), startupgate.NoopGateRecorder{}, "my-node", "my-namespace")
 
 	require.NotNil(t, r)
 	assert.Equal(t, "my-node", r.nodeName)
@@ -401,6 +404,170 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_GateInteraction(t *testing.T) {
+	const gen int64 = 4
+	workerNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testutil.TestNodeName,
+			Labels: map[string]string{"role": "worker"},
+		},
+	}
+	matching := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testRulesfileName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			InlineRules: &apiextensionsv1.JSON{Raw: []byte(testInlineRulesJSON)},
+		},
+	}
+	mismatched := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testRulesfileName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+		},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "gpu"}},
+		},
+	}
+	withFinalizer := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testRulesfileName,
+			Namespace:  testutil.TestNamespace,
+			Generation: gen,
+			Finalizers: []string{testFinalizerName()},
+		},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			InlineRules: &apiextensionsv1.JSON{Raw: []byte(testInlineRulesJSON)},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		objects         []client.Object
+		triggerDeletion bool
+		writeErr        error
+		req             ctrl.Request
+		wantErr         bool
+		wantReconciled  []startupgate.FakeGateCall
+		wantForgotten   []startupgate.FakeGateCall
+	}{
+		{
+			name:          "NotFound forgets the CR",
+			req:           testutil.Request(testRulesfileName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName}},
+		},
+		{
+			name:          "selector mismatch forgets the CR",
+			objects:       []client.Object{workerNode, mismatched},
+			req:           testutil.Request(testRulesfileName),
+			wantForgotten: []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName}},
+		},
+		{
+			name:            "completed deletion forgets the CR",
+			objects:         []client.Object{workerNode, withFinalizer},
+			triggerDeletion: true,
+			req:             testutil.Request(testRulesfileName),
+			wantForgotten:   []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName}},
+		},
+		{
+			name:    "first reconcile only adds the finalizer and must NOT mark reconciled",
+			objects: []client.Object{workerNode, matching},
+			req:     testutil.Request(testRulesfileName),
+		},
+		{
+			name:           "successful reconcile marks reconciled with current generation",
+			objects:        []client.Object{workerNode, withFinalizer},
+			req:            testutil.Request(testRulesfileName),
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName, Generation: gen}},
+		},
+		{
+			name:           "real reconcile failure still marks reconciled after finalizer",
+			objects:        []client.Object{workerNode, withFinalizer},
+			writeErr:       fmt.Errorf("disk full"),
+			req:            testutil.Request(testRulesfileName),
+			wantErr:        true,
+			wantReconciled: []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName, Generation: gen}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, cl := newTestReconciler(t, tt.objects...)
+			rec := &startupgate.FakeGateRecorder{}
+			r.gate = rec
+			if tt.writeErr != nil {
+				r.artifactManager = artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+					artifact.WithFS(&filesystem.MockFileSystem{WriteErr: tt.writeErr}),
+					artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+				)
+			}
+			if tt.triggerDeletion {
+				obj := &artifactv1alpha1.Rulesfile{}
+				require.NoError(t, cl.Get(context.Background(), tt.req.NamespacedName, obj))
+				require.NoError(t, cl.Delete(context.Background(), obj))
+			}
+
+			_, err := r.Reconcile(context.Background(), tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantReconciled, rec.Reconciled)
+			assert.Equal(t, tt.wantForgotten, rec.Forgotten)
+		})
+	}
+}
+
+func TestReconcile_GateForgetsOnDeletionCleanupFailure(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
+	finalizer := testFinalizerName()
+	rulesfile := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testRulesfileName,
+			Namespace:         testutil.TestNamespace,
+			Generation:        1,
+			Finalizers:        []string{finalizer},
+			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rulesfile).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("patch failed: cluster unreachable")
+			},
+		}).
+		Build()
+
+	r := &RulesfileReconciler{
+		Client:    cl,
+		Scheme:    s,
+		recorder:  events.NewFakeRecorder(100),
+		gate:      &startupgate.FakeGateRecorder{},
+		finalizer: finalizer,
+		artifactManager: artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+			artifact.WithFS(filesystem.NewMockFileSystem()),
+			artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+		),
+		nodeName:  testutil.TestNodeName,
+		namespace: testutil.TestNamespace,
+	}
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+
+	rec := r.gate.(*startupgate.FakeGateRecorder)
+	assert.Empty(t, rec.Reconciled)
+	assert.Equal(t, []startupgate.FakeGateCall{{Kind: "Rulesfile", Namespace: testutil.TestNamespace, Name: testRulesfileName}}, rec.Forgotten)
 }
 
 func TestEnsureFinalizer(t *testing.T) {
@@ -1042,6 +1209,7 @@ func TestFindRulesfilesForConfigMap(t *testing.T) {
 		Client:          cl,
 		Scheme:          s,
 		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
 		finalizer:       testFinalizerName(),
 		artifactManager: am,
 		nodeName:        testutil.TestNodeName,

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -225,6 +225,19 @@ var FalcoDefaults = &InstanceDefaults{
 				{Name: mounts.RulesfileMountName, MountPath: mounts.RulesfileDirPath},
 				{Name: mounts.PluginMountName, MountPath: mounts.PluginDirPath},
 			},
+			StartupProbe: &corev1.Probe{
+				InitialDelaySeconds: 3,
+				TimeoutSeconds:      5,
+				PeriodSeconds:       5,
+				FailureThreshold:    20,
+				SuccessThreshold:    1,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/readyz",
+						Port: intstr.FromInt32(8081),
+					},
+				},
+			},
 			ReadinessProbe: &corev1.Probe{
 				InitialDelaySeconds: 5,
 				TimeoutSeconds:      5,
@@ -233,7 +246,7 @@ var FalcoDefaults = &InstanceDefaults{
 				SuccessThreshold:    1,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
+						Path: "/readyz",
 						Port: intstr.FromInt32(8081),
 					},
 				},

--- a/internal/pkg/resources/forge_test.go
+++ b/internal/pkg/resources/forge_test.go
@@ -40,6 +40,18 @@ func mustGetPodTemplateLabels(t *testing.T, obj *unstructured.Unstructured) map[
 	return labels
 }
 
+func assertArtifactOperatorReadinessProbes(t *testing.T, c *corev1.Container) {
+	t.Helper()
+	require.NotNil(t, c.StartupProbe)
+	require.NotNil(t, c.StartupProbe.HTTPGet)
+	assert.Equal(t, "/readyz", c.StartupProbe.HTTPGet.Path)
+	assert.Equal(t, int32(8081), c.StartupProbe.HTTPGet.Port.IntVal)
+
+	require.NotNil(t, c.ReadinessProbe)
+	require.NotNil(t, c.ReadinessProbe.HTTPGet)
+	assert.Equal(t, "/readyz", c.ReadinessProbe.HTTPGet.Path)
+}
+
 func TestGenerateWorkload(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -207,6 +219,7 @@ func TestGenerateWorkload(t *testing.T) {
 						assert.Equal(t, version.ArtifactOperatorImage, c.Image, "sidecar should have the correct image")
 						require.NotNil(t, c.RestartPolicy, "native sidecar should have RestartPolicy set")
 						assert.Equal(t, corev1.ContainerRestartPolicyAlways, *c.RestartPolicy, "native sidecar RestartPolicy should be Always")
+						assertArtifactOperatorReadinessProbes(t, &c)
 						break
 					}
 					assert.True(t, foundSidecar, "native sidecar %s not found in initContainers", tt.wantSidecarName)
@@ -222,6 +235,7 @@ func TestGenerateWorkload(t *testing.T) {
 							foundSidecar = true
 							assert.Equal(t, version.ArtifactOperatorImage, c.Image, "sidecar should have the correct image")
 							assert.Nil(t, c.RestartPolicy, "non-native sidecar should have nil RestartPolicy")
+							assertArtifactOperatorReadinessProbes(t, &c)
 							break
 						}
 					}

--- a/internal/pkg/startupgate/doc.go
+++ b/internal/pkg/startupgate/doc.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package startupgate provides a readiness check that succeeds once every
+// node-applicable artifact CR has been locally reconciled.
+package startupgate

--- a/internal/pkg/startupgate/gate.go
+++ b/internal/pkg/startupgate/gate.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package startupgate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+)
+
+const (
+	KindPlugin    = "Plugin"
+	KindRulesfile = "Rulesfile"
+	KindConfig    = "Config"
+)
+
+// Recorder marks CRs as reconciled or forgotten.
+type Recorder interface {
+	MarkReconciled(kind, namespace, name string, generation int64)
+	Forget(kind, namespace, name string)
+}
+
+// Gate tracks node-applicable artifact CRs and reports readiness when each has
+// been locally reconciled at least once.
+type Gate struct {
+	client    client.Client
+	nodeName  string
+	namespace string
+
+	cacheSynced atomic.Bool
+
+	labelsMu   sync.RWMutex
+	nodeLabels labels.Set
+
+	mu        sync.Mutex
+	expected  map[string]int64
+	processed map[string]int64
+}
+
+func NewGate(cl client.Client, nodeName, namespace string) *Gate {
+	return &Gate{
+		client:    cl,
+		nodeName:  nodeName,
+		namespace: namespace,
+		expected:  make(map[string]int64),
+		processed: make(map[string]int64),
+	}
+}
+
+// MarkCacheSynced caches the node labels and builds the startup snapshot.
+func (g *Gate) MarkCacheSynced(ctx context.Context) error {
+	node := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+	}
+	if err := g.client.Get(ctx, client.ObjectKey{Name: g.nodeName}, node); err != nil {
+		return fmt.Errorf("fetching node %q: %w", g.nodeName, err)
+	}
+
+	g.labelsMu.Lock()
+	g.nodeLabels = labels.Set(node.Labels)
+	g.labelsMu.Unlock()
+
+	if err := g.snapshot(ctx); err != nil {
+		return err
+	}
+
+	g.cacheSynced.Store(true)
+	return nil
+}
+
+func (g *Gate) snapshot(ctx context.Context) error {
+	pluginList := &artifactv1alpha1.PluginList{}
+	if err := g.client.List(ctx, pluginList, client.InNamespace(g.namespace)); err != nil {
+		return fmt.Errorf("listing plugins: %w", err)
+	}
+	rulesfileList := &artifactv1alpha1.RulesfileList{}
+	if err := g.client.List(ctx, rulesfileList, client.InNamespace(g.namespace)); err != nil {
+		return fmt.Errorf("listing rulesfiles: %w", err)
+	}
+	configList := &artifactv1alpha1.ConfigList{}
+	if err := g.client.List(ctx, configList, client.InNamespace(g.namespace)); err != nil {
+		return fmt.Errorf("listing configs: %w", err)
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for i := range pluginList.Items {
+		p := &pluginList.Items[i]
+		if g.nodeMatches(p.Spec.Selector) {
+			g.expected[key(KindPlugin, p.Namespace, p.Name)] = p.Generation
+		}
+	}
+	for i := range rulesfileList.Items {
+		r := &rulesfileList.Items[i]
+		if g.nodeMatches(r.Spec.Selector) {
+			g.expected[key(KindRulesfile, r.Namespace, r.Name)] = r.Generation
+		}
+	}
+	for i := range configList.Items {
+		c := &configList.Items[i]
+		if g.nodeMatches(c.Spec.Selector) {
+			g.expected[key(KindConfig, c.Namespace, c.Name)] = c.Generation
+		}
+	}
+	return nil
+}
+
+// MarkReconciled records that the CR was reconciled at the given generation.
+func (g *Gate) MarkReconciled(kind, namespace, name string, generation int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	k := key(kind, namespace, name)
+	if cur, ok := g.processed[k]; ok && cur >= generation {
+		return
+	}
+	g.processed[k] = generation
+}
+
+// Forget drops a CR from both the snapshot and the processed set.
+func (g *Gate) Forget(kind, namespace, name string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	k := key(kind, namespace, name)
+	delete(g.expected, k)
+	delete(g.processed, k)
+}
+
+// Check returns nil when every snapshotted CR has been processed.
+func (g *Gate) Check(_ *http.Request) error {
+	if !g.cacheSynced.Load() {
+		return fmt.Errorf("artifact-operator cache not yet synced")
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	var pending []string
+	for k, want := range g.expected {
+		if got, ok := g.processed[k]; !ok || got < want {
+			pending = append(pending, k)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	sort.Strings(pending)
+	return fmt.Errorf("waiting for first reconcile of: %s", strings.Join(pending, ", "))
+}
+
+func (g *Gate) nodeMatches(labelSelector *metav1.LabelSelector) bool {
+	if labelSelector == nil {
+		return true
+	}
+	sel, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return false
+	}
+	g.labelsMu.RLock()
+	defer g.labelsMu.RUnlock()
+	return sel.Matches(g.nodeLabels)
+}
+
+func key(kind, namespace, name string) string {
+	return kind + "/" + namespace + "/" + name
+}

--- a/internal/pkg/startupgate/gate_test.go
+++ b/internal/pkg/startupgate/gate_test.go
@@ -1,0 +1,400 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package startupgate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+)
+
+const (
+	testNodeName  = "node-1"
+	testNamespace = "falco"
+)
+
+var testNodeLabels = map[string]string{"role": "worker"}
+
+// artifactOpts builds an artifact CR. progStatus == "" leaves the status empty.
+type artifactOpts struct {
+	name       string
+	generation int64
+	progStatus metav1.ConditionStatus
+	obsGen     int64
+	selector   *metav1.LabelSelector
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, artifactv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testNodeName, Labels: testNodeLabels},
+	}
+}
+
+func buildConditions(opts artifactOpts) []metav1.Condition {
+	if opts.progStatus == "" {
+		return nil
+	}
+	return []metav1.Condition{{
+		Type:               commonv1alpha1.ConditionProgrammed.String(),
+		Status:             opts.progStatus,
+		Reason:             "TestReason",
+		Message:            "test",
+		ObservedGeneration: opts.obsGen,
+		LastTransitionTime: metav1.Now(),
+	}}
+}
+
+func newPlugin(opts artifactOpts) *artifactv1alpha1.Plugin {
+	return &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: opts.name, Namespace: testNamespace, Generation: opts.generation},
+		Spec:       artifactv1alpha1.PluginSpec{Selector: opts.selector},
+		Status:     artifactv1alpha1.PluginStatus{Conditions: buildConditions(opts)},
+	}
+}
+
+func newRulesfile(opts artifactOpts) *artifactv1alpha1.Rulesfile {
+	return &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: opts.name, Namespace: testNamespace, Generation: opts.generation},
+		Spec:       artifactv1alpha1.RulesfileSpec{Selector: opts.selector},
+		Status:     artifactv1alpha1.RulesfileStatus{Conditions: buildConditions(opts)},
+	}
+}
+
+func newConfig(opts artifactOpts) *artifactv1alpha1.Config {
+	return &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: opts.name, Namespace: testNamespace, Generation: opts.generation},
+		Spec:       artifactv1alpha1.ConfigSpec{Selector: opts.selector},
+		Status:     artifactv1alpha1.ConfigStatus{Conditions: buildConditions(opts)},
+	}
+}
+
+func newProbeRequest() *http.Request {
+	return httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
+}
+
+func newGateReady(t *testing.T, objects ...client.Object) *Gate {
+	t.Helper()
+	s := newScheme(t)
+	all := append([]client.Object{newNode()}, objects...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(all...).Build()
+	g := NewGate(cl, testNodeName, testNamespace)
+	require.NoError(t, g.MarkCacheSynced(context.Background()))
+	return g
+}
+
+func TestGate_MarkCacheSynced(t *testing.T) {
+	workerSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"role": "worker"}}
+	masterSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"role": "master"}}
+
+	tests := []struct {
+		name             string
+		objects          []client.Object
+		omitNode         bool
+		wantErr          bool
+		wantExpectedKeys []string
+	}{
+		{
+			name:     "fails when node does not exist",
+			omitNode: true,
+			wantErr:  true,
+		},
+		{
+			name:             "empty cluster yields empty snapshot",
+			wantExpectedKeys: nil,
+		},
+		{
+			name: "snapshots node-applicable CRs of every kind",
+			objects: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+				newPlugin(artifactOpts{name: "p2", generation: 1, selector: workerSelector}),
+				newRulesfile(artifactOpts{name: "r1", generation: 2}),
+				newConfig(artifactOpts{name: "c1", generation: 3}),
+			},
+			wantExpectedKeys: []string{
+				"Config/falco/c1",
+				"Plugin/falco/p1",
+				"Plugin/falco/p2",
+				"Rulesfile/falco/r1",
+			},
+		},
+		{
+			name: "skips CRs whose selector does not match the node",
+			objects: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1, selector: masterSelector}),
+				newRulesfile(artifactOpts{name: "r1", generation: 1, selector: workerSelector}),
+			},
+			wantExpectedKeys: []string{"Rulesfile/falco/r1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s)
+			if !tt.omitNode {
+				builder = builder.WithObjects(newNode())
+			}
+			builder = builder.WithObjects(tt.objects...)
+			cl := builder.Build()
+			g := NewGate(cl, testNodeName, testNamespace)
+
+			err := g.MarkCacheSynced(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, g.cacheSynced.Load())
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, g.cacheSynced.Load())
+			assert.ElementsMatch(t, tt.wantExpectedKeys, keysOf(g.expected))
+		})
+	}
+}
+
+func TestGate_Check(t *testing.T) {
+	tests := []struct {
+		name            string
+		skipMarkSynced  bool
+		snapshot        []client.Object
+		marks           []mark
+		forgets         []forget
+		wantErr         bool
+		wantErrContains []string
+	}{
+		{
+			name:            "cache not synced returns error",
+			skipMarkSynced:  true,
+			wantErr:         true,
+			wantErrContains: []string{"cache not yet synced"},
+		},
+		{
+			name: "empty snapshot is ready immediately",
+		},
+		{
+			name: "snapshotted CR with no MarkReconciled is pending",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+			},
+			wantErr:         true,
+			wantErrContains: []string{"Plugin/falco/p1"},
+		},
+		{
+			name: "MarkReconciled with matching generation makes CR ready",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+			},
+			marks: []mark{{KindPlugin, testNamespace, "p1", 1}},
+		},
+		{
+			name: "MarkReconciled with higher generation than snapshot makes CR ready",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+			},
+			marks: []mark{{KindPlugin, testNamespace, "p1", 2}},
+		},
+		{
+			name: "MarkReconciled with lower generation than snapshot stays pending",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 5}),
+			},
+			marks:           []mark{{KindPlugin, testNamespace, "p1", 4}},
+			wantErr:         true,
+			wantErrContains: []string{"Plugin/falco/p1"},
+		},
+		{
+			name: "Forget drops a snapshotted CR from the expected set",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+				newRulesfile(artifactOpts{name: "r1", generation: 1}),
+			},
+			marks:   []mark{{KindRulesfile, testNamespace, "r1", 1}},
+			forgets: []forget{{KindPlugin, testNamespace, "p1"}},
+		},
+		{
+			name: "CR with Programmed=True but no local MarkReconciled is still pending",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1, progStatus: metav1.ConditionTrue, obsGen: 1}),
+			},
+			wantErr:         true,
+			wantErrContains: []string{"Plugin/falco/p1"},
+		},
+		{
+			name: "mixed kinds: pending entries are reported sorted",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+				newPlugin(artifactOpts{name: "p2", generation: 1}),
+				newRulesfile(artifactOpts{name: "r1", generation: 1}),
+				newConfig(artifactOpts{name: "c1", generation: 1}),
+			},
+			marks: []mark{
+				{KindPlugin, testNamespace, "p1", 1},
+				{KindRulesfile, testNamespace, "r1", 1},
+			},
+			wantErr: true,
+			wantErrContains: []string{
+				"Config/falco/c1",
+				"Plugin/falco/p2",
+			},
+		},
+		{
+			name: "all snapshotted CRs reconciled returns nil",
+			snapshot: []client.Object{
+				newPlugin(artifactOpts{name: "p1", generation: 1}),
+				newRulesfile(artifactOpts{name: "r1", generation: 2}),
+				newConfig(artifactOpts{name: "c1", generation: 3}),
+			},
+			marks: []mark{
+				{KindPlugin, testNamespace, "p1", 1},
+				{KindRulesfile, testNamespace, "r1", 2},
+				{KindConfig, testNamespace, "c1", 3},
+			},
+		},
+		{
+			name:  "MarkReconciled for a CR not in snapshot does not affect readiness",
+			marks: []mark{{KindPlugin, testNamespace, "stray", 7}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newScheme(t)
+			objects := append([]client.Object{newNode()}, tt.snapshot...)
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(objects...).Build()
+			g := NewGate(cl, testNodeName, testNamespace)
+
+			if !tt.skipMarkSynced {
+				require.NoError(t, g.MarkCacheSynced(context.Background()))
+			}
+			for _, m := range tt.marks {
+				g.MarkReconciled(m.kind, m.namespace, m.name, m.generation)
+			}
+			for _, f := range tt.forgets {
+				g.Forget(f.kind, f.namespace, f.name)
+			}
+
+			err := g.Check(newProbeRequest())
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, sub := range tt.wantErrContains {
+					assert.Contains(t, err.Error(), sub)
+				}
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestGate_MarkCacheSynced_ListErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		failKind    string
+		wantErrText string
+	}{
+		{name: "plugin list error surfaces", failKind: "Plugin", wantErrText: "listing plugins"},
+		{name: "rulesfile list error surfaces", failKind: "Rulesfile", wantErrText: "listing rulesfiles"},
+		{name: "config list error surfaces", failKind: "Config", wantErrText: "listing configs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injected := errors.New("injected list error")
+			intercept := interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					switch tt.failKind {
+					case "Plugin":
+						if _, ok := list.(*artifactv1alpha1.PluginList); ok {
+							return injected
+						}
+					case "Rulesfile":
+						if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+							return injected
+						}
+					case "Config":
+						if _, ok := list.(*artifactv1alpha1.ConfigList); ok {
+							return injected
+						}
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}
+
+			s := newScheme(t)
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(newNode()).
+				WithInterceptorFuncs(intercept).
+				Build()
+
+			g := NewGate(cl, testNodeName, testNamespace)
+			err := g.MarkCacheSynced(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrText)
+			assert.False(t, g.cacheSynced.Load())
+		})
+	}
+}
+
+func TestGate_MarkReconciled_MonotonicOnGeneration(t *testing.T) {
+	g := newGateReady(t, newPlugin(artifactOpts{name: "p1", generation: 5}))
+
+	g.MarkReconciled(KindPlugin, testNamespace, "p1", 7)
+	g.MarkReconciled(KindPlugin, testNamespace, "p1", 4)
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	assert.Equal(t, int64(7), g.processed[key(KindPlugin, testNamespace, "p1")])
+}
+
+type mark struct {
+	kind, namespace, name string
+	generation            int64
+}
+
+type forget struct {
+	kind, namespace, name string
+}
+
+func keysOf(m map[string]int64) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/pkg/startupgate/mock.go
+++ b/internal/pkg/startupgate/mock.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package startupgate
+
+// NoopGateRecorder is a Recorder that ignores every call.
+type NoopGateRecorder struct{}
+
+func (NoopGateRecorder) MarkReconciled(string, string, string, int64) {}
+func (NoopGateRecorder) Forget(string, string, string)                {}
+
+// FakeGateRecorder captures Recorder calls.
+type FakeGateRecorder struct {
+	Reconciled []FakeGateCall
+	Forgotten  []FakeGateCall
+}
+
+type FakeGateCall struct {
+	Kind, Namespace, Name string
+	Generation            int64
+}
+
+func (r *FakeGateRecorder) MarkReconciled(kind, namespace, name string, generation int64) {
+	r.Reconciled = append(r.Reconciled, FakeGateCall{Kind: kind, Namespace: namespace, Name: name, Generation: generation})
+}
+
+func (r *FakeGateRecorder) Forget(kind, namespace, name string) {
+	r.Forgotten = append(r.Forgotten, FakeGateCall{Kind: kind, Namespace: namespace, Name: name})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

/area artifact-operator

> /area chart

/area pkg

> /area api

> /area docs

**What this PR does / why we need it**:

Without a startupProbe, kubelet marks the artifact-operator native sidecar Started the moment it launches, so the Falco main container boots in parallel with the sidecar's first reconcile and races plugin `.so` / rules / config writes into the shared emptyDir volumes. The result is a startup loop with `LOAD_ERR_VALIDATE` errors and 1–2 container restarts on every fresh Falco pod.

This PR adds a process-local startup gate and a StartupProbe on the sidecar that points at it. The gate snapshots node-applicable Plugin/Rulesfile/Config CRs at boot and opens only after each one has had a real local reconcile attempt in this process — not after a cluster-wide `.status.conditions` flip, which can be stale from a previous pod's emptyDir.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #326 

**Special notes for your reviewer**:
