### PR TITLE
chore(chart): align chart release workflow

### DIFF
--- a/.github/workflows/helm-check.yml
+++ b/.github/workflows/helm-check.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
@@ -25,78 +27,22 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
 
-      - name: Verify Helm chart renders
-        run: |
-          helm lint chart/falco-operator
-          helm template falco-operator chart/falco-operator --namespace falco-operator --include-crds > /tmp/falco-operator.yaml
-
       - name: Verify chart README is in sync
-        run: |
-          go tool helm-docs -c ./chart/falco-operator -t ./README.gotmpl -o ./README.md
-          git diff --exit-code -- chart/falco-operator/README.md
+        run: make chart-docs-check
 
-      - name: Regenerate manifests into a temp directory
-        run: |
-          TMPDIR=$(mktemp -d)
-          echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
-          mkdir -p "$TMPDIR/crds" "$TMPDIR/files"
-          go tool controller-gen \
-            rbac:roleName=falco-operator-role \
-            crd:generateEmbeddedObjectMeta=true \
-            paths="./..." \
-            output:crd:artifacts:config="$TMPDIR/crds" \
-            output:rbac:stdout | sed -n '/^rules:/,$p' > "$TMPDIR/files/ClusterRole.yaml"
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
 
-      - name: Verify CRDs are in sync
-        run: |
-          echo "Checking chart/falco-operator/crds/ against freshly-generated CRDs..."
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
-          for crd in "$TMPDIR"/crds/*.yaml; do
-            filename=$(basename "$crd")
-            chart_crd="chart/falco-operator/crds/$filename"
+      - name: Run chart-testing lint
+        run: ct lint --config ct.yaml --charts chart/falco-operator
 
-            if [[ ! -f "$chart_crd" ]]; then
-              echo "Missing CRD in chart: $chart_crd"
-              echo "Run 'make manifests' and commit the result."
-              exit 1
-            fi
+      - name: Create KIND Cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
-            if ! diff -q "$crd" "$chart_crd" > /dev/null 2>&1; then
-              echo "CRD out of sync: $filename"
-              echo "Run 'make manifests' and commit the result."
-              diff "$crd" "$chart_crd" || true
-              exit 1
-            fi
-          done
-
-          for chart_crd in chart/falco-operator/crds/*.yaml; do
-            filename=$(basename "$chart_crd")
-            if [[ ! -f "$TMPDIR/crds/$filename" ]]; then
-              echo "Stale CRD in chart (no longer produced by controller-gen): $chart_crd"
-              echo "Run 'make manifests' and remove stale files."
-              exit 1
-            fi
-          done
-
-          echo "All CRDs are in sync"
-
-      - name: Verify RBAC is in sync
-        run: |
-          echo "Checking chart/falco-operator/files/ClusterRole.yaml against freshly-generated rules..."
-
-          chart_rules="chart/falco-operator/files/ClusterRole.yaml"
-
-          if [[ ! -f "$chart_rules" ]]; then
-            echo "Missing file: $chart_rules"
-            echo "Run 'make manifests' and commit the result."
-            exit 1
-          fi
-
-          if ! diff -q "$TMPDIR/files/ClusterRole.yaml" "$chart_rules" > /dev/null 2>&1; then
-            echo "RBAC rules are out of sync"
-            echo "Run 'make manifests' and commit the result."
-            diff "$TMPDIR/files/ClusterRole.yaml" "$chart_rules" || true
-            exit 1
-          fi
-
-          echo "RBAC is in sync"
+      - name: Run chart-testing install
+        run: ct install --exclude-deprecated --config ct.yaml --charts chart/falco-operator

--- a/.github/workflows/manifests-check.yml
+++ b/.github/workflows/manifests-check.yml
@@ -1,0 +1,89 @@
+name: Generated Manifests Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  manifests-check:
+    name: Verify Generated Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Regenerate manifests into a temp directory
+        run: |
+          TMPDIR=$(mktemp -d)
+          echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
+          mkdir -p "$TMPDIR/crds" "$TMPDIR/files"
+          go tool controller-gen \
+            rbac:roleName=falco-operator-role \
+            crd:generateEmbeddedObjectMeta=true \
+            paths="./..." \
+            output:crd:artifacts:config="$TMPDIR/crds" \
+            output:rbac:stdout | sed -n '/^rules:/,$p' > "$TMPDIR/files/ClusterRole.yaml"
+
+      - name: Verify CRDs are in sync
+        run: |
+          echo "Checking chart/falco-operator/crds/ against freshly-generated CRDs..."
+
+          for crd in "$TMPDIR"/crds/*.yaml; do
+            filename=$(basename "$crd")
+            chart_crd="chart/falco-operator/crds/$filename"
+
+            if [[ ! -f "$chart_crd" ]]; then
+              echo "Missing CRD in chart: $chart_crd"
+              echo "Run 'make manifests' and commit the result."
+              exit 1
+            fi
+
+            if ! diff -q "$crd" "$chart_crd" > /dev/null 2>&1; then
+              echo "CRD out of sync: $filename"
+              echo "Run 'make manifests' and commit the result."
+              diff "$crd" "$chart_crd" || true
+              exit 1
+            fi
+          done
+
+          for chart_crd in chart/falco-operator/crds/*.yaml; do
+            filename=$(basename "$chart_crd")
+            if [[ ! -f "$TMPDIR/crds/$filename" ]]; then
+              echo "Stale CRD in chart (no longer produced by controller-gen): $chart_crd"
+              echo "Run 'make manifests' and remove stale files."
+              exit 1
+            fi
+          done
+
+          echo "All CRDs are in sync"
+
+      - name: Verify RBAC is in sync
+        run: |
+          echo "Checking chart/falco-operator/files/ClusterRole.yaml against freshly-generated rules..."
+
+          chart_rules="chart/falco-operator/files/ClusterRole.yaml"
+
+          if [[ ! -f "$chart_rules" ]]; then
+            echo "Missing file: $chart_rules"
+            echo "Run 'make manifests' and commit the result."
+            exit 1
+          fi
+
+          if ! diff -q "$TMPDIR/files/ClusterRole.yaml" "$chart_rules" > /dev/null 2>&1; then
+            echo "RBAC rules are out of sync"
+            echo "Run 'make manifests' and commit the result."
+            diff "$TMPDIR/files/ClusterRole.yaml" "$chart_rules" || true
+            exit 1
+          fi
+
+          echo "RBAC is in sync"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 OPERATOR ?= instance
 PROJECT ?= github.com/falcosecurity/falco-operator
 ARTIFACT_OPERATOR_IMAGE ?= docker.io/falcosecurity/artifact-operator:latest
+HELM ?= helm
 HELM_DOCS ?= go tool helm-docs
+chart ?= chart/falco-operator
 
 # SED_INPLACE defines the sed in-place flag based on the OS.
 # macOS requires an empty string argument after -i, while Linux does not.
@@ -55,11 +57,22 @@ manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefin
 
 .PHONY: chart-docs
 chart-docs: ## Generate Helm chart README.
-	$(HELM_DOCS) -c ./chart/falco-operator -t ./README.gotmpl -o ./README.md
+	$(HELM_DOCS) -c ./$(chart) -t ./README.gotmpl -o ./README.md
 
 .PHONY: chart-docs-check
 chart-docs-check: chart-docs ## Verify Helm chart README is up to date.
-	git diff --exit-code -- chart/falco-operator/README.md
+	git diff --exit-code -- $(chart)/README.md
+
+.PHONY: chart-lint
+chart-lint: ## Lint the Helm chart.
+	$(HELM) lint $(chart)
+
+.PHONY: chart-template
+chart-template: ## Render the Helm chart.
+	$(HELM) template falco-operator $(chart) --namespace falco-operator --include-crds
+
+.PHONY: chart-check
+chart-check: chart-lint chart-template chart-docs-check ## Verify the Helm chart.
 
 .PHONY: generate
 generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/chart/falco-operator/CHANGELOG.md
+++ b/chart/falco-operator/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to the `falco-operator` Helm Chart. The
 release numbering uses [semantic versioning](http://semver.org).
 
+## Unreleased
+
+* Document Helm chart installation as a first-class installation method.
+
 ## v0.1.0
 
 ### Major Changes

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,9 @@
+remote: origin
+validate-maintainers: false
+check-version-increment: false
+target-branch: main
+chart-repos:
+  - falcosecurity=https://falcosecurity.github.io/charts
+helm-extra-args: --timeout 800s
+chart-dirs:
+  - chart

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -112,19 +112,16 @@ This generates `dist/install.yaml` via `helm template`, aggregating CRDs, RBAC, 
 
 ### Helm chart publishing and versioning
 
-The Helm chart source lives in [`../chart/falco-operator/`](../chart/falco-operator/). This repository is the source of truth for the chart content and release metadata, including [`../chart/falco-operator/Chart.yaml`](../chart/falco-operator/Chart.yaml), [`../chart/falco-operator/CHANGELOG.md`](../chart/falco-operator/CHANGELOG.md), [`../chart/falco-operator/README.gotmpl`](../chart/falco-operator/README.gotmpl), and the generated [`../chart/falco-operator/README.md`](../chart/falco-operator/README.md).
+The Helm chart source lives in [`../chart/falco-operator/`](../chart/falco-operator/). Published Falco Helm charts live in [`falcosecurity/charts`](https://github.com/falcosecurity/charts), and Falco infrastructure syncs this chart there only when the chart version is bumped.
 
-Published Falco Helm charts live in the [`falcosecurity/charts`](https://github.com/falcosecurity/charts) repository, so the Falco Operator chart is published by syncing this source chart into `falcosecurity/charts/charts/falco-operator` and merging a chart-release PR there.
+Open Falco Operator chart issues and PRs in this repository; `falcosecurity/charts` receives the generated sync PR.
 
-PRs that change chart templates, values, CRDs, RBAC, or the operator application version rendered by the chart must update the chart release metadata in this repository before they are synced to `falcosecurity/charts`.
+- Regular chart PRs: do not bump [`../chart/falco-operator/Chart.yaml`](../chart/falco-operator/Chart.yaml); add the change under `## Unreleased` in [`../chart/falco-operator/CHANGELOG.md`](../chart/falco-operator/CHANGELOG.md).
+- Chart release PRs: use `/kind chart-release`, bump [`../chart/falco-operator/Chart.yaml`](../chart/falco-operator/Chart.yaml), and move the selected `## Unreleased` entries into the new version section. Entries not included in that release can stay under `## Unreleased`.
 
-Use SemVer for `Chart.yaml` `version`: major for breaking changes to chart values, rendered resources, or upgrade behavior; minor for backward-compatible chart features; patch for backward-compatible fixes or metadata changes. Set `Chart.yaml` `appVersion` to the Falco Operator application version rendered by the chart.
+Use SemVer for `Chart.yaml` `version`: major for breaking changes, minor for backward-compatible chart features, patch for fixes or metadata changes. Set `appVersion` to the Falco Operator version rendered by the chart when preparing a chart release.
 
-Run `make chart-docs` after changing chart values or chart documentation, and update [`../chart/falco-operator/CHANGELOG.md`](../chart/falco-operator/CHANGELOG.md) when preparing a chart release.
-
-Chart releases are authored as **release PRs in this source repository**: a release PR bumps [`../chart/falco-operator/Chart.yaml`](../chart/falco-operator/Chart.yaml), updates [`../chart/falco-operator/CHANGELOG.md`](../chart/falco-operator/CHANGELOG.md), and carries the `/kind chart-release` label. Normal chart changes and version bumps must not be authored directly in `falcosecurity/charts`.
-
-The cross-repository sync to `falcosecurity/charts` belongs to Falco infrastructure, not to this repository. A Prow job in [`falcosecurity/test-infra`](https://github.com/falcosecurity/test-infra), running as the Falco project automation bot, opens or updates the corresponding sync PR (titled `sync(charts/falco-operator): v<version>`) in `falcosecurity/charts` when [`../chart/falco-operator/`](../chart/falco-operator/) changes. That sync PR is the publication gate: merging it on `falcosecurity/charts` publishes the chart.
+Run `make chart-docs` after changing chart values or chart documentation. Normal chart changes and version bumps must not be authored directly in `falcosecurity/charts`.
 
 ## Code Generation
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

/kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

/area chart

> /area pkg

> /area api

/area docs

**What this PR does / why we need it**:

Aligns the operator chart with the source-managed chart workflow.

This PR:

- documents how chart changes and chart release PRs are handled from this source repo;
- adds the `Unreleased` changelog section used before a chart release is prepared;
- adds chart-testing configuration with version increment checks disabled for normal chart PRs;
- keeps chart validation in the Helm workflow;
- moves the generated manifest checks into their own workflow without changing their logic.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
