### PR TITLE
fix(artifact): repull OCI artifacts on source changes

### DIFF
--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -37,13 +37,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/priority"
 	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
 )
@@ -168,8 +171,36 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 func (r *PluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&artifactv1alpha1.Plugin{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.findPluginsForSecret),
+		).
 		Named("artifact-plugin").
 		Complete(r)
+}
+
+// findPluginsForSecret finds all Plugins that reference a given Secret using the index.
+func (r *PluginReconciler) findPluginsForSecret(ctx context.Context, secret client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	pluginList := &artifactv1alpha1.PluginList{}
+
+	indexKey := secret.GetNamespace() + "/" + secret.GetName()
+	if err := r.List(ctx, pluginList, client.MatchingFields{index.SecretOnPlugin: indexKey}); err != nil {
+		logger.Error(err, "unable to list Plugins by Secret index")
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, len(pluginList.Items))
+	for i := range pluginList.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      pluginList.Items[i].Name,
+				Namespace: pluginList.Items[i].Namespace,
+			},
+		}
+	}
+
+	return requests
 }
 
 // ensureFinalizers ensures that the finalizer is set on the Plugin instance.

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 	"github.com/falcosecurity/falco-operator/internal/pkg/priority"
 	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
@@ -1729,4 +1730,82 @@ func TestPatchStatus(t *testing.T) {
 	testutil.RequireConditions(t, obj.Status.Conditions, []testutil.ConditionExpect{
 		{Type: commonv1alpha1.ConditionReconciled.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonReconciled},
 	})
+}
+
+func TestFindPluginsForSecret(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
+	pl := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPluginName,
+			Namespace: testutil.TestNamespace,
+		},
+		Spec: artifactv1alpha1.PluginSpec{
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "ghcr.io/repo", Tag: "latest"},
+				Registry: &commonv1alpha1.RegistryConfig{
+					Auth: &commonv1alpha1.RegistryAuth{
+						SecretRef: &commonv1alpha1.SecretRef{Name: "my-pull-secret"},
+					},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(pl).
+		WithIndex(&artifactv1alpha1.Plugin{}, index.SecretOnPlugin, index.PluginBySecretRef).
+		Build()
+
+	mockFS := filesystem.NewMockFileSystem()
+	am := artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+		artifact.WithFS(mockFS),
+		artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+	)
+
+	r := &PluginReconciler{
+		Client:          cl,
+		Scheme:          s,
+		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
+		finalizer:       testFinalizerName(),
+		artifactManager: am,
+		PluginsConfig:   &PluginsConfig{},
+		nodeName:        testutil.TestNodeName,
+		crToConfigName:  make(map[string]string),
+	}
+
+	tests := []struct {
+		name       string
+		secretName string
+		wantCount  int
+	}{
+		{
+			name:       "matching secret returns plugin requests",
+			secretName: "my-pull-secret",
+			wantCount:  1,
+		},
+		{
+			name:       "non-matching secret returns empty",
+			secretName: "other-secret",
+			wantCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.secretName,
+					Namespace: testutil.TestNamespace,
+				},
+			}
+			requests := r.findPluginsForSecret(context.Background(), secret)
+			require.Len(t, requests, tt.wantCount)
+			if tt.wantCount > 0 {
+				assert.Equal(t, testPluginName, requests[0].Name)
+				assert.Equal(t, testutil.TestNamespace, requests[0].Namespace)
+			}
+		})
+	}
 }

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -158,6 +158,10 @@ func (r *RulesfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findRulesfilesForConfigMap),
 		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.findRulesfilesForSecret),
+		).
 		Named("artifact-rulesfile").
 		Complete(r)
 }
@@ -170,6 +174,30 @@ func (r *RulesfileReconciler) findRulesfilesForConfigMap(ctx context.Context, co
 	indexKey := configMap.GetNamespace() + "/" + configMap.GetName()
 	if err := r.List(ctx, rulesfileList, client.MatchingFields{index.ConfigMapOnRulesfile: indexKey}); err != nil {
 		logger.Error(err, "unable to list Rulesfiles by ConfigMap index")
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, len(rulesfileList.Items))
+	for i := range rulesfileList.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name:      rulesfileList.Items[i].Name,
+				Namespace: rulesfileList.Items[i].Namespace,
+			},
+		}
+	}
+
+	return requests
+}
+
+// findRulesfilesForSecret finds all Rulesfiles that reference a given Secret using the index.
+func (r *RulesfileReconciler) findRulesfilesForSecret(ctx context.Context, secret client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	rulesfileList := &artifactv1alpha1.RulesfileList{}
+
+	indexKey := secret.GetNamespace() + "/" + secret.GetName()
+	if err := r.List(ctx, rulesfileList, client.MatchingFields{index.SecretOnRulesfile: indexKey}); err != nil {
+		logger.Error(err, "unable to list Rulesfiles by Secret index")
 		return []reconcile.Request{}
 	}
 

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -624,7 +624,7 @@ func TestEnsureRulesfile(t *testing.T) {
 		writeErr error
 		pullErr  error
 		// useRealFS uses a real OS filesystem backed by a temp dir instead of the mock FS.
-		// Required for test cases that exercise the full OCI pull path (ExtractTarGz uses os.* directly).
+		// Required for test cases that assert the OCI file lifecycle on disk.
 		useRealFS      bool
 		wantErr        bool
 		wantConditions []testutil.ConditionExpect
@@ -865,7 +865,7 @@ func TestEnsureRulesfile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: testRulesfileName, Namespace: testutil.TestNamespace},
 				Spec:       artifactv1alpha1.RulesfileSpec{},
 			},
-			// ExtractTarGz uses os.* directly, so the full OCI path needs a real FS with an injectable dir.
+			// This case asserts the previous OCI file is removed from disk.
 			useRealFS: true,
 			wantConditions: []testutil.ConditionExpect{
 				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionTrue, Reason: artifact.ReasonProgrammed},
@@ -884,16 +884,18 @@ func TestEnsureRulesfile(t *testing.T) {
 			var tmpDir string
 
 			if tt.useRealFS {
-				// ExtractTarGz calls os.* directly, so tests that exercise the full
-				// OCI pull-and-extract path need a real FS backed by a temp directory.
+				// The full OCI pull-and-extract path writes to disk via the manager: use a real
+				// filesystem rooted at a temp directory so each test gets an isolated rules.d.
 				realFS := filesystem.NewOSFileSystem()
 				tmpDir = t.TempDir()
+				layer, layerErr := puller.MakeTarGz("rules.yaml", []byte("fake-rules-content"))
+				require.NoError(t, layerErr)
 				managerOpts = append(managerOpts,
 					artifact.WithFS(realFS),
 					artifact.WithRulesfileDir(tmpDir),
 					artifact.WithOCIPuller(&puller.MockOCIPuller{
-						Result: &puller.RegistryResult{Filename: "falco-rules.tar.gz"},
-						FS:     realFS,
+						Result:       &puller.RegistryResult{Filename: "falco-rules.tar.gz", Type: puller.Rulesfile},
+						LayerContent: layer,
 					}),
 				)
 			} else {

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -1181,6 +1181,83 @@ func TestPatchStatus(t *testing.T) {
 	})
 }
 
+func TestFindRulesfilesForSecret(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
+	rf := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRulesfileName,
+			Namespace: testutil.TestNamespace,
+		},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "ghcr.io/repo", Tag: "latest"},
+				Registry: &commonv1alpha1.RegistryConfig{
+					Auth: &commonv1alpha1.RegistryAuth{
+						SecretRef: &commonv1alpha1.SecretRef{Name: "my-pull-secret"},
+					},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithIndex(&artifactv1alpha1.Rulesfile{}, index.SecretOnRulesfile, index.RulesfileBySecretRef).
+		Build()
+
+	mockFS := filesystem.NewMockFileSystem()
+	am := artifact.NewManagerWithOptions(cl, testutil.TestNamespace,
+		artifact.WithFS(mockFS),
+		artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+	)
+
+	r := &RulesfileReconciler{
+		Client:          cl,
+		Scheme:          s,
+		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
+		finalizer:       testFinalizerName(),
+		artifactManager: am,
+		nodeName:        testutil.TestNodeName,
+		namespace:       testutil.TestNamespace,
+	}
+
+	tests := []struct {
+		name       string
+		secretName string
+		wantCount  int
+	}{
+		{
+			name:       "matching secret returns rulesfile requests",
+			secretName: "my-pull-secret",
+			wantCount:  1,
+		},
+		{
+			name:       "non-matching secret returns empty",
+			secretName: "other-secret",
+			wantCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.secretName,
+					Namespace: testutil.TestNamespace,
+				},
+			}
+			requests := r.findRulesfilesForSecret(context.Background(), secret)
+			require.Len(t, requests, tt.wantCount)
+			if tt.wantCount > 0 {
+				assert.Equal(t, testRulesfileName, requests[0].Name)
+				assert.Equal(t, testutil.TestNamespace, requests[0].Namespace)
+			}
+		})
+	}
+}
+
 func TestFindRulesfilesForConfigMap(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme)
 	rf := &artifactv1alpha1.Rulesfile{

--- a/docs/crds/plugin.md
+++ b/docs/crds/plugin.md
@@ -97,3 +97,4 @@ spec:
 - When `config.name` is not specified, the operator derives it from the OCI artifact metadata.
 - The operator manages plugin configuration entries in the shared Falco config automatically.
 - The operator adds a finalizer to referenced Secrets to prevent accidental deletion.
+- OCI artifacts are re-pulled when any of `image.repository`, `image.tag`, `registry.name`, `registry.plainHTTP`, `registry.tls.insecureSkipVerify`, `registry.auth.secretRef.name`, or the referenced auth Secret data changes. Pin `image.tag` to a digest (`sha256:...`) for strict GitOps: a mutable tag whose content moves on the registry is not detected until the spec changes or the pod restarts.

--- a/docs/crds/rulesfile.md
+++ b/docs/crds/rulesfile.md
@@ -154,3 +154,4 @@ spec:
 - When combining multiple sources (OCI + inline + ConfigMap), each source gets a sub-priority within the main priority.
 - The ConfigMap must contain a key named `rules.yaml` with the rules content.
 - The operator adds a finalizer to referenced ConfigMaps to prevent accidental deletion.
+- OCI artifacts are re-pulled when any of `image.repository`, `image.tag`, `registry.name`, `registry.plainHTTP`, `registry.tls.insecureSkipVerify`, `registry.auth.secretRef.name`, or the referenced auth Secret data changes. Pin `image.tag` to a digest (`sha256:...`) for strict GitOps: a mutable tag whose content moves on the registry is not detected until the spec changes or the pod restarts.

--- a/internal/pkg/artifact/manager.go
+++ b/internal/pkg/artifact/manager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"runtime"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
-	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/credentials"
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 	"github.com/falcosecurity/falco-operator/internal/pkg/mounts"
@@ -284,117 +282,80 @@ func (am *Manager) StoreFromOCI(ctx context.Context, name string, artifactPriori
 		}
 		return StoreActionNone, nil
 	}
-	newFile := File{
-		Path:     am.Path(name, artifactPriority, MediumOCI, artifactType),
-		Medium:   MediumOCI,
-		Priority: artifactPriority,
+
+	secretRef := authSecretRef(artifact)
+
+	authSecret, err := am.fetchOCIAuthSecret(ctx, secretRef)
+	if err != nil {
+		logger.Error(err, "unable to fetch auth secret for the OCI artifact", "authSecretRef", secretRef)
+		return StoreActionNone, err
+	}
+	creds, err := credentials.FromSecret(ResolveRegistryHost(artifact), authSecret)
+	if err != nil {
+		logger.Error(err, "unable to derive credentials for the OCI artifact", "authSecretRef", secretRef)
+		return StoreActionNone, err
 	}
 
-	// Check if the artifact is already stored.
-	if file := am.getArtifactFile(name, MediumOCI); file != nil {
-		logger.V(4).Info("Artifact already stored", "artifact", file)
-		// Check if the file already exists on the filesystem.
-		ok, err := am.fs.Exists(file.Path)
-		if err != nil {
-			logger.Error(err, "Failed to check if file exists", "file", file.Path)
-			return StoreActionNone, err
-		}
-		// If the file exists and the priority has changed, we rename the file reflecting the new priority.
-		if ok && file.Priority != artifactPriority {
+	newFile := File{
+		Path:            am.Path(name, artifactPriority, MediumOCI, artifactType),
+		Medium:          MediumOCI,
+		Priority:        artifactPriority,
+		SourceSignature: computeOCISourceSignature(artifact, authSecret),
+	}
+
+	oldFile, err := am.getCurrentOCIFile(ctx, name)
+	if err != nil {
+		logger.Error(err, "Failed to get current OCI file", "name", name)
+		return StoreActionNone, err
+	}
+
+	if oldFile != nil {
+		if oldFile.SourceSignature == newFile.SourceSignature {
+			if oldFile.Priority == artifactPriority {
+				return StoreActionUnchanged, nil
+			}
 			logger.Info("Renaming artifact file due to priority change",
-				"oldPriority", file.Priority, "newPriority", artifactPriority, "oldFile", file.Path, "newFile", newFile.Path)
-			if err := am.fs.Rename(file.Path, newFile.Path); err != nil {
-				logger.Error(err, "Failed to rename file", "oldFile", file.Path, "newFile", newFile.Path)
+				"oldPriority", oldFile.Priority, "newPriority", artifactPriority,
+				"oldFile", oldFile.Path, "newFile", newFile.Path)
+			if err := am.fs.Rename(oldFile.Path, newFile.Path); err != nil {
+				logger.Error(err, "Failed to rename file", "oldFile", oldFile.Path, "newFile", newFile.Path)
 				return StoreActionNone, err
 			}
 			am.removeArtifactFile(name, MediumOCI)
 			am.addArtifactFile(name, newFile)
 			return StoreActionPriorityChanged, nil
 		}
-		// If the file does not exist on the filesystem, we remove it from the manager and return an error.
-		// Next time the artifact is requested, it will be fetched from the OCI registry.
-		if !ok {
-			am.removeArtifactFile(name, MediumOCI)
-			err := fmt.Errorf("artifact %q not found on filesystem", file.Path)
-			logger.Error(err, "Failed to find file on filesystem", "file", newFile.Path)
-			return StoreActionNone, err
-		}
-
-		return StoreActionUnchanged, nil
+		logger.Info("OCI source signature changed, re-pulling artifact",
+			"name", name, "oldFile", oldFile.Path, "newFile", newFile.Path)
 	}
-
-	var dstDir string
-	switch artifactType {
-	case TypeRulesfile:
-		dstDir = am.rulesfileDir
-	case TypePlugin:
-		dstDir = mounts.PluginDirPath
-	default:
-		dstDir = ""
-	}
-
-	// Resolve auth credentials.
-	var authSecretRef *commonv1alpha1.SecretRef
-	if artifact.Registry != nil && artifact.Registry.Auth != nil {
-		authSecretRef = artifact.Registry.Auth.SecretRef
-	}
-
-	logger.V(4).Info("Getting credentials from auth secret ref", "authSecretRef", authSecretRef)
-	creds, err := credentials.GetCredentialsFromSecret(ctx, am.client, am.namespace, authSecretRef)
-	if err != nil {
-		logger.Error(err, "unable to get credentials for the OCI artifact", "authSecretRef", authSecretRef)
-		return StoreActionNone, err
-	}
-
-	// Resolve registry TLS options.
-	registryOpts := ResolveRegistryOptions(artifact)
 
 	ref := ResolveReference(artifact)
 	logger.Info("Pulling OCI artifact", "reference", ref)
-	res, err := am.ociPuller.Pull(ctx, ref, dstDir, runtime.GOOS, runtime.GOARCH, creds, registryOpts)
+
+	payload, err := am.pullOCIFile(ctx, ref, artifactType, artifact, creds)
 	if err != nil {
 		logger.Error(err, "unable to pull artifact", "reference", ref)
 		return StoreActionNone, err
 	}
-	if res == nil {
-		return StoreActionNone, fmt.Errorf("puller returned nil result for reference %q", ref)
-	}
 
-	archiveFile := filepath.Clean(filepath.Join(dstDir, res.Filename))
-
-	// Extract the rulesfile from the archive.
-	f, err := am.fs.Open(archiveFile)
-	if err != nil {
+	if err := am.installOCIFile(ctx, newFile.Path, payload); err != nil {
+		logger.Error(err, "unable to install OCI artifact file", "file", newFile.Path)
 		return StoreActionNone, err
 	}
+	logger.Info("OCI artifact saved", "artifact", newFile.Path, "reference", ref)
 
-	logger.V(4).Info("Extracting OCI artifact", "archive", archiveFile)
-
-	// Extract artifact and move it to its destination directory
-	files, err := common.ExtractTarGz(ctx, f, dstDir, 0)
-	if err != nil {
-		logger.Error(err, "unable to extract OCI artifact", "filename", archiveFile)
-		return StoreActionNone, err
+	if oldFile == nil {
+		am.addArtifactFile(name, newFile)
+		return StoreActionAdded, nil
 	}
 
-	// Clean up the archive.
-	if err = am.fs.Remove(archiveFile); err != nil {
-		logger.Error(err, "unable to remove OCI artifact", "filename", archiveFile)
+	if err := am.removeReplacedOCIFile(ctx, oldFile, newFile.Path); err != nil {
+		logger.Error(err, "unable to remove replaced OCI file", "file", oldFile.Path)
 		return StoreActionNone, err
 	}
-
-	logger.V(4).Info("Writing OCI artifact", "filename", newFile.Path)
-	// Rename the artifact to the generated name.
-	if err = am.fs.Rename(files[0], newFile.Path); err != nil {
-		logger.Error(err, "unable to rename artifact", "source", files[0], "destination", newFile.Path)
-		return StoreActionNone, err
-	}
-	logger.Info("OCI artifact downloaded and saved", "artifact", newFile.Path)
-
-	// Add the artifact to the manager.
-	am.files[name] = append(am.files[name], newFile)
-
-	return StoreActionAdded, nil
+	am.removeArtifactFile(name, MediumOCI)
+	am.addArtifactFile(name, newFile)
+	return StoreActionUpdated, nil
 }
 
 // StoreFromConfigMap stores an artifact from a ConfigMap to the local filesystem.

--- a/internal/pkg/artifact/manager_test.go
+++ b/internal/pkg/artifact/manager_test.go
@@ -19,6 +19,7 @@ package artifact
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
-	"oras.land/oras-go/v2/registry/remote/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1246,6 +1246,13 @@ func TestStoreFromOCI(t *testing.T) {
 		Tag:        "latest",
 	}
 
+	validLayer := func(t *testing.T) []byte {
+		t.Helper()
+		data, err := puller.MakeTarGz("rules.yaml", []byte("fake-rules-content"))
+		require.NoError(t, err)
+		return data
+	}
+
 	tests := []struct {
 		name            string
 		artifact        *commonv1alpha1.OCIArtifact
@@ -1254,22 +1261,22 @@ func TestStoreFromOCI(t *testing.T) {
 		artifactType    Type
 		existingFile    *File
 		existingData    string
+		layerContent    func(t *testing.T) []byte
 		pullerResult    *puller.RegistryResult
 		pullerErr       error
-		archiveContent  []byte
-		useRealFS       bool
-		customPuller    puller.Puller
+		allowNilResult  bool
 		fsRenameErr     error
 		fsRemoveErr     error
 		fsStatErr       error
-		fsOpenErr       error
+		fsWriteErr      error
 		wantErr         bool
 		wantErrMsg      string
 		wantPullCalls   int
+		wantWriteCalls  int
 		wantRenameCalls int
 		wantRemoveCalls int
-		wantFilesLen    int
 		wantFile        *File
+		wantFileContent string
 		wantOpts        *puller.RegistryOptions
 		wantAction      StoreAction
 	}{
@@ -1281,20 +1288,13 @@ func TestStoreFromOCI(t *testing.T) {
 				Medium:   MediumOCI,
 				Priority: 50,
 			},
-			wantErr:         false,
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
 			wantRemoveCalls: 1,
 			wantAction:      StoreActionRemoved,
 		},
 		{
-			name:            "does nothing when artifact is nil and no existing file",
-			artifact:        nil,
-			wantErr:         false,
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
+			name:       "does nothing when artifact is nil and no existing file",
+			artifact:   nil,
+			wantAction: StoreActionNone,
 		},
 		{
 			name: "returns error when artifact already stored but file not found on filesystem",
@@ -1308,51 +1308,43 @@ func TestStoreFromOCI(t *testing.T) {
 				Medium:   MediumOCI,
 				Priority: 50,
 			},
-			wantErr:         true,
-			wantErrMsg:      "not found on filesystem",
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
+			wantErr:    true,
+			wantErrMsg: "not found on filesystem",
+			wantAction: StoreActionNone,
 		},
 		{
-			name: "renames file when priority changes",
+			name: "renames file when only priority changes",
 			artifact: &commonv1alpha1.OCIArtifact{
 				Image: testImage,
 			},
 			priority:     60,
 			artifactType: TypeRulesfile,
 			existingFile: &File{
-				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
-				Medium:   MediumOCI,
-				Priority: 50,
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
 			},
 			existingData:    "existing content",
-			wantErr:         false,
-			wantPullCalls:   0,
 			wantRenameCalls: 1,
-			wantRemoveCalls: 0,
 			wantFile:        &File{Path: "/etc/falco/rules.d/60-01-test-artifact-oci.yaml", Medium: MediumOCI, Priority: 60},
 			wantAction:      StoreActionPriorityChanged,
 		},
 		{
-			name: "skips pull when file already exists with same priority",
+			name: "skips pull when file already exists with same signature and priority",
 			artifact: &commonv1alpha1.OCIArtifact{
 				Image: testImage,
 			},
 			priority:     50,
 			artifactType: TypeRulesfile,
 			existingFile: &File{
-				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
-				Medium:   MediumOCI,
-				Priority: 50,
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
 			},
-			existingData:    "existing content",
-			wantErr:         false,
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionUnchanged,
+			existingData: "existing content",
+			wantAction:   StoreActionUnchanged,
 		},
 		{
 			name: "returns error when credentials getter fails",
@@ -1364,123 +1356,88 @@ func TestStoreFromOCI(t *testing.T) {
 					},
 				},
 			},
-			priority:        50,
-			artifactType:    TypeRulesfile,
-			wantErr:         true,
-			wantErrMsg:      "failed to get pull secret",
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
+			priority:     50,
+			artifactType: TypeRulesfile,
+			wantErr:      true,
+			wantErrMsg:   "failed to get pull secret",
+			wantAction:   StoreActionNone,
 		},
 		{
 			name: "returns error when puller fails",
 			artifact: &commonv1alpha1.OCIArtifact{
 				Image: testImage,
 			},
+			priority:      50,
+			artifactType:  TypeRulesfile,
+			pullerErr:     fmt.Errorf("registry unavailable"),
+			wantErr:       true,
+			wantErrMsg:    "registry unavailable",
+			wantPullCalls: 1,
+			wantAction:    StoreActionNone,
+		},
+		{
+			name:           "puller returns nil result",
+			artifact:       &commonv1alpha1.OCIArtifact{Image: testImage},
+			priority:       50,
+			artifactType:   TypeRulesfile,
+			allowNilResult: true,
+			wantErr:        true,
+			wantErrMsg:     "nil result",
+			wantPullCalls:  1,
+			wantAction:     StoreActionNone,
+		},
+		{
+			name:          "returns error when layer content is not a valid gzip",
+			artifact:      &commonv1alpha1.OCIArtifact{Image: testImage},
+			priority:      50,
+			artifactType:  TypeRulesfile,
+			pullerResult:  &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:  func(t *testing.T) []byte { return []byte("not-a-valid-gzip") },
+			wantErr:       true,
+			wantPullCalls: 1,
+			wantAction:    StoreActionNone,
+		},
+		{
+			name:          "returns error when pulled artifact type does not match resource type",
+			artifact:      &commonv1alpha1.OCIArtifact{Image: testImage},
+			priority:      50,
+			artifactType:  TypeRulesfile,
+			pullerResult:  &puller.RegistryResult{Filename: "plugin.tar.gz", Type: puller.Plugin},
+			layerContent:  validLayer,
+			wantErr:       true,
+			wantErrMsg:    "does not match expected type",
+			wantPullCalls: 1,
+			wantAction:    StoreActionNone,
+		},
+		{
+			name:            "returns error when WriteFile fails on tmp",
+			artifact:        &commonv1alpha1.OCIArtifact{Image: testImage},
 			priority:        50,
 			artifactType:    TypeRulesfile,
-			pullerErr:       fmt.Errorf("registry unavailable"),
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			fsWriteErr:      fmt.Errorf("disk full"),
 			wantErr:         true,
-			wantErrMsg:      "registry unavailable",
+			wantErrMsg:      "disk full",
 			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
+			wantWriteCalls:  1,
+			wantRemoveCalls: 1,
 			wantAction:      StoreActionNone,
 		},
 		{
-			name: "returns error when rename fails during priority change",
-			artifact: &commonv1alpha1.OCIArtifact{
-				Image: testImage,
-			},
-			priority:     60,
-			artifactType: TypeRulesfile,
-			existingFile: &File{
-				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
-				Medium:   MediumOCI,
-				Priority: 50,
-			},
-			existingData:    "existing content",
-			fsRenameErr:     fmt.Errorf("permission denied"),
+			name:            "returns error when Rename of tmp to final path fails",
+			artifact:        &commonv1alpha1.OCIArtifact{Image: testImage},
+			priority:        50,
+			artifactType:    TypeRulesfile,
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			fsRenameErr:     fmt.Errorf("rename failed"),
 			wantErr:         true,
-			wantErrMsg:      "permission denied",
-			wantPullCalls:   0,
+			wantErrMsg:      "rename failed",
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
 			wantRenameCalls: 1,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
-		},
-		{
-			name: "returns error when Exists check fails",
-			artifact: &commonv1alpha1.OCIArtifact{
-				Image: testImage,
-			},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			existingFile: &File{
-				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
-				Medium:   MediumOCI,
-				Priority: 50,
-			},
-			fsStatErr:       fmt.Errorf("permission denied"),
-			wantErr:         true,
-			wantErrMsg:      "permission denied",
-			wantPullCalls:   0,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
-		},
-		{
-			name: "returns error when Open fails after successful pull",
-			artifact: &commonv1alpha1.OCIArtifact{
-				Image: testImage,
-			},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			pullerResult: &puller.RegistryResult{
-				Filename: "rules.tar.gz",
-			},
-			fsOpenErr:       fmt.Errorf("cannot open archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot open archive",
-			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
-		},
-		{
-			name: "uses plugin directory for plugin artifact type",
-			artifact: &commonv1alpha1.OCIArtifact{
-				Image: testImage,
-			},
-			priority:     50,
-			artifactType: TypePlugin,
-			pullerResult: &puller.RegistryResult{
-				Filename: "plugin.tar.gz",
-			},
-			fsOpenErr:       fmt.Errorf("cannot open archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot open archive",
-			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantAction:      StoreActionNone,
-		},
-		{
-			name: "uses empty directory for unknown artifact type",
-			artifact: &commonv1alpha1.OCIArtifact{
-				Image: testImage,
-			},
-			priority:     50,
-			artifactType: Type("unknown"),
-			pullerResult: &puller.RegistryResult{
-				Filename: "artifact.tar.gz",
-			},
-			fsOpenErr:       fmt.Errorf("cannot open archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot open archive",
-			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
+			wantRemoveCalls: 1,
 			wantAction:      StoreActionNone,
 		},
 		{
@@ -1491,105 +1448,46 @@ func TestStoreFromOCI(t *testing.T) {
 					PlainHTTP: new(true),
 				},
 			},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			pullerResult: &puller.RegistryResult{
-				Filename: "rules.tar.gz",
-			},
-			fsOpenErr:       fmt.Errorf("cannot open archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot open archive",
+			priority:        50,
+			artifactType:    TypeRulesfile,
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
 			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
 			wantOpts:        &puller.RegistryOptions{PlainHTTP: true},
-			wantAction:      StoreActionNone,
+			wantAction:      StoreActionAdded,
 		},
 		{
 			name: "passes TLS insecureSkipVerify option to puller",
 			artifact: &commonv1alpha1.OCIArtifact{
 				Image: testImage,
 				Registry: &commonv1alpha1.RegistryConfig{
-					TLS: &commonv1alpha1.TLSConfig{
-						InsecureSkipVerify: true,
-					},
+					TLS: &commonv1alpha1.TLSConfig{InsecureSkipVerify: true},
 				},
 			},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			pullerResult: &puller.RegistryResult{
-				Filename: "rules.tar.gz",
-			},
-			fsOpenErr:       fmt.Errorf("cannot open archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot open archive",
+			priority:        50,
+			artifactType:    TypeRulesfile,
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
 			wantPullCalls:   1,
-			wantRenameCalls: 0,
-			wantRemoveCalls: 0,
-			wantOpts:        &puller.RegistryOptions{InsecureSkipVerify: true},
-			wantAction:      StoreActionNone,
-		},
-		{
-			name:         "puller returns nil result",
-			artifact:     &commonv1alpha1.OCIArtifact{Image: testImage},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			customPuller: nilResultPuller{},
-			wantErr:      true,
-			wantErrMsg:   "nil result",
-			wantAction:   StoreActionNone,
-		},
-		{
-			name:         "successfully pulls, extracts and stores artifact",
-			artifact:     &commonv1alpha1.OCIArtifact{Image: testImage},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			useRealFS:    true,
-			wantFilesLen: 1,
-			wantAction:   StoreActionAdded,
-		},
-		{
-			name:           "returns error when ExtractTarGz fails due to invalid archive content",
-			artifact:       &commonv1alpha1.OCIArtifact{Image: testImage},
-			priority:       50,
-			artifactType:   TypeRulesfile,
-			archiveContent: []byte("not-a-valid-gzip"),
-			wantErr:        true,
-			wantPullCalls:  1,
-			wantAction:     StoreActionNone,
-		},
-		{
-			name:         "returns error when Remove of archive fails after successful extraction",
-			artifact:     &commonv1alpha1.OCIArtifact{Image: testImage},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			archiveContent: func() []byte {
-				data, _ := puller.MakeTarGz("rules.yaml", []byte("fake"))
-				return data
-			}(),
-			fsRemoveErr:     fmt.Errorf("cannot remove archive"),
-			wantErr:         true,
-			wantErrMsg:      "cannot remove archive",
-			wantPullCalls:   1,
-			wantRemoveCalls: 1,
-			wantAction:      StoreActionNone,
-		},
-		{
-			name:         "returns error when Rename fails after successful extraction",
-			artifact:     &commonv1alpha1.OCIArtifact{Image: testImage},
-			priority:     50,
-			artifactType: TypeRulesfile,
-			archiveContent: func() []byte {
-				data, _ := puller.MakeTarGz("rules.yaml", []byte("fake"))
-				return data
-			}(),
-			fsRenameErr:     fmt.Errorf("cannot rename file"),
-			wantErr:         true,
-			wantErrMsg:      "cannot rename file",
-			wantPullCalls:   1,
-			wantRemoveCalls: 1,
+			wantWriteCalls:  1,
 			wantRenameCalls: 1,
-			wantAction:      StoreActionNone,
+			wantOpts:        &puller.RegistryOptions{InsecureSkipVerify: true},
+			wantAction:      StoreActionAdded,
+		},
+		{
+			name:            "successfully pulls, extracts and stores artifact",
+			artifact:        &commonv1alpha1.OCIArtifact{Image: testImage},
+			priority:        50,
+			artifactType:    TypeRulesfile,
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantFileContent: "fake-rules-content",
+			wantAction:      StoreActionAdded,
 		},
 		{
 			name:     "returns error when removeArtifact fails on nil artifact",
@@ -1604,6 +1502,224 @@ func TestStoreFromOCI(t *testing.T) {
 			wantErrMsg:      "remove failed",
 			wantRemoveCalls: 1,
 			wantAction:      StoreActionNone,
+		},
+		{
+			name: "re-pulls when OCI tag changes (signature drift)",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{
+					Repository: "falcosecurity/rules/falco-rules",
+					Tag:        "v2",
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:   MediumOCI,
+				Priority: 50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{
+					Image: commonv1alpha1.ImageSpec{
+						Repository: "falcosecurity/rules/falco-rules",
+						Tag:        "v1",
+					},
+				}, nil),
+			},
+			existingData:    "v1 rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantFileContent: "fake-rules-content",
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when OCI repository changes",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{
+					Repository: "falcosecurity/rules/falco-rules-extras",
+					Tag:        "latest",
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when OCI registry name changes",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: testImage,
+				Registry: &commonv1alpha1.RegistryConfig{
+					Name: "quay.io",
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when plainHTTP toggles",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: testImage,
+				Registry: &commonv1alpha1.RegistryConfig{
+					PlainHTTP: new(true),
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantOpts:        &puller.RegistryOptions{PlainHTTP: true},
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when insecureSkipVerify toggles",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: testImage,
+				Registry: &commonv1alpha1.RegistryConfig{
+					TLS: &commonv1alpha1.TLSConfig{InsecureSkipVerify: true},
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:            "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:          MediumOCI,
+				Priority:        50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{Image: testImage}, nil),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantOpts:        &puller.RegistryOptions{InsecureSkipVerify: true},
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when auth secret reference name changes",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: testImage,
+				Registry: &commonv1alpha1.RegistryConfig{
+					Auth: &commonv1alpha1.RegistryAuth{
+						SecretRef: &commonv1alpha1.SecretRef{Name: "new-pull-secret"},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-pull-secret", Namespace: testNamespace},
+					Data: map[string][]byte{
+						commonv1alpha1.SecretUsernameKey: []byte("u"),
+						commonv1alpha1.SecretPasswordKey: []byte("p"),
+					},
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:   MediumOCI,
+				Priority: 50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{
+					Image: testImage,
+					Registry: &commonv1alpha1.RegistryConfig{
+						Auth: &commonv1alpha1.RegistryAuth{
+							SecretRef: &commonv1alpha1.SecretRef{Name: "old-pull-secret"},
+						},
+					},
+				}, nil),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantAction:      StoreActionUpdated,
+		},
+		{
+			name: "re-pulls when auth secret data rotates",
+			artifact: &commonv1alpha1.OCIArtifact{
+				Image: testImage,
+				Registry: &commonv1alpha1.RegistryConfig{
+					Auth: &commonv1alpha1.RegistryAuth{
+						SecretRef: &commonv1alpha1.SecretRef{Name: "rotating-secret"},
+					},
+				},
+			},
+			objects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "rotating-secret", Namespace: testNamespace},
+					Data: map[string][]byte{
+						commonv1alpha1.SecretUsernameKey: []byte("u"),
+						commonv1alpha1.SecretPasswordKey: []byte("rotated-password"),
+					},
+				},
+			},
+			priority:     50,
+			artifactType: TypeRulesfile,
+			existingFile: &File{
+				Path:     "/etc/falco/rules.d/50-01-test-artifact-oci.yaml",
+				Medium:   MediumOCI,
+				Priority: 50,
+				SourceSignature: computeOCISourceSignature(&commonv1alpha1.OCIArtifact{
+					Image: testImage,
+					Registry: &commonv1alpha1.RegistryConfig{
+						Auth: &commonv1alpha1.RegistryAuth{
+							SecretRef: &commonv1alpha1.SecretRef{Name: "rotating-secret"},
+						},
+					},
+				}, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "rotating-secret", Namespace: testNamespace},
+					Data: map[string][]byte{
+						commonv1alpha1.SecretUsernameKey: []byte("u"),
+						commonv1alpha1.SecretPasswordKey: []byte("pre-rotation-password"),
+					},
+				}),
+			},
+			existingData:    "original rules",
+			pullerResult:    &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+			layerContent:    validLayer,
+			wantPullCalls:   1,
+			wantWriteCalls:  1,
+			wantRenameCalls: 1,
+			wantAction:      StoreActionUpdated,
 		},
 	}
 
@@ -1620,40 +1736,30 @@ func TestStoreFromOCI(t *testing.T) {
 			mockFS := filesystem.NewMockFileSystem()
 			mockFS.RenameErr = tt.fsRenameErr
 			mockFS.StatErr = tt.fsStatErr
-			mockFS.OpenErr = tt.fsOpenErr
 			mockFS.RemoveErr = tt.fsRemoveErr
+			mockFS.WriteErr = tt.fsWriteErr
 
 			mockPuller := &puller.MockOCIPuller{
-				Result:  tt.pullerResult,
-				PullErr: tt.pullerErr,
+				Result:         tt.pullerResult,
+				PullErr:        tt.pullerErr,
+				AllowNilResult: tt.allowNilResult,
 			}
-			if tt.archiveContent != nil {
-				mockPuller.Result = &puller.RegistryResult{Filename: "falco-rules.tar.gz"}
-				mockFS.Files[filepath.Join(tmpDir, "falco-rules.tar.gz")] = tt.archiveContent
-			}
-
-			var thePuller puller.Puller = mockPuller
-			if tt.customPuller != nil {
-				thePuller = tt.customPuller
+			if tt.layerContent != nil {
+				mockPuller.LayerContent = tt.layerContent(t)
 			}
 
-			var managerOpts []ManagerOption
-			if tt.useRealFS {
-				realFS := filesystem.NewOSFileSystem()
-				realPuller := &puller.MockOCIPuller{
-					Result: &puller.RegistryResult{Filename: "falco-rules.tar.gz"},
-					FS:     realFS,
-				}
-				managerOpts = []ManagerOption{WithFS(realFS), WithRulesfileDir(tmpDir), WithOCIPuller(realPuller)}
-			} else {
-				managerOpts = []ManagerOption{WithFS(mockFS), WithRulesfileDir(tmpDir), WithOCIPuller(thePuller)}
-			}
-
-			manager := NewManagerWithOptions(fakeClient, testNamespace, managerOpts...)
+			manager := NewManagerWithOptions(fakeClient, testNamespace,
+				WithFS(mockFS),
+				WithRulesfileDir(tmpDir),
+				WithOCIPuller(mockPuller),
+			)
 
 			if tt.existingFile != nil {
+				if tt.existingFile.Medium == MediumOCI && tt.artifactType != "" {
+					tt.existingFile.Path = manager.Path(testArtifactName, tt.existingFile.Priority, MediumOCI, tt.artifactType)
+				}
 				manager.files[testArtifactName] = []File{*tt.existingFile}
-				if tt.existingData != "" && !tt.useRealFS {
+				if tt.existingData != "" {
 					mockFS.Files[tt.existingFile.Path] = []byte(tt.existingData)
 				}
 			}
@@ -1671,33 +1777,298 @@ func TestStoreFromOCI(t *testing.T) {
 			if tt.wantAction != "" {
 				assert.Equal(t, tt.wantAction, action)
 			}
-			if !tt.useRealFS && tt.customPuller == nil {
-				assert.Len(t, mockPuller.PullCalls, tt.wantPullCalls)
-				assert.Len(t, mockFS.RenameCalls, tt.wantRenameCalls)
-				assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveCalls)
-				if tt.wantOpts != nil && len(mockPuller.PullCalls) > 0 {
-					assert.Equal(t, tt.wantOpts, mockPuller.PullCalls[0].Opts)
-				}
+			assert.Len(t, mockPuller.PullCalls, tt.wantPullCalls)
+			if tt.wantOpts != nil && len(mockPuller.PullCalls) > 0 {
+				assert.Equal(t, tt.wantOpts, mockPuller.PullCalls[0].Opts)
 			}
+			assert.Len(t, mockFS.WriteCalls, tt.wantWriteCalls)
+			assert.Len(t, mockFS.RenameCalls, tt.wantRenameCalls)
+			assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveCalls)
 
-			if tt.wantFilesLen > 0 {
-				assert.Len(t, manager.files[testArtifactName], tt.wantFilesLen)
-			}
 			if tt.wantFile != nil {
 				file := manager.getArtifactFile(testArtifactName, tt.wantFile.Medium)
 				require.NotNil(t, file)
 				assert.Equal(t, filepath.Base(tt.wantFile.Path), filepath.Base(file.Path))
 				assert.Equal(t, tt.wantFile.Priority, file.Priority)
 			}
+			if tt.wantFileContent != "" {
+				path := manager.Path(testArtifactName, tt.priority, MediumOCI, tt.artifactType)
+				data, ok := mockFS.Files[path]
+				require.True(t, ok, "expected final file %q to exist", path)
+				assert.Equal(t, tt.wantFileContent, string(data))
+			}
 		})
 	}
 }
 
-// nilResultPuller always returns (nil, nil) to exercise the nil-result guard in StoreFromOCI.
-type nilResultPuller struct{}
+func TestStoreFromOCI_TagChangeTriggersRePull(t *testing.T) {
+	const (
+		testNamespace    = "test-namespace"
+		testArtifactName = "test-rules"
+	)
 
-func (nilResultPuller) Pull(_ context.Context, _, _, _, _ string, _ auth.CredentialFunc, _ *puller.RegistryOptions) (*puller.RegistryResult, error) {
-	return nil, nil
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tmpDir := t.TempDir()
+
+	realFS := filesystem.NewOSFileSystem()
+	layerV1, err := puller.MakeTarGz("rules.yaml", []byte("v1-rules-content"))
+	require.NoError(t, err)
+	layerV2, err := puller.MakeTarGz("rules.yaml", []byte("v2-rules-content"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{Filename: "falco-rules.tar.gz", Type: puller.Rulesfile},
+		LayerContent: layerV1,
+	}
+
+	manager := NewManagerWithOptions(fakeClient, testNamespace,
+		WithFS(realFS),
+		WithRulesfileDir(tmpDir),
+		WithOCIPuller(mockPuller),
+	)
+
+	ctx := context.Background()
+
+	artifactV1 := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{
+			Repository: "falcosecurity/rules/falco-rules",
+			Tag:        "v1",
+		},
+	}
+
+	action, err := manager.StoreFromOCI(ctx, testArtifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionAdded, action)
+	require.Len(t, mockPuller.PullCalls, 1)
+	assert.Contains(t, mockPuller.PullCalls[0].Ref, ":v1")
+
+	action, err = manager.StoreFromOCI(ctx, testArtifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionUnchanged, action)
+	assert.Len(t, mockPuller.PullCalls, 1, "spec unchanged: must not pull again")
+
+	artifactV2 := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{
+			Repository: "falcosecurity/rules/falco-rules",
+			Tag:        "v2",
+		},
+	}
+	mockPuller.LayerContent = layerV2
+	action, err = manager.StoreFromOCI(ctx, testArtifactName, 50, TypeRulesfile, artifactV2)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionUpdated, action)
+	require.Len(t, mockPuller.PullCalls, 2, "tag changed: must re-pull")
+	assert.Contains(t, mockPuller.PullCalls[1].Ref, ":v2")
+
+	stored := manager.getArtifactFile(testArtifactName, MediumOCI)
+	require.NotNil(t, stored)
+	expectedSig := computeOCISourceSignature(artifactV2, nil)
+	assert.Equal(t, expectedSig, stored.SourceSignature, "cache entry must carry the new source signature")
+
+	action, err = manager.StoreFromOCI(ctx, testArtifactName, 50, TypeRulesfile, artifactV2)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionUnchanged, action)
+	assert.Len(t, mockPuller.PullCalls, 2, "spec stable on v2: must not pull again")
+}
+
+func TestStoreFromOCI_TagAndPriorityChange_RemovesOldPath(t *testing.T) {
+	const (
+		testNamespace = "test-namespace"
+		artifactName  = "test-rules"
+	)
+
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tmpDir := t.TempDir()
+	realFS := filesystem.NewOSFileSystem()
+
+	layerV1, err := puller.MakeTarGz("rules.yaml", []byte("v1-content"))
+	require.NoError(t, err)
+	layerV2, err := puller.MakeTarGz("rules.yaml", []byte("v2-content"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+		LayerContent: layerV1,
+	}
+	manager := NewManagerWithOptions(fakeClient, testNamespace,
+		WithFS(realFS),
+		WithRulesfileDir(tmpDir),
+		WithOCIPuller(mockPuller),
+	)
+	ctx := context.Background()
+
+	artifactV1 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v1"}}
+	_, err = manager.StoreFromOCI(ctx, artifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	oldPath := manager.Path(artifactName, 50, MediumOCI, TypeRulesfile)
+	require.FileExists(t, oldPath)
+
+	mockPuller.LayerContent = layerV2
+	artifactV2 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v2"}}
+	action, err := manager.StoreFromOCI(ctx, artifactName, 60, TypeRulesfile, artifactV2)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionUpdated, action)
+
+	newPath := manager.Path(artifactName, 60, MediumOCI, TypeRulesfile)
+	require.FileExists(t, newPath)
+	require.NoFileExists(t, oldPath, "old artifact path must be removed when priority changes alongside the signature")
+
+	stored := manager.getArtifactFile(artifactName, MediumOCI)
+	require.NotNil(t, stored)
+	assert.Equal(t, newPath, stored.Path)
+	assert.Equal(t, int32(60), stored.Priority)
+}
+
+func TestStoreFromOCI_PullFailureAfterDrift_PreservesOldFileAndCache(t *testing.T) {
+	const (
+		testNamespace = "test-namespace"
+		artifactName  = "test-rules"
+	)
+
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tmpDir := t.TempDir()
+	realFS := filesystem.NewOSFileSystem()
+
+	layerV1, err := puller.MakeTarGz("rules.yaml", []byte("v1-content"))
+	require.NoError(t, err)
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+		LayerContent: layerV1,
+	}
+	manager := NewManagerWithOptions(fakeClient, testNamespace,
+		WithFS(realFS),
+		WithRulesfileDir(tmpDir),
+		WithOCIPuller(mockPuller),
+	)
+	ctx := context.Background()
+
+	artifactV1 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v1"}}
+	_, err = manager.StoreFromOCI(ctx, artifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	path := manager.Path(artifactName, 50, MediumOCI, TypeRulesfile)
+	require.FileExists(t, path)
+
+	sigBefore := manager.getArtifactFile(artifactName, MediumOCI).SourceSignature
+
+	mockPuller.PullErr = fmt.Errorf("registry unavailable")
+	artifactV2 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v2"}}
+	action, err := manager.StoreFromOCI(ctx, artifactName, 50, TypeRulesfile, artifactV2)
+	require.Error(t, err)
+	assert.Equal(t, StoreActionNone, action)
+
+	require.FileExists(t, path, "previous artifact must remain on disk on pull failure")
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "v1-content", string(contents))
+
+	stored := manager.getArtifactFile(artifactName, MediumOCI)
+	require.NotNil(t, stored, "cache entry for previous artifact must remain after pull failure")
+	assert.Equal(t, sigBefore, stored.SourceSignature)
+}
+
+func TestStoreFromOCI_RetryAfterPullFailure_Converges(t *testing.T) {
+	const (
+		testNamespace = "test-namespace"
+		artifactName  = "test-rules"
+	)
+
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tmpDir := t.TempDir()
+	realFS := filesystem.NewOSFileSystem()
+
+	layerV1, err := puller.MakeTarGz("rules.yaml", []byte("v1-content"))
+	require.NoError(t, err)
+	layerV2, err := puller.MakeTarGz("rules.yaml", []byte("v2-content"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+		LayerContent: layerV1,
+	}
+	manager := NewManagerWithOptions(fakeClient, testNamespace,
+		WithFS(realFS),
+		WithRulesfileDir(tmpDir),
+		WithOCIPuller(mockPuller),
+	)
+	ctx := context.Background()
+
+	artifactV1 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v1"}}
+	_, err = manager.StoreFromOCI(ctx, artifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	oldPath := manager.Path(artifactName, 50, MediumOCI, TypeRulesfile)
+
+	artifactV2 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v2"}}
+
+	mockPuller.PullErr = fmt.Errorf("transient registry error")
+	_, err = manager.StoreFromOCI(ctx, artifactName, 60, TypeRulesfile, artifactV2)
+	require.Error(t, err)
+	require.FileExists(t, oldPath)
+
+	mockPuller.PullErr = nil
+	mockPuller.LayerContent = layerV2
+	action, err := manager.StoreFromOCI(ctx, artifactName, 60, TypeRulesfile, artifactV2)
+	require.NoError(t, err)
+	assert.Equal(t, StoreActionUpdated, action)
+
+	newPath := manager.Path(artifactName, 60, MediumOCI, TypeRulesfile)
+	require.FileExists(t, newPath)
+	require.NoFileExists(t, oldPath, "old path must be removed after the successful retry")
+}
+
+func TestStoreFromOCI_OldPathRemoveFailure_RollsBackNewPathAndLeavesCacheUnchanged(t *testing.T) {
+	const (
+		testNamespace = "test-namespace"
+		artifactName  = "test-rules"
+	)
+
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	tmpDir := t.TempDir()
+	mockFS := filesystem.NewMockFileSystem()
+
+	layerV1, err := puller.MakeTarGz("rules.yaml", []byte("v1-content"))
+	require.NoError(t, err)
+	layerV2, err := puller.MakeTarGz("rules.yaml", []byte("v2-content"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{Filename: "rules.tar.gz", Type: puller.Rulesfile},
+		LayerContent: layerV1,
+	}
+	manager := NewManagerWithOptions(fakeClient, testNamespace,
+		WithFS(mockFS),
+		WithRulesfileDir(tmpDir),
+		WithOCIPuller(mockPuller),
+	)
+	ctx := context.Background()
+
+	artifactV1 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v1"}}
+	_, err = manager.StoreFromOCI(ctx, artifactName, 50, TypeRulesfile, artifactV1)
+	require.NoError(t, err)
+	oldPath := manager.Path(artifactName, 50, MediumOCI, TypeRulesfile)
+	sigBefore := manager.getArtifactFile(artifactName, MediumOCI).SourceSignature
+
+	mockPuller.LayerContent = layerV2
+	mockFS.RemoveErrFor = map[string]error{oldPath: fmt.Errorf("device busy")}
+
+	artifactV2 := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v2"}}
+	action, err := manager.StoreFromOCI(ctx, artifactName, 60, TypeRulesfile, artifactV2)
+	require.Error(t, err)
+	assert.Equal(t, StoreActionNone, action)
+	assert.Contains(t, err.Error(), "device busy")
+
+	stored := manager.getArtifactFile(artifactName, MediumOCI)
+	require.NotNil(t, stored, "cache entry must be preserved when old path removal fails")
+	assert.Equal(t, sigBefore, stored.SourceSignature, "cache must still point to the previous artifact")
+	assert.Equal(t, oldPath, stored.Path)
+
+	assert.Contains(t, mockFS.Files, oldPath, "old artifact must still be on disk after a failed Remove")
+	newPath := manager.Path(artifactName, 60, MediumOCI, TypeRulesfile)
+	assert.NotContains(t, mockFS.Files, newPath, "new artifact must be rolled back when the old path cannot be removed")
 }
 
 func TestCheckReferenceResolution(t *testing.T) {

--- a/internal/pkg/artifact/oci.go
+++ b/internal/pkg/artifact/oci.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+func (am *Manager) fetchOCIAuthSecret(ctx context.Context, ref *commonv1alpha1.SecretRef) (*corev1.Secret, error) {
+	if ref == nil {
+		return nil, nil
+	}
+
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{Name: ref.Name, Namespace: am.namespace}
+	if err := am.client.Get(ctx, key, secret); err != nil {
+		return nil, fmt.Errorf("failed to get pull secret %s: %w", ref.Name, err)
+	}
+	return secret, nil
+}
+
+func (am *Manager) getCurrentOCIFile(ctx context.Context, name string) (*File, error) {
+	logger := log.FromContext(ctx)
+	file := am.getArtifactFile(name, MediumOCI)
+	if file == nil {
+		return nil, nil
+	}
+
+	ok, err := am.fs.Exists(file.Path)
+	if err != nil {
+		logger.Error(err, "Failed to check if file exists", "file", file.Path)
+		return nil, err
+	}
+	if !ok {
+		am.removeArtifactFile(name, MediumOCI)
+		err := fmt.Errorf("artifact %q not found on filesystem", file.Path)
+		logger.Error(err, "Failed to find file on filesystem", "file", file.Path)
+		return nil, err
+	}
+
+	current := *file
+	return &current, nil
+}
+
+func (am *Manager) pullOCIFile(ctx context.Context, ref string, artifactType Type, artifact *commonv1alpha1.OCIArtifact, creds auth.CredentialFunc) (common.ExtractedFile, error) {
+	var compressed bytes.Buffer
+	res, err := am.ociPuller.Pull(ctx, ref, runtime.GOOS, runtime.GOARCH, creds, ResolveRegistryOptions(artifact), &compressed)
+	if err != nil {
+		return common.ExtractedFile{}, err
+	}
+	if res == nil {
+		return common.ExtractedFile{}, fmt.Errorf("puller returned nil result for reference %q", ref)
+	}
+	if !isExpectedOCIArtifactType(artifactType, res.Type) {
+		return common.ExtractedFile{}, fmt.Errorf("pulled OCI artifact type %q does not match expected type %q", res.Type, artifactType)
+	}
+
+	file, err := common.ExtractSingleFileFromTarGz(ctx, &compressed, 0)
+	if err != nil {
+		return common.ExtractedFile{}, err
+	}
+	return file, nil
+}
+
+func isExpectedOCIArtifactType(expected Type, actual puller.ArtifactType) bool {
+	switch expected {
+	case TypeRulesfile:
+		return actual == puller.Rulesfile
+	case TypePlugin:
+		return actual == puller.Plugin
+	default:
+		return false
+	}
+}
+
+func (am *Manager) removeReplacedOCIFile(ctx context.Context, oldFile *File, newPath string) error {
+	if oldFile == nil || oldFile.Path == newPath {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	if err := am.fs.Remove(oldFile.Path); err != nil {
+		logger.Error(err, "unable to remove previous artifact at old path", "oldFile", oldFile.Path)
+		if rollbackErr := am.fs.Remove(newPath); rollbackErr != nil && !errors.Is(rollbackErr, fs.ErrNotExist) {
+			logger.Error(rollbackErr, "unable to roll back newly installed artifact", "file", newPath)
+			return fmt.Errorf("remove previous artifact %q: %w; rollback new artifact %q: %w", oldFile.Path, err, newPath, rollbackErr)
+		}
+		return fmt.Errorf("remove previous artifact %q: %w", oldFile.Path, err)
+	}
+	return nil
+}
+
+func (am *Manager) installOCIFile(ctx context.Context, path string, file common.ExtractedFile) error {
+	logger := log.FromContext(ctx)
+	tmpPath := path + ".tmp"
+
+	if err := am.fs.WriteFile(tmpPath, file.Content, file.Perm); err != nil {
+		logger.Error(err, "unable to write artifact temp file", "file", tmpPath)
+		if removeErr := am.fs.Remove(tmpPath); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+			logger.Error(removeErr, "unable to remove leftover temp file", "file", tmpPath)
+		}
+		return err
+	}
+
+	if err := am.fs.Rename(tmpPath, path); err != nil {
+		logger.Error(err, "unable to rename temp artifact to final path", "tmp", tmpPath, "final", path)
+		if removeErr := am.fs.Remove(tmpPath); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+			logger.Error(removeErr, "unable to remove leftover temp file", "file", tmpPath)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/pkg/artifact/oci_test.go
+++ b/internal/pkg/artifact/oci_test.go
@@ -1,0 +1,404 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+func TestFetchOCIAuthSecret(t *testing.T) {
+	const namespace = "test-namespace"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: namespace},
+	}
+
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		ref      *commonv1alpha1.SecretRef
+		wantName string
+		wantErr  string
+	}{
+		{
+			name: "returns nil when reference is nil",
+		},
+		{
+			name:     "returns referenced secret",
+			objects:  []client.Object{secret},
+			ref:      &commonv1alpha1.SecretRef{Name: "pull-secret"},
+			wantName: "pull-secret",
+		},
+		{
+			name:    "returns error when secret is missing",
+			ref:     &commonv1alpha1.SecretRef{Name: "missing"},
+			wantErr: "failed to get pull secret missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(createTestScheme(t))
+			if len(tt.objects) > 0 {
+				builder = builder.WithObjects(tt.objects...)
+			}
+			manager := NewManager(builder.Build(), namespace)
+
+			got, err := manager.fetchOCIAuthSecret(context.Background(), tt.ref)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantName == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantName, got.Name)
+		})
+	}
+}
+
+func TestGetCurrentOCIFile(t *testing.T) {
+	tests := []struct {
+		name             string
+		file             *File
+		files            map[string][]byte
+		statErr          error
+		wantPath         string
+		wantErr          string
+		wantCacheCleared bool
+		wantCopy         bool
+	}{
+		{
+			name: "returns nil when file is not tracked",
+		},
+		{
+			name:     "returns tracked file when it exists",
+			file:     &File{Path: "/old", Medium: MediumOCI, Priority: 50},
+			files:    map[string][]byte{"/old": []byte("content")},
+			wantPath: "/old",
+			wantCopy: true,
+		},
+		{
+			name:             "clears stale cache when tracked file is missing",
+			file:             &File{Path: "/old", Medium: MediumOCI, Priority: 50},
+			wantErr:          "not found on filesystem",
+			wantCacheCleared: true,
+		},
+		{
+			name:    "returns error when existence check fails",
+			file:    &File{Path: "/old", Medium: MediumOCI, Priority: 50},
+			statErr: fmt.Errorf("permission denied"),
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := filesystem.NewMockFileSystem()
+			mockFS.StatErr = tt.statErr
+			maps.Copy(mockFS.Files, tt.files)
+
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace",
+				WithFS(mockFS),
+			)
+			if tt.file != nil {
+				manager.files["rules"] = []File{*tt.file}
+			}
+
+			got, err := manager.getCurrentOCIFile(context.Background(), "rules")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, got)
+				if tt.wantCacheCleared {
+					assert.Nil(t, manager.getArtifactFile("rules", MediumOCI))
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantPath == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantPath, got.Path)
+			if tt.wantCopy {
+				got.Priority = 60
+				assert.Equal(t, int32(50), manager.files["rules"][0].Priority)
+			}
+		})
+	}
+}
+
+func TestPullOCIFile(t *testing.T) {
+	validLayer, err := puller.MakeTarGz("rules.yaml", []byte("rules-content"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		result      *puller.RegistryResult
+		layer       []byte
+		nilResult   bool
+		wantErr     string
+		wantContent string
+	}{
+		{
+			name:        "pulls and extracts single file",
+			result:      &puller.RegistryResult{Type: puller.Rulesfile},
+			layer:       validLayer,
+			wantContent: "rules-content",
+		},
+		{
+			name:    "rejects mismatched artifact type",
+			result:  &puller.RegistryResult{Type: puller.Plugin},
+			layer:   validLayer,
+			wantErr: "does not match expected type",
+		},
+		{
+			name:    "rejects empty artifact type",
+			result:  &puller.RegistryResult{},
+			layer:   validLayer,
+			wantErr: "does not match expected type",
+		},
+		{
+			name:      "rejects nil puller result",
+			nilResult: true,
+			wantErr:   "nil result",
+		},
+		{
+			name:    "rejects invalid gzip layer",
+			result:  &puller.RegistryResult{Type: puller.Rulesfile},
+			layer:   []byte("not-gzip"),
+			wantErr: "unexpected EOF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace",
+				WithOCIPuller(&puller.MockOCIPuller{
+					Result:         tt.result,
+					LayerContent:   tt.layer,
+					AllowNilResult: tt.nilResult,
+				}),
+			)
+
+			file, err := manager.pullOCIFile(
+				context.Background(),
+				"registry.example.test/falco/rules:latest",
+				TypeRulesfile,
+				&commonv1alpha1.OCIArtifact{},
+				nil,
+			)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantContent, string(file.Content))
+			assert.Equal(t, fs.FileMode(0o644), file.Perm)
+		})
+	}
+}
+
+func TestRemoveReplacedOCIFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldFile       *File
+		newPath       string
+		files         map[string][]byte
+		removeErrFor  map[string]error
+		wantErr       string
+		wantRemoveLen int
+		wantFiles     map[string]bool
+	}{
+		{
+			name:    "does nothing when old file is nil",
+			newPath: "/new",
+		},
+		{
+			name:    "does nothing when path is unchanged",
+			oldFile: &File{Path: "/same"},
+			newPath: "/same",
+		},
+		{
+			name:          "removes replaced old path",
+			oldFile:       &File{Path: "/old"},
+			newPath:       "/new",
+			files:         map[string][]byte{"/old": []byte("old"), "/new": []byte("new")},
+			wantRemoveLen: 1,
+			wantFiles:     map[string]bool{"/old": false, "/new": true},
+		},
+		{
+			name:          "rolls back new file when old path cannot be removed",
+			oldFile:       &File{Path: "/old"},
+			newPath:       "/new",
+			files:         map[string][]byte{"/old": []byte("old"), "/new": []byte("new")},
+			removeErrFor:  map[string]error{"/old": fmt.Errorf("device busy")},
+			wantErr:       "device busy",
+			wantRemoveLen: 2,
+			wantFiles:     map[string]bool{"/old": true, "/new": false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := filesystem.NewMockFileSystem()
+			mockFS.RemoveErrFor = tt.removeErrFor
+			maps.Copy(mockFS.Files, tt.files)
+
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace",
+				WithFS(mockFS),
+			)
+
+			err := manager.removeReplacedOCIFile(context.Background(), tt.oldFile, tt.newPath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveLen)
+			for path, exists := range tt.wantFiles {
+				if exists {
+					assert.Contains(t, mockFS.Files, path)
+				} else {
+					assert.NotContains(t, mockFS.Files, path)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallOCIFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		writeErr       error
+		renameErr      error
+		wantErr        string
+		wantFinalFile  bool
+		wantWriteLen   int
+		wantRenameLen  int
+		wantRemoveLen  int
+		wantFinalBytes []byte
+	}{
+		{
+			name:           "writes temp file and renames it to final path",
+			wantFinalFile:  true,
+			wantWriteLen:   1,
+			wantRenameLen:  1,
+			wantFinalBytes: []byte("rules-content"),
+		},
+		{
+			name:          "cleans temp path when write fails",
+			writeErr:      fmt.Errorf("disk full"),
+			wantErr:       "disk full",
+			wantWriteLen:  1,
+			wantRemoveLen: 1,
+		},
+		{
+			name:          "cleans temp path when rename fails",
+			renameErr:     fmt.Errorf("rename failed"),
+			wantErr:       "rename failed",
+			wantWriteLen:  1,
+			wantRenameLen: 1,
+			wantRemoveLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFS := filesystem.NewMockFileSystem()
+			mockFS.WriteErr = tt.writeErr
+			mockFS.RenameErr = tt.renameErr
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace",
+				WithFS(mockFS),
+			)
+
+			err := manager.installOCIFile(context.Background(), "/artifact.yaml", common.ExtractedFile{
+				Content: []byte("rules-content"),
+				Perm:    0o640,
+			})
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantFinalFile {
+				assert.Equal(t, tt.wantFinalBytes, mockFS.Files["/artifact.yaml"])
+			} else {
+				assert.NotContains(t, mockFS.Files, "/artifact.yaml")
+			}
+			assert.NotContains(t, mockFS.Files, "/artifact.yaml.tmp")
+			assert.Len(t, mockFS.WriteCalls, tt.wantWriteLen)
+			assert.Len(t, mockFS.RenameCalls, tt.wantRenameLen)
+			assert.Len(t, mockFS.RemoveCalls, tt.wantRemoveLen)
+		})
+	}
+}
+
+func TestIsExpectedOCIArtifactType(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected Type
+		actual   puller.ArtifactType
+		want     bool
+	}{
+		{name: "rulesfile matches", expected: TypeRulesfile, actual: puller.Rulesfile, want: true},
+		{name: "plugin matches", expected: TypePlugin, actual: puller.Plugin, want: true},
+		{name: "rulesfile rejects plugin", expected: TypeRulesfile, actual: puller.Plugin},
+		{name: "plugin rejects rulesfile", expected: TypePlugin, actual: puller.Rulesfile},
+		{name: "unsupported expected type", expected: TypeConfig, actual: puller.Rulesfile},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isExpectedOCIArtifactType(tt.expected, tt.actual))
+		})
+	}
+}

--- a/internal/pkg/artifact/registry.go
+++ b/internal/pkg/artifact/registry.go
@@ -31,12 +31,7 @@ const (
 // ResolveReference builds the full OCI reference string from an OCIArtifact.
 // Defaults to "ghcr.io" when no registry name is specified and "latest" when no tag is set.
 func ResolveReference(artifact *commonv1alpha1.OCIArtifact) string {
-	registry := DefaultRegistry
-	if artifact.Registry != nil && artifact.Registry.Name != "" {
-		registry = artifact.Registry.Name
-	}
-
-	ref := registry + "/" + artifact.Image.Repository
+	ref := ResolveRegistryHost(artifact) + "/" + artifact.Image.Repository
 
 	tag := artifact.Image.Tag
 	if tag == "" {
@@ -50,6 +45,29 @@ func ResolveReference(artifact *commonv1alpha1.OCIArtifact) string {
 	}
 
 	return ref
+}
+
+// ResolveRegistryHost returns the registry hostname used for an OCIArtifact.
+func ResolveRegistryHost(artifact *commonv1alpha1.OCIArtifact) string {
+	if artifact != nil && artifact.Registry != nil && artifact.Registry.Name != "" {
+		return artifact.Registry.Name
+	}
+	return DefaultRegistry
+}
+
+func authSecretRefName(artifact *commonv1alpha1.OCIArtifact) string {
+	ref := authSecretRef(artifact)
+	if ref == nil {
+		return ""
+	}
+	return ref.Name
+}
+
+func authSecretRef(artifact *commonv1alpha1.OCIArtifact) *commonv1alpha1.SecretRef {
+	if artifact == nil || artifact.Registry == nil || artifact.Registry.Auth == nil {
+		return nil
+	}
+	return artifact.Registry.Auth.SecretRef
 }
 
 // ResolveRegistryOptions builds a RegistryOptions from the registry configuration of an OCIArtifact.

--- a/internal/pkg/artifact/signature.go
+++ b/internal/pkg/artifact/signature.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+)
+
+func computeOCISourceSignature(artifact *commonv1alpha1.OCIArtifact, authSecret *corev1.Secret) string {
+	if artifact == nil {
+		return ""
+	}
+
+	h := sha256.New()
+
+	writeHashString(h, ResolveReference(artifact))
+
+	opts := ResolveRegistryOptions(artifact)
+	if opts == nil {
+		writeHashBool(h, false)
+		writeHashBool(h, false)
+	} else {
+		writeHashBool(h, opts.PlainHTTP)
+		writeHashBool(h, opts.InsecureSkipVerify)
+	}
+
+	writeHashString(h, authSecretRefName(artifact))
+	if authSecret != nil {
+		writeHashBytes(h, authSecret.Data[commonv1alpha1.SecretUsernameKey])
+		writeHashBytes(h, authSecret.Data[commonv1alpha1.SecretPasswordKey])
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeHashString(h hash.Hash, value string) {
+	writeHashBytes(h, []byte(value))
+}
+
+func writeHashBool(h hash.Hash, value bool) {
+	writeHashString(h, strconv.FormatBool(value))
+}
+
+func writeHashBytes(h hash.Hash, value []byte) {
+	_, _ = io.WriteString(h, strconv.Itoa(len(value)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write(value)
+	_, _ = h.Write([]byte{0})
+}

--- a/internal/pkg/artifact/signature_test.go
+++ b/internal/pkg/artifact/signature_test.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+)
+
+func TestComputeOCISourceSignatureNormalizesDefaults(t *testing.T) {
+	implicitDefaults := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/rules/falco-rules"},
+	}
+	explicitDefaults := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{
+			Repository: "falcosecurity/rules/falco-rules",
+			Tag:        "latest",
+		},
+		Registry: &commonv1alpha1.RegistryConfig{
+			Name:      DefaultRegistry,
+			PlainHTTP: new(false),
+			TLS:       &commonv1alpha1.TLSConfig{},
+		},
+	}
+
+	assert.Equal(t,
+		computeOCISourceSignature(implicitDefaults, nil),
+		computeOCISourceSignature(explicitDefaults, nil),
+	)
+}
+
+func TestComputeOCISourceSignatureUsesSecretDataOnly(t *testing.T) {
+	artifact := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "repo/rules", Tag: "v1"},
+		Registry: &commonv1alpha1.RegistryConfig{
+			Auth: &commonv1alpha1.RegistryAuth{
+				SecretRef: &commonv1alpha1.SecretRef{Name: "pull-secret"},
+			},
+		},
+	}
+	secret := pullSecret("pull-secret", "user", "password")
+	sameDataDifferentMetadata := secret.DeepCopy()
+	sameDataDifferentMetadata.ResourceVersion = "2"
+	sameDataDifferentMetadata.Labels = map[string]string{"rotated-at": "metadata-only"}
+
+	rotated := pullSecret("pull-secret", "user", "new-password")
+
+	assert.Equal(t,
+		computeOCISourceSignature(artifact, secret),
+		computeOCISourceSignature(artifact, sameDataDifferentMetadata),
+	)
+	assert.NotEqual(t,
+		computeOCISourceSignature(artifact, secret),
+		computeOCISourceSignature(artifact, rotated),
+	)
+}
+
+func pullSecret(name, username, password string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data: map[string][]byte{
+			commonv1alpha1.SecretUsernameKey: []byte(username),
+			commonv1alpha1.SecretPasswordKey: []byte(password),
+		},
+	}
+}

--- a/internal/pkg/artifact/types.go
+++ b/internal/pkg/artifact/types.go
@@ -49,7 +49,8 @@ const (
 
 // File represents a tracked file for any artifact type.
 type File struct {
-	Path     string // Full Path on filesystem
-	Medium   Medium // How the artifact is stored/distributed
-	Priority int32  // Priority when created
+	Path            string // Full Path on filesystem
+	Medium          Medium // How the artifact is stored/distributed
+	Priority        int32  // Priority when created
+	SourceSignature string // Resolved source identity (set for MediumOCI)
 }

--- a/internal/pkg/common/archive.go
+++ b/internal/pkg/common/archive.go
@@ -18,11 +18,13 @@ package common
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +33,78 @@ import (
 type link struct {
 	Name string
 	Path string
+}
+
+// ExtractedFile is a regular file read from an archive.
+type ExtractedFile struct {
+	Content []byte
+	Perm    fs.FileMode
+}
+
+// ExtractSingleFileFromTarGz reads a gzipped tar archive and returns its only
+// regular file. Directory entries are accepted as packaging metadata;
+// links, unknown entry types, empty archives, and multi-file archives are rejected.
+func ExtractSingleFileFromTarGz(ctx context.Context, gzipStream io.Reader, stripPathComponents int) (ExtractedFile, error) {
+	var content bytes.Buffer
+	var fileMode fs.FileMode
+	var found bool
+
+	uncompressed, err := gzip.NewReader(gzipStream)
+	if err != nil {
+		return ExtractedFile{}, err
+	}
+	defer uncompressed.Close()
+
+	tarReader := tar.NewReader(uncompressed)
+	for {
+		select {
+		case <-ctx.Done():
+			return ExtractedFile{}, errors.New("interrupted")
+		default:
+		}
+
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			if !found {
+				return ExtractedFile{}, fmt.Errorf("no regular file found in tar archive")
+			}
+			return ExtractedFile{Content: content.Bytes(), Perm: fileMode}, nil
+		}
+		if err != nil {
+			return ExtractedFile{}, err
+		}
+
+		_, ok, err := archivePath(header.Name, stripPathComponents)
+		if err != nil {
+			return ExtractedFile{}, err
+		}
+		if !ok {
+			continue
+		}
+
+		info := header.FileInfo()
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg:
+			if found {
+				return ExtractedFile{}, fmt.Errorf("multiple regular files found in tar archive")
+			}
+			if written, err := io.CopyN(&content, tarReader, header.Size); err != nil {
+				return ExtractedFile{}, err
+			} else if written != header.Size {
+				return ExtractedFile{}, io.ErrShortWrite
+			}
+			fileMode = info.Mode().Perm()
+			found = true
+		case tar.TypeLink:
+			return ExtractedFile{}, fmt.Errorf("hard links are not allowed in OCI artifact tar archive")
+		case tar.TypeSymlink:
+			return ExtractedFile{}, fmt.Errorf("symbolic links are not allowed in OCI artifact tar archive")
+		default:
+			return ExtractedFile{}, fmt.Errorf("extractTarGz: uknown type: %b in %s", header.Typeflag, header.Name)
+		}
+	}
 }
 
 // ExtractTarGz extracts a *.tar.gz compressed archive and moves its content to destDir.
@@ -147,6 +221,33 @@ func ExtractTarGz(ctx context.Context, gzipStream io.Reader, destDir string, str
 		}
 	}
 	return files, nil
+}
+
+func archivePath(headerName string, stripPathComponents int) (path string, ok bool, err error) {
+	if strings.Contains(headerName, "..") {
+		return "", false, fmt.Errorf("not allowed relative path in tar archive")
+	}
+
+	name, ok := strippedPath(headerName, stripPathComponents)
+	if !ok {
+		return "", false, nil
+	}
+	clean := filepath.Clean(name)
+	if clean == "." {
+		return "", false, nil
+	}
+	if filepath.IsAbs(clean) {
+		return "", false, fmt.Errorf("absolute path %q is not allowed in tar archive", headerName)
+	}
+	return clean, true, nil
+}
+
+func strippedPath(headerName string, stripPathComponents int) (string, bool) {
+	name := headerName
+	if stripPathComponents > 0 {
+		name = stripComponents(name, stripPathComponents)
+	}
+	return name, name != ""
 }
 
 func stripComponents(headerName string, stripComponents int) string {

--- a/internal/pkg/common/archive_test.go
+++ b/internal/pkg/common/archive_test.go
@@ -1,0 +1,186 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestExtractSingleFileFromTarGz(t *testing.T) {
+	tests := []struct {
+		name     string
+		entries  []tarGzEntry
+		strip    int
+		wantData string
+		wantMode fs.FileMode
+		wantErr  string
+	}{
+		{
+			name: "extracts the only regular file",
+			entries: []tarGzEntry{
+				{name: "rules.yaml", mode: 0o640, body: "rules-content"},
+			},
+			wantData: "rules-content",
+			wantMode: 0o640,
+		},
+		{
+			name: "allows directory packaging around the single regular file",
+			entries: []tarGzEntry{
+				{name: "rules", typ: tar.TypeDir, mode: 0o755},
+				{name: "rules/falco_rules.yaml", mode: 0o600, body: "packaged-rules"},
+			},
+			wantData: "packaged-rules",
+			wantMode: 0o600,
+		},
+		{
+			name: "applies strip path components",
+			entries: []tarGzEntry{
+				{name: "pkg/rules.yaml", mode: 0o644, body: "stripped-rules"},
+			},
+			strip:    1,
+			wantData: "stripped-rules",
+			wantMode: 0o644,
+		},
+		{
+			name: "rejects archives without regular files",
+			entries: []tarGzEntry{
+				{name: "rules", typ: tar.TypeDir, mode: 0o755},
+			},
+			wantErr: "no regular file found",
+		},
+		{
+			name: "rejects archives with multiple regular files",
+			entries: []tarGzEntry{
+				{name: "rules.yaml", mode: 0o644, body: "first"},
+				{name: "extra.yaml", mode: 0o644, body: "second"},
+			},
+			wantErr: "multiple regular files",
+		},
+		{
+			name: "rejects symbolic links",
+			entries: []tarGzEntry{
+				{name: "rules.yaml", typ: tar.TypeSymlink, linkname: "target.yaml"},
+			},
+			wantErr: "symbolic links are not allowed",
+		},
+		{
+			name: "rejects hard links",
+			entries: []tarGzEntry{
+				{name: "rules.yaml", typ: tar.TypeLink, linkname: "target.yaml"},
+			},
+			wantErr: "hard links are not allowed",
+		},
+		{
+			name: "rejects relative path escapes",
+			entries: []tarGzEntry{
+				{name: "../rules.yaml", mode: 0o644, body: "bad"},
+			},
+			wantErr: "not allowed relative path",
+		},
+		{
+			name: "rejects absolute paths",
+			entries: []tarGzEntry{
+				{name: "/rules.yaml", mode: 0o644, body: "bad"},
+			},
+			wantErr: "absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := ExtractSingleFileFromTarGz(context.Background(), newTarGz(t, tt.entries...), tt.strip)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if file.Perm != tt.wantMode {
+				t.Fatalf("got file mode %o, want %o", file.Perm, tt.wantMode)
+			}
+			if string(file.Content) != tt.wantData {
+				t.Fatalf("got data %q, want %q", string(file.Content), tt.wantData)
+			}
+		})
+	}
+}
+
+type tarGzEntry struct {
+	name     string
+	typ      byte
+	mode     int64
+	body     string
+	linkname string
+}
+
+func newTarGz(t *testing.T, entries ...tarGzEntry) *bytes.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	for _, entry := range entries {
+		typ := entry.typ
+		if typ == 0 {
+			typ = tar.TypeReg
+		}
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+
+		header := &tar.Header{
+			Name:     entry.name,
+			Typeflag: typ,
+			Mode:     mode,
+			Linkname: entry.linkname,
+		}
+		if typ == tar.TypeReg {
+			header.Size = int64(len(entry.body))
+		}
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if typ == tar.TypeReg {
+			if _, err := tarWriter.Write([]byte(entry.body)); err != nil {
+				t.Fatalf("write tar body: %v", err)
+			}
+		}
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}

--- a/internal/pkg/credentials/secret.go
+++ b/internal/pkg/credentials/secret.go
@@ -21,52 +21,46 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"oras.land/oras-go/v2/registry/remote/auth"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 )
 
-func credentialFuncFromCredentials(creds auth.Credential) auth.CredentialFunc {
-	return func(ctx context.Context, hostport string) (auth.Credential, error) {
-		return creds, nil
-	}
+func anonymousCredential(_ context.Context, _ string) (auth.Credential, error) {
+	return auth.EmptyCredential, nil
 }
 
-// GetCredentialsFromSecret retrieves credentials from the Kubernetes secret
-// referenced by the AuthSecretRef and returns an ORAS credential.
-func GetCredentialsFromSecret(ctx context.Context, k8sClient client.Client, namespace string, authSecretRef *commonv1alpha1.SecretRef) (auth.CredentialFunc, error) {
-	var creds = auth.EmptyCredential
-
-	if authSecretRef == nil {
-		return credentialFuncFromCredentials(creds), nil
+// FromSecret derives an ORAS credential function from a Secret.
+// A nil secret yields anonymous credentials.
+func FromSecret(registry string, secret *corev1.Secret) (auth.CredentialFunc, error) {
+	if secret == nil {
+		return anonymousCredential, nil
+	}
+	if registry == "" {
+		return nil, fmt.Errorf("registry host is required when using pull credentials")
 	}
 
-	// Fetch the secret
-	secret := &corev1.Secret{}
-	secretNamespacedName := types.NamespacedName{
-		Name:      authSecretRef.Name,
-		Namespace: namespace,
+	creds, err := CredentialsFromSecret(secret)
+	if err != nil {
+		return nil, err
 	}
+	return auth.StaticCredential(registry, creds), nil
+}
 
-	if err := k8sClient.Get(ctx, secretNamespacedName, secret); err != nil {
-		return nil, fmt.Errorf("failed to get pull secret %s: %w", authSecretRef.Name, err)
-	}
-
-	// Extract username and password using standard kubernetes.io/basic-auth keys.
+// CredentialsFromSecret extracts registry credentials from a Kubernetes Secret.
+func CredentialsFromSecret(secret *corev1.Secret) (auth.Credential, error) {
 	username, ok := secret.Data[commonv1alpha1.SecretUsernameKey]
 	if !ok {
-		return nil, fmt.Errorf("key %q not found in secret %s", commonv1alpha1.SecretUsernameKey, authSecretRef.Name)
+		return auth.Credential{}, fmt.Errorf("key %q not found in secret %s", commonv1alpha1.SecretUsernameKey, secret.Name)
 	}
 
 	password, ok := secret.Data[commonv1alpha1.SecretPasswordKey]
 	if !ok {
-		return nil, fmt.Errorf("key %q not found in secret %s", commonv1alpha1.SecretPasswordKey, authSecretRef.Name)
+		return auth.Credential{}, fmt.Errorf("key %q not found in secret %s", commonv1alpha1.SecretPasswordKey, secret.Name)
 	}
 
-	return credentialFuncFromCredentials(auth.Credential{
+	return auth.Credential{
 		Username: string(username),
 		Password: string(password),
-	}), nil
+	}, nil
 }

--- a/internal/pkg/filesystem/mock.go
+++ b/internal/pkg/filesystem/mock.go
@@ -24,19 +24,20 @@ import (
 
 // MockFileSystem implements FileSystem for testing.
 type MockFileSystem struct {
-	Files       map[string][]byte
-	StatErr     error
-	ReadErr     error
-	WriteErr    error
-	RemoveErr   error
-	RenameErr   error
-	OpenErr     error
-	statCalls   []string
-	readCalls   []string
-	WriteCalls  []writeCall
-	RemoveCalls []string
-	RenameCalls []renameCall
-	openCalls   []string
+	Files        map[string][]byte
+	StatErr      error
+	ReadErr      error
+	WriteErr     error
+	RemoveErr    error
+	RemoveErrFor map[string]error
+	RenameErr    error
+	OpenErr      error
+	statCalls    []string
+	readCalls    []string
+	WriteCalls   []writeCall
+	RemoveCalls  []string
+	RenameCalls  []renameCall
+	openCalls    []string
 }
 
 type renameCall struct {
@@ -95,6 +96,9 @@ func (m *MockFileSystem) WriteFile(name string, data []byte, perm fs.FileMode) e
 // Remove deletes the named file from the mock filesystem.
 func (m *MockFileSystem) Remove(name string) error {
 	m.RemoveCalls = append(m.RemoveCalls, name)
+	if err, ok := m.RemoveErrFor[name]; ok {
+		return err
+	}
 	if m.RemoveErr != nil {
 		return m.RemoveErr
 	}

--- a/internal/pkg/oci/puller/mock.go
+++ b/internal/pkg/oci/puller/mock.go
@@ -22,11 +22,9 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"path/filepath"
+	"io"
 
 	"oras.land/oras-go/v2/registry/remote/auth"
-
-	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 )
 
 // MockOCIPuller implements Puller for testing.
@@ -35,51 +33,42 @@ type MockOCIPuller struct {
 	Result *RegistryResult
 	// PullErr is returned instead of pulling when set.
 	PullErr error
-	// FS is the filesystem used to write the archive on a successful pull.
-	// When set, Pull writes a minimal valid tar.gz archive to destDir/Result.Filename
-	// so that the caller (e.g. Manager.StoreFromOCI) can open and extract it.
-	FS        filesystem.FileSystem
-	PullCalls []PullCall
+	// AllowNilResult makes Pull return (nil, nil) when Result is nil.
+	AllowNilResult bool
+	// LayerContent is the raw layer payload (typically a tar.gz archive) copied to the
+	// destination writer when PullErr is nil. If nil, the payload is empty.
+	LayerContent []byte
+	PullCalls    []PullCall
 }
 
 // PullCall records the arguments of a Pull invocation.
 type PullCall struct {
-	Ref     string
-	DestDir string
-	OS      string
-	Arch    string
-	Opts    *RegistryOptions
+	Ref  string
+	OS   string
+	Arch string
+	Opts *RegistryOptions
 }
 
-// Pull records the call and returns the preset result or error.
-// When FS is set and Result is non-nil, it writes a minimal tar.gz archive to
-// destDir/Result.Filename before returning so the full StoreFromOCI path can proceed.
-func (m *MockOCIPuller) Pull(ctx context.Context, ref, destDir, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions) (*RegistryResult, error) {
-	m.PullCalls = append(m.PullCalls, PullCall{Ref: ref, DestDir: destDir, OS: os, Arch: arch, Opts: opts})
+// Pull records the call, writes LayerContent to dst, and returns the preset result.
+func (m *MockOCIPuller) Pull(ctx context.Context, ref, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions, dst io.Writer) (*RegistryResult, error) {
+	m.PullCalls = append(m.PullCalls, PullCall{Ref: ref, OS: os, Arch: arch, Opts: opts})
 	if m.PullErr != nil {
 		return nil, m.PullErr
 	}
 	if m.Result == nil {
+		if m.AllowNilResult {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("MockOCIPuller: Result is not set for ref %q", ref)
 	}
-	if m.FS != nil {
-		archivePath := filepath.Join(destDir, m.Result.Filename)
-		// Use "rules.yaml" as the inner file name so it differs from the archive
-		// file name; the manager removes the archive after extraction, and having
-		// the same name for both would cause the extracted file to be deleted too.
-		data, err := MakeTarGz("rules.yaml", []byte("fake-rules-content"))
-		if err != nil {
-			return nil, fmt.Errorf("MockOCIPuller: failed to create fake archive: %w", err)
-		}
-		if err := m.FS.WriteFile(archivePath, data, 0o644); err != nil {
-			return nil, fmt.Errorf("MockOCIPuller: failed to write archive to FS: %w", err)
-		}
+	if _, err := dst.Write(m.LayerContent); err != nil {
+		return nil, err
 	}
 	return m.Result, nil
 }
 
 // MakeTarGz creates a minimal valid tar.gz archive containing a single file
-// with the given name and content. Useful for seeding mock filesystems in tests.
+// with the given name and content. Useful for seeding mock pullers in tests.
 func MakeTarGz(filename string, content []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)

--- a/internal/pkg/oci/puller/puller.go
+++ b/internal/pkg/oci/puller/puller.go
@@ -26,7 +26,7 @@ import (
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -36,7 +36,7 @@ import (
 
 // Puller defines the interface for pulling OCI artifacts.
 type Puller interface {
-	Pull(ctx context.Context, ref, destDir, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions) (*RegistryResult, error)
+	Pull(ctx context.Context, ref, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions, dst io.Writer) (*RegistryResult, error)
 }
 
 // OciPuller implements the Puller interface for OCI artifacts.
@@ -52,18 +52,18 @@ func NewOciPuller(defaults *RegistryOptions) *OciPuller {
 	return &OciPuller{defaults: defaults}
 }
 
-// Pull an artifact from a remote registry.
+// Pull resolves ref to its artifact layer and copies the compressed layer payload into dst.
+//
 // Ref format follows: REGISTRY/REPO[:TAG|@DIGEST]. Ex. localhost:5000/hello:latest.
 // When opts is non-nil it overrides the puller defaults entirely.
-func (p *OciPuller) Pull(ctx context.Context, ref, destDir, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions) (*RegistryResult, error) {
+func (p *OciPuller) Pull(ctx context.Context, ref, os, arch string, creds auth.CredentialFunc, opts *RegistryOptions, dst io.Writer) (*RegistryResult, error) {
+	if dst == nil {
+		return nil, fmt.Errorf("nil destination writer")
+	}
+
 	options := p.defaults
 	if opts != nil {
 		options = opts
-	}
-
-	fileStore, err := file.New(destDir)
-	if err != nil {
-		return nil, err
 	}
 
 	repo, err := remote.NewRepository(ref)
@@ -85,31 +85,25 @@ func (p *OciPuller) Pull(ctx context.Context, ref, destDir, os, arch string, cre
 
 	repo.Client = client.NewClient(clientOpts...)
 
-	// if no tag was specified, "latest" is used
 	if repo.Reference.Reference == "" {
-		ref += ":" + DefaultTag
 		repo.Reference.Reference = DefaultTag
 	}
+	copyRef := repo.Reference.String()
 
-	refDesc, _, err := repo.FetchReference(ctx, ref)
+	refDesc, err := repo.Resolve(ctx, repo.Reference.Reference)
 	if err != nil {
 		return nil, err
 	}
 
-	copyOpts := oras.CopyOptions{}
-	copyOpts.Concurrency = 1
+	copyOpts := oras.CopyOptions{
+		CopyGraphOptions: oras.CopyGraphOptions{Concurrency: 1},
+	}
 	if refDesc.MediaType == v1.MediaTypeImageIndex {
-		plt := &v1.Platform{
-			OS:           os,
-			Architecture: arch,
-		}
-		copyOpts.WithTargetPlatform(plt)
+		copyOpts.WithTargetPlatform(&v1.Platform{OS: os, Architecture: arch})
 	}
 
-	localTarget := oras.Target(fileStore)
-
-	desc, err := oras.Copy(ctx, repo, ref, localTarget, ref, copyOpts)
-
+	localTarget := oras.Target(memory.New())
+	desc, err := oras.Copy(ctx, repo, copyRef, localTarget, copyRef, copyOpts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to pull artifact %s with tag %s from repo %s: %w",
 			repo.Reference.Repository, repo.Reference.Reference, repo.Reference.Repository, err)
@@ -120,8 +114,9 @@ func (p *OciPuller) Pull(ctx context.Context, ref, destDir, os, arch string, cre
 		return nil, err
 	}
 
+	layerDesc := manifest.Layers[0]
 	var artifactType ArtifactType
-	switch manifest.Layers[0].MediaType {
+	switch layerDesc.MediaType {
 	case FalcoPluginLayerMediaType:
 		artifactType = Plugin
 	case FalcoRulesfileLayerMediaType:
@@ -129,39 +124,64 @@ func (p *OciPuller) Pull(ctx context.Context, ref, destDir, os, arch string, cre
 	case FalcoAssetLayerMediaType:
 		artifactType = Asset
 	default:
-		return nil, fmt.Errorf("unknown media type: %q", manifest.Layers[0].MediaType)
+		return nil, fmt.Errorf("unknown media type: %q", layerDesc.MediaType)
 	}
 
-	filename := manifest.Layers[0].Annotations[v1.AnnotationTitle]
+	layerReader, err := localTarget.Fetch(ctx, layerDesc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch layer for %s: %w", ref, err)
+	}
+	if err := copyAndClose(dst, layerReader); err != nil {
+		return nil, fmt.Errorf("unable to read layer for %s: %w", ref, err)
+	}
 
 	return &RegistryResult{
 		RootDigest: string(refDesc.Digest),
 		Digest:     string(desc.Digest),
 		Type:       artifactType,
-		Filename:   filename,
+		Filename:   layerDesc.Annotations[v1.AnnotationTitle],
 	}, nil
 }
 
 func manifestFromDesc(ctx context.Context, target oras.Target, desc *v1.Descriptor) (*v1.Manifest, error) {
-	var manifest v1.Manifest
-
 	descReader, err := target.Fetch(ctx, *desc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch descriptor with digest %q: %w", desc.Digest, err)
 	}
 
-	descBytes, err := io.ReadAll(descReader)
+	descBytes, err := readAndClose(descReader)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read bytes from descriptor: %w", err)
 	}
 
-	if err = json.Unmarshal(descBytes, &manifest); err != nil {
+	var manifest v1.Manifest
+	if err := json.Unmarshal(descBytes, &manifest); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal manifest: %w", err)
 	}
-
 	if len(manifest.Layers) < 1 {
 		return nil, fmt.Errorf("no layers in manifest")
 	}
 
 	return &manifest, nil
+}
+
+func readAndClose(reader io.ReadCloser) ([]byte, error) {
+	data, readErr := io.ReadAll(reader)
+	closeErr := reader.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return data, nil
+}
+
+func copyAndClose(dst io.Writer, reader io.ReadCloser) error {
+	_, copyErr := io.Copy(dst, reader)
+	closeErr := reader.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }

--- a/internal/pkg/oci/puller/types.go
+++ b/internal/pkg/oci/puller/types.go
@@ -16,9 +16,7 @@
 
 package puller
 
-import (
-	"errors"
-)
+import "errors"
 
 // ArtifactType represents a rules file or a plugin. Used to select the right mediaType when interacting with the registry.
 type ArtifactType string

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -139,6 +139,11 @@ var FalcoDefaults = &InstanceDefaults{
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{"events.k8s.io"},
 			Resources: []string{"events"},
 			Verbs:     []string{"create", "patch"},

--- a/internal/pkg/resources/generator_test.go
+++ b/internal/pkg/resources/generator_test.go
@@ -179,9 +179,9 @@ func TestGenerateRole(t *testing.T) {
 		wantRuleCount int
 	}{
 		{
-			name:          "falco role has 4 rules",
+			name:          "falco role has 5 rules",
 			defs:          FalcoDefaults,
-			wantRuleCount: 4,
+			wantRuleCount: 5,
 		},
 		{
 			name:          "metacollector role has no rules",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

/area artifact-operator

> /area chart

/area pkg

> /area api

> /area docs

This fixes OCI artifact reconciliation when the effective source of an artifact changes after the artifact has already been installed.

The operator now detects source changes, pulls the updated OCI content, installs the new artifact through an pseudo-atomic final-file replacement, and keeps the previous artifact available if the update cannot be completed. This prevents stale rules or plugins from remaining active after `OCIArtifact` CR inputs change.

The controllers also reconcile dependent artifacts when referenced pull Secrets change, so authentication updates are applied without requiring an unrelated resource update.

**Which issue(s) this PR fixes**:

Fixes #337

**Special notes for your reviewer**:
