### PR TITLE
chore(instance): update default Falco image to 0.44.0

### DIFF
--- a/chart/falco-operator/CHANGELOG.md
+++ b/chart/falco-operator/CHANGELOG.md
@@ -6,6 +6,7 @@ release numbering uses [semantic versioning](http://semver.org).
 ## Unreleased
 
 * Document Helm chart installation as a first-class installation method.
+* Update the default managed Falco image tag to `0.44.0`.
 
 ## v0.1.0
 

--- a/docs/crds/falco.md
+++ b/docs/crds/falco.md
@@ -15,7 +15,7 @@ The `Falco` Custom Resource defines a Falco instance in the cluster. The operato
 |-------|------|---------|-------------|
 | `type` | `*string` | `DaemonSet` | Deployment mode: `DaemonSet` or `Deployment` |
 | `replicas` | `*int32` | `1` | Number of replicas (Deployment mode only) |
-| `version` | `*string` | *(auto-detected)* | Falco version to deploy |
+| `version` | `*string` | *(built-in default)* | Falco version to deploy. If omitted, the operator resolves it from the Falco container image tag in `podTemplateSpec` when provided, otherwise it uses the built-in default pinned in this operator release. |
 | `podTemplateSpec` | `*corev1.PodTemplateSpec` | *(operator defaults)* | Custom pod template to override defaults |
 | `updateStrategy` | `*appsv1.DaemonSetUpdateStrategy` | — | Update strategy for DaemonSet mode |
 | `strategy` | `*appsv1.DeploymentStrategy` | — | Update strategy for Deployment mode |
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: falco
-          image: falcosecurity/falco:0.43.0
+          image: falcosecurity/falco:0.44.0
           resources:
             requests:
               cpu: 200m
@@ -112,6 +112,6 @@ spec:
 ## Notes
 
 - When `type` is omitted, the operator defaults to `DaemonSet` mode.
-- When `version` is omitted, the operator resolves the version from the container image tag or uses a built-in default.
+- When `version` is omitted, the operator resolves the version from the Falco container image tag in `podTemplateSpec` when provided, otherwise it uses the built-in default pinned in this operator release.
 - The `podTemplateSpec` allows full customization of the Falco pod, including the Artifact Operator sidecar (init container named `artifact-operator`) and the Falco container (named `falco`).
 - Only one Falco CR should be created per namespace to avoid conflicts.

--- a/internal/pkg/image/const.go
+++ b/internal/pkg/image/const.go
@@ -25,7 +25,7 @@ const (
 	// FalcoImage the default image name used for Falco.
 	FalcoImage = "falco"
 	// FalcoTag the default tag used for Falco.
-	FalcoTag = "0.43.0"
+	FalcoTag = "0.44.0"
 
 	// MetacollectorImage the default image name used for k8s-metacollector.
 	MetacollectorImage = "k8s-metacollector"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

/kind documentation

> /kind failing-test

/kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

/area chart

> /area pkg

> /area api

/area docs

**What this PR does / why we need it**:

Updates the default managed Falco image tag to `0.44.0`.

This keeps the operator built-in Falco default aligned with the latest supported Falco release, and updates the Falco CRD documentation/example to describe how the default version is resolved when `spec.version` is omitted.

The Helm chart release/version bump is intentionally not part of this PR and will be handled separately.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
