### PR TITLE
feat(chart): add dnsPolicy and dnsConfig support

### DIFF
--- a/chart/falco-operator/CHANGELOG.md
+++ b/chart/falco-operator/CHANGELOG.md
@@ -5,6 +5,8 @@ release numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Add `dnsPolicy` and `dnsConfig` support for the operator pod.
+
 ## v0.2.0
 
 * Update the default Falco Operator image tag to `0.3.0`.

--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -48,6 +48,8 @@ The following table lists the configurable parameters of the falco-operator char
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules |
+| dnsConfig | object | `{}` | Pod DNS config. Requires dnsPolicy to be set to None to take full effect. |
+| dnsPolicy | string | `""` | Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None. |
 | extraArgs | list | `[]` | Additional CLI arguments passed to the operator binary |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraObjects | list | `[]` | Array of extra Kubernetes manifests to deploy alongside the operator. Each entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`) is supported within values. |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -102,4 +102,11 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -132,6 +132,19 @@ topologySpreadConstraints: []
 # -- Priority class name
 priorityClassName: ""
 
+# -- Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None.
+dnsPolicy: ""
+
+# -- Pod DNS config. Requires dnsPolicy to be set to None to take full effect.
+dnsConfig: {}
+  # nameservers:
+  #   - 1.1.1.1
+  # searches:
+  #   - ns.svc.cluster.local
+  # options:
+  #   - name: ndots
+  #     value: "2"
+
 # -- Array of extra Kubernetes manifests to deploy alongside the operator. Each
 # entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`)
 # is supported within values.


### PR DESCRIPTION
## What this PR does

Adds `dnsPolicy` and `dnsConfig` chart values so users can customize DNS resolution for the operator pod via the standard Pod spec fields. This complements the existing scheduling knobs (`nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, `priorityClassName`).

Both fields are guarded with `{{- with }}`, so they render nothing when left at their empty defaults and behavior is unchanged for existing users.

## Changes

* `values.yaml`: add `dnsPolicy: ""` and `dnsConfig: {}` (with commented examples).
* `templates/deployment.yaml`: render `dnsPolicy` and `dnsConfig` on the pod spec.
* `README.md`: regenerated via `make chart-docs`.
* `CHANGELOG.md`: add Unreleased entry.

## How to test

```yaml
dnsPolicy: None
dnsConfig:
  nameservers:
    - 1.1.1.1
  searches:
    - ns.svc.cluster.local
  options:
    - name: ndots
      value: "2"
```

`helm template` renders the fields onto the pod spec, and `helm lint` passes.