### PR TITLE
fix(instance): drop falco.yaml keys removed in Falco 0.44

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ The Falco Operator manages Falco deployments, companion components, and runtime 
 
 ### Falco Operator (Instance Controller)
 
-The Falco Operator is the primary component that users install and interact with. It runs as a DaemonSet (by default) in the `falco-operator` namespace and watches for Custom Resources in the `instance.falcosecurity.dev` and `artifact.falcosecurity.dev` API groups.
+The Falco Operator is the primary component that users install and interact with. It runs as a Deployment in the `falco-operator` namespace and watches for Custom Resources in the `instance.falcosecurity.dev` and `artifact.falcosecurity.dev` API groups.
 
 The instance operator binary registers four controllers:
 1. **Falco controller** — Reconciles `Falco` CRs
@@ -142,21 +142,19 @@ All controllers use **Server-Side Apply (SSA)** for resource management:
 | Setting | Value |
 |---------|-------|
 | Engine | `modern_ebpf` |
-| Container engines | CRI + Docker enabled |
 | Outputs | stdout + syslog |
 | Webserver | Enabled (port 8765, Prometheus metrics) |
 | Security context | Privileged |
 | Host mounts | `/proc`, `/sys`, `/dev`, `/etc`, container runtimes |
 | Resource requests | 100m CPU, 512Mi memory |
 | Resource limits | 1000m CPU, 1024Mi memory |
-| Probes | Liveness (60s delay), Readiness (30s delay) |
+| Probes | Startup (HTTP `/healthz`, 3s delay, 5s period, 20 failures), Liveness & Readiness (0s delay — the startup probe handles the wait) |
 
 ### Deployment Mode
 
 | Setting | Value |
 |---------|-------|
 | Engine | `nodriver` (plugin-only) |
-| Container engines | All disabled |
 | Designed for | Plugin-based event sources |
 
 ### Artifact Operator Sidecar
@@ -165,5 +163,5 @@ All controllers use **Server-Side Apply (SSA)** for resource management:
 |---------|-------|
 | Image | Configurable via `ARTIFACT_OPERATOR_IMAGE` env var |
 | Default image | `docker.io/falcosecurity/artifact-operator:latest` |
-| Probes | Readiness (5s delay), Liveness (15s delay) on port 8081 |
+| Probes | Startup (`/readyz`, 3s delay), Readiness (`/readyz`, 5s delay), Liveness (`/healthz`, 15s delay) — all on port 8081 |
 | Volumes | 3 shared `emptyDir` volumes (config, rulesfiles, plugins) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,8 @@ This means you do not need to provide a complete Falco configuration. Only speci
 
 ## Default Settings
 
+> These are the defaults of the operator-generated base `falco.yaml`. Optional functionality such as container metadata enrichment (`container.*`, `k8s.*` fields) is **not** part of the base config — load the [container plugin](getting-started.md) via a `Plugin` CR to enable it.
+
 ### DaemonSet Mode
 
 When a Falco CR uses `type: DaemonSet` (or omits `type`), the operator applies these defaults:
@@ -19,7 +21,6 @@ When a Falco CR uses `type: DaemonSet` (or omits `type`), the operator applies t
 | Category | Setting | Default Value |
 |----------|---------|---------------|
 | **Engine** | `engine.kind` | `modern_ebpf` |
-| **Container engines** | CRI, Docker | Both enabled |
 | **Outputs** | `stdout_output.enabled` | `true` |
 | | `syslog_output.enabled` | `true` |
 | **Webserver** | `webserver.enabled` | `true` |
@@ -35,7 +36,7 @@ When a Falco CR uses `type: DaemonSet` (or omits `type`), the operator applies t
 | | Liveness | HTTP `/healthz`, delay 0s (startup probe handles the wait) |
 | | Readiness | HTTP `/healthz`, delay 0s (startup probe handles the wait) |
 
-The full default `falco.yaml` configuration (engine, CRI sockets, outputs, metrics, etc.) is defined in [`internal/pkg/resources/falco.go`](../internal/pkg/resources/falco.go).
+The full default `falco.yaml` configuration (engine, outputs, metrics, etc.) is defined in [`internal/pkg/resources/falco.go`](../internal/pkg/resources/falco.go).
 
 ### Deployment Mode
 
@@ -44,7 +45,6 @@ When a Falco CR uses `type: Deployment`, the operator applies these defaults:
 | Category | Setting | Default Value |
 |----------|---------|---------------|
 | **Engine** | `engine.kind` | `nodriver` |
-| **Container engines** | All | Disabled |
 | **Designed for** | | Plugin-only workloads |
 
 All other settings (outputs, webserver, resources) follow the same defaults as DaemonSet mode.

--- a/docs/crds/plugin.md
+++ b/docs/crds/plugin.md
@@ -73,6 +73,8 @@ spec:
       with_size: false
 ```
 
+> Socket paths under `initConfig.engines.<engine>.sockets` are node paths (e.g. `/run/containerd/containerd.sock`) — do not prepend `/host`; the container plugin adds `HOST_ROOT` automatically.
+
 ### K8s audit plugin
 
 ```yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,7 +79,7 @@ kubectl get falco
 kubectl get pods -l app.kubernetes.io/name=falco
 ```
 
-> **Note**: Falco starts in idle mode — it will not actively monitor until you provide detection rules.
+> **Note**: Falco starts in idle mode — it will not actively monitor until you provide detection rules. Container metadata fields (`container.*`, `k8s.*`) are also unavailable until you load the container plugin (next step).
 
 ## 3. Add the Container Plugin
 
@@ -100,6 +100,8 @@ spec:
       name: ghcr.io
 EOF
 ```
+
+> **Note**: The default runtime sockets work out of the box — the operator mounts them and the plugin resolves paths via `HOST_ROOT`. If you set custom sockets under `spec.config.initConfig.engines`, use plain node paths (e.g. `/run/containerd/containerd.sock`) — do **not** prepend `/host`; the plugin adds it automatically.
 
 ## 4. Add Detection Rules
 

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -289,29 +289,7 @@ base_syscalls:
 buffered_outputs: false
 config_files:
 - /etc/falco/config.d
-container_engines:
-  bpm:
-    enabled: false
-  cri:
-    enabled: true
-    sockets:
-    - /run/containerd/containerd.sock
-    - /run/crio/crio.sock
-    - /run/k3s/containerd/containerd.sock
-    - /run/host-containerd/containerd.sock
-  docker:
-    enabled: true
-  libvirt_lxc:
-    enabled: false
-  lxc:
-    enabled: false
-  podman:
-    enabled: false
 engine:
-  ebpf:
-    buf_size_preset: 4
-    drop_failed_exit: false
-    probe: ${HOME}/.falco/falco-bpf.o
   kind: modern_ebpf
   kmod:
     buf_size_preset: 4
@@ -329,12 +307,6 @@ file_output:
   enabled: false
   filename: ./events.txt
   keep_alive: false
-grpc:
-  bind_address: unix:///run/falco/falco.sock
-  enabled: false
-  threadiness: 0
-grpc_output:
-  enabled: false
 http_output:
   ca_bundle: ""
   ca_cert: ""
@@ -420,29 +392,7 @@ base_syscalls:
 buffered_outputs: false
 config_files:
 - /etc/falco/config.d
-container_engines:
-  bpm:
-    enabled: false
-  cri:
-    enabled: false
-    sockets:
-    - /run/containerd/containerd.sock
-    - /run/crio/crio.sock
-    - /run/k3s/containerd/containerd.sock
-    - /run/host-containerd/containerd.sock
-  docker:
-    enabled: false
-  libvirt_lxc:
-    enabled: false
-  lxc:
-    enabled: false
-  podman:
-    enabled: false
 engine:
-  ebpf:
-    buf_size_preset: 4
-    drop_failed_exit: false
-    probe: ${HOME}/.falco/falco-bpf.o
   kind: nodriver
   kmod:
     buf_size_preset: 4
@@ -460,12 +410,6 @@ file_output:
   enabled: false
   filename: ./events.txt
   keep_alive: false
-grpc:
-  bind_address: unix:///run/falco/falco.sock
-  enabled: false
-  threadiness: 0
-grpc_output:
-  enabled: false
 http_output:
   ca_bundle: ""
   ca_cert: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

/area docs

**What this PR does / why we need it**:

The operator's base `falco.yaml` still shipped keys that Falco 0.44 removed, so the agent reports a schema-validation error at startup (`schema validation: failed for <root>[engine]: ... 'ebpf'`). This drops them from both the DaemonSet and Deployment base configs: `engine.ebpf` (legacy eBPF probe), `grpc`/`grpc_output` (gRPC server/output), and the now-dead `container_engines` block (inert since Falco 0.41; dropped upstream in falcosecurity/falco#3924). Engine kinds (`modern_ebpf`/`nodriver`) are unchanged and no behavior changes on the supported drivers — both configs pass `falco 0.44.0 --dry-run` with `schema validation: ok`.

The docs commit aligns `configuration.md`/`architecture.md` with this change and fixes a few unrelated pre-existing inaccuracies in `architecture.md` (operator runs as a Deployment, not a DaemonSet; correct Falco and sidecar probe values).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #344 

**Special notes for your reviewer**:
