### PR TITLE
feat(instance): allow excluding labels from propagation to generated resources

### DIFF
--- a/chart/falco-operator/CHANGELOG.md
+++ b/chart/falco-operator/CHANGELOG.md
@@ -5,6 +5,7 @@ release numbering uses [semantic versioning](http://semver.org).
 
 ## Unreleased
 
+* Add `excludedLabels` to stop propagating tracking labels used by external tools onto operator-generated resources, preventing repeated removal/recreation of cluster-scoped resources.
 * Add `dnsPolicy` and `dnsConfig` support for the operator pod.
 
 ## v0.2.0

--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the falco-operator char
 | affinity | object | `{}` | Affinity rules |
 | dnsConfig | object | `{}` | Pod DNS config. Requires dnsPolicy to be set to None to take full effect. |
 | dnsPolicy | string | `""` | Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None. |
+| excludedLabels | list | `[]` | Label keys that must NOT be propagated onto operator-generated resources. Supports the '*' wildcard (e.g. `kustomize.toolkit.fluxcd.io/*`). |
 | extraArgs | list | `[]` | Additional CLI arguments passed to the operator binary |
 | extraEnv | list | `[]` | Extra environment variables |
 | extraObjects | list | `[]` | Array of extra Kubernetes manifests to deploy alongside the operator. Each entry is rendered with `tpl`, so Helm templating (e.g. `{{ .Release.Name }}`) is supported within values. |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - /usr/bin/manager
           args:
             - --health-probe-bind-address=:8081
+            {{- range .Values.excludedLabels }}
+            - --excluded-labels={{ . }}
+            {{- end }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -101,6 +101,13 @@ volumes: []
 # -- Additional volume mounts
 volumeMounts: []
 
+# -- Label keys that must NOT be propagated onto operator-generated resources.
+# Supports the '*' wildcard (e.g. `kustomize.toolkit.fluxcd.io/*`).
+excludedLabels: []
+  # - argocd.argoproj.io/instance
+  # - kustomize.toolkit.fluxcd.io/name
+  # - kustomize.toolkit.fluxcd.io/namespace
+
 # -- Additional CLI arguments passed to the operator binary
 extraArgs: []
   # - --metrics-bind-address=:8443

--- a/cmd/instance/main.go
+++ b/cmd/instance/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -42,6 +43,7 @@ import (
 	secretctr "github.com/falcosecurity/falco-operator/controllers/instance/reference/secret"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/instance"
 	"github.com/falcosecurity/falco-operator/internal/pkg/version"
 )
 
@@ -49,6 +51,18 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+// stringSliceFlag accumulates repeated string flag values into a slice.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -66,6 +80,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var excludedLabels stringSliceFlag
 	var tlsOpts []func(*tls.Config)
 	var opts zap.Options
 
@@ -86,6 +101,9 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.Var(&excludedLabels, "excluded-labels",
+		"A label key to exclude from propagation onto operator-generated resources. "+
+			"The '*' wildcard is supported (e.g. kustomize.toolkit.fluxcd.io/*). May be repeated.")
 
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -183,6 +201,10 @@ func main() {
 
 	setupLog.Info("SidecarContainers feature", "enabled", sidecarEnabled)
 
+	// Build the label filter applied to generated resources.
+	labelFilter := instance.NewLabelFilter(excludedLabels)
+	setupLog.V(4).Info("Label propagation filter", "excludedLabels", []string(excludedLabels))
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -218,6 +240,7 @@ func main() {
 
 	if err = falco.NewReconciler(
 		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("falco-controller"), sidecarEnabled,
+		falco.WithLabelFilter(labelFilter),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Falco")
 		os.Exit(1)
@@ -225,6 +248,7 @@ func main() {
 
 	if err = component.NewReconciler(
 		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("component-controller"),
+		component.WithLabelFilter(labelFilter),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Component")
 		os.Exit(1)

--- a/controllers/instance/component/controller.go
+++ b/controllers/instance/component/controller.go
@@ -59,17 +59,32 @@ var clusterScopedGVKs = []schema.GroupVersionKind{
 // Reconciler reconciles a Component object.
 type Reconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	recorder events.EventRecorder
+	Scheme      *runtime.Scheme
+	recorder    events.EventRecorder
+	labelFilter instance.LabelFilter
+}
+
+// Option configures a Reconciler.
+type Option func(*Reconciler)
+
+// WithLabelFilter sets the label filter applied to generated resources.
+func WithLabelFilter(f instance.LabelFilter) Option {
+	return func(r *Reconciler) {
+		r.labelFilter = f
+	}
 }
 
 // NewReconciler creates a new Reconciler.
-func NewReconciler(cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) *Reconciler {
-	return &Reconciler{
+func NewReconciler(cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder, opts ...Option) *Reconciler {
+	r := &Reconciler{
 		Client:   cl,
 		Scheme:   scheme,
 		recorder: recorder,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=components;components/status,verbs=create;delete;get;list;patch;update;watch
@@ -102,6 +117,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	if ok, err := r.handleDeletion(ctx, comp); ok || err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Drop excluded label keys up front so they are not propagated onto any
+	// generated resource. This mutates the in-memory copy only; the Component
+	// resource on the API server keeps its labels.
+	comp.SetLabels(r.labelFilter.Apply(comp.GetLabels()))
 
 	// Patch status via defer to ensure it's always called.
 	defer func() {

--- a/controllers/instance/component/controller_unit_test.go
+++ b/controllers/instance/component/controller_unit_test.go
@@ -720,3 +720,89 @@ func TestPatchStatus(t *testing.T) {
 	assert.Equal(t, int32(1), obj.Status.DesiredReplicas)
 	assert.Equal(t, int32(1), obj.Status.AvailableReplicas)
 }
+
+// TestReconcileLabelExclusion verifies the contract of the label filter: keys
+// propagated from the Component resource's metadata are dropped from generated
+// resources (cluster-scoped, workload metadata and pod template), pod selector
+// labels are always preserved, and the Component resource itself is never mutated.
+func TestReconcileLabelExclusion(t *testing.T) {
+	scheme := testutil.Scheme(t, instancev1alpha1.AddToScheme)
+
+	tests := []struct {
+		name        string
+		crLabels    map[string]string
+		excluded    []string
+		wantAbsent  []string
+		wantPodTmpl map[string]string
+		wantCRKeeps []string
+	}{
+		{
+			name:        "tracking label is not propagated, benign label is",
+			crLabels:    map[string]string{"argocd.argoproj.io/instance": "tracked", "team": "secops"},
+			excluded:    []string{"argocd.argoproj.io/instance"},
+			wantAbsent:  []string{"argocd.argoproj.io/instance"},
+			wantPodTmpl: map[string]string{"team": "secops", "app.kubernetes.io/name": "test-mc", "app.kubernetes.io/instance": "test-mc"},
+			wantCRKeeps: []string{"argocd.argoproj.io/instance"},
+		},
+		{
+			name:        "excluding a selector key still preserves it in the pod template",
+			crLabels:    map[string]string{"app.kubernetes.io/instance": "custom", "app.kubernetes.io/version": "1.0", "team": "secops"},
+			excluded:    []string{"app.kubernetes.io/*"},
+			wantAbsent:  []string{"app.kubernetes.io/version"},
+			wantPodTmpl: map[string]string{"team": "secops", "app.kubernetes.io/name": "test-mc", "app.kubernetes.io/instance": "test-mc"},
+		},
+		{
+			name:     "disabled filter propagates labels unchanged",
+			crLabels: map[string]string{"argocd.argoproj.io/instance": "tracked"},
+			excluded: nil,
+			wantPodTmpl: map[string]string{
+				"argocd.argoproj.io/instance": "tracked",
+				"app.kubernetes.io/name":      "test-mc",
+				"app.kubernetes.io/instance":  "test-mc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := newMetacollectorComponent("test-mc").WithLabels(tt.crLabels).Build()
+			// Pre-set the finalizer so Reconcile proceeds past ensureFinalizer in one pass.
+			comp.Finalizers = []string{finalizer}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(comp).
+				WithStatusSubresource(comp).Build()
+			r := NewReconciler(cl, scheme, events.NewFakeRecorder(10),
+				WithLabelFilter(instance.NewLabelFilter(tt.excluded)))
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(comp)})
+			require.NoError(t, err)
+
+			dep := &appsv1.Deployment{}
+			require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(comp), dep))
+			cr := &rbacv1.ClusterRole{}
+			require.NoError(t, cl.Get(context.Background(),
+				client.ObjectKey{Name: resources.GenerateUniqueName(comp.Name, comp.Namespace)}, cr))
+
+			for _, k := range tt.wantAbsent {
+				assert.NotContains(t, cr.Labels, k, "ClusterRole must not carry %s", k)
+				assert.NotContains(t, dep.Labels, k, "Deployment metadata must not carry %s", k)
+				assert.NotContains(t, dep.Spec.Template.Labels, k, "pod template must not carry %s", k)
+			}
+			for k, v := range tt.wantPodTmpl {
+				assert.Equal(t, v, dep.Spec.Template.Labels[k], "pod template label %s", k)
+			}
+
+			// The pod template must always remain a superset of the immutable selector.
+			require.NotEmpty(t, dep.Spec.Selector.MatchLabels)
+			for k, v := range dep.Spec.Selector.MatchLabels {
+				assert.Equal(t, v, dep.Spec.Template.Labels[k], "pod template must satisfy selector key %s", k)
+			}
+
+			// The Component resource itself must keep its labels (filter is in-memory only).
+			srv := &instancev1alpha1.Component{}
+			require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(comp), srv))
+			for _, k := range tt.wantCRKeeps {
+				assert.Contains(t, srv.Labels, k, "Component resource must retain %s", k)
+			}
+		})
+	}
+}

--- a/controllers/instance/falco/controller.go
+++ b/controllers/instance/falco/controller.go
@@ -64,16 +64,33 @@ type Reconciler struct {
 	recorder events.EventRecorder
 	// NativeSidecar is a flag to enable the native sidecar.
 	NativeSidecar bool
+	// labelFilter excludes label keys from propagation onto generated resources.
+	labelFilter instance.LabelFilter
+}
+
+// Option configures a Reconciler.
+type Option func(*Reconciler)
+
+// WithLabelFilter sets the label filter applied to generated resources.
+func WithLabelFilter(f instance.LabelFilter) Option {
+	return func(r *Reconciler) {
+		r.labelFilter = f
+	}
 }
 
 // NewReconciler creates a new Reconciler.
-func NewReconciler(cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder, nativeSidecar bool) *Reconciler {
-	return &Reconciler{
+func NewReconciler(cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder,
+	nativeSidecar bool, opts ...Option) *Reconciler {
+	r := &Reconciler{
 		Client:        cl,
 		Scheme:        scheme,
 		recorder:      recorder,
 		NativeSidecar: nativeSidecar,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos;falcos/status,verbs=create;delete;get;list;patch;update;watch
@@ -110,6 +127,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	if ok, err := r.handleDeletion(ctx, falco); ok || err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Drop excluded label keys up front so they are not propagated onto any
+	// generated resource. This mutates the in-memory copy only; the Falco
+	// resource on the API server keeps its labels.
+	falco.SetLabels(r.labelFilter.Apply(falco.GetLabels()))
 
 	// Patch status via defer to ensure it's always called.
 	defer func() {

--- a/controllers/instance/falco/controller_unit_test.go
+++ b/controllers/instance/falco/controller_unit_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -614,6 +615,89 @@ func TestEnsureDeployment(t *testing.T) {
 				assert.Equal(t, tt.falco.Name, dep.GetOwnerReferences()[0].Name)
 			default:
 				assert.Fail(t, "unknown resource type")
+			}
+		})
+	}
+}
+
+// TestReconcileLabelExclusion verifies the contract of the label filter: keys
+// propagated from the Falco resource's metadata are dropped from generated
+// resources (cluster-scoped, workload metadata and pod template), pod selector
+// labels are always preserved, and the Falco resource itself is never mutated.
+func TestReconcileLabelExclusion(t *testing.T) {
+	scheme := testutil.Scheme(t, instancev1alpha1.AddToScheme)
+
+	tests := []struct {
+		name        string
+		crLabels    map[string]string
+		excluded    []string
+		wantAbsent  []string          // keys that must NOT appear on generated resources
+		wantPodTmpl map[string]string // keys+values that must appear in the pod template
+		wantCRKeeps []string          // keys the Falco resource must retain
+	}{
+		{
+			name:        "tracking label is not propagated, benign label is",
+			crLabels:    map[string]string{"argocd.argoproj.io/instance": "tracked", "team": "secops"},
+			excluded:    []string{"argocd.argoproj.io/instance"},
+			wantAbsent:  []string{"argocd.argoproj.io/instance"},
+			wantPodTmpl: map[string]string{"team": "secops", "app.kubernetes.io/name": "test", "app.kubernetes.io/instance": "test"},
+			wantCRKeeps: []string{"argocd.argoproj.io/instance"},
+		},
+		{
+			name:        "excluding a selector key still preserves it in the pod template",
+			crLabels:    map[string]string{"app.kubernetes.io/instance": "custom", "app.kubernetes.io/version": "1.0", "team": "secops"},
+			excluded:    []string{"app.kubernetes.io/*"},
+			wantAbsent:  []string{"app.kubernetes.io/version"},
+			wantPodTmpl: map[string]string{"team": "secops", "app.kubernetes.io/name": "test", "app.kubernetes.io/instance": "test"},
+		},
+		{
+			name:        "disabled filter propagates labels unchanged",
+			crLabels:    map[string]string{"argocd.argoproj.io/instance": "tracked"},
+			excluded:    nil,
+			wantPodTmpl: map[string]string{"argocd.argoproj.io/instance": "tracked", "app.kubernetes.io/name": "test", "app.kubernetes.io/instance": "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			falco := builders.NewFalco().WithName("test").WithNamespace(testutil.TestNamespace).
+				WithType(resources.ResourceTypeDaemonSet).WithLabels(tt.crLabels).Build()
+			// Pre-set the finalizer so Reconcile proceeds past ensureFinalizer in one pass.
+			falco.Finalizers = []string{finalizer}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(falco).
+				WithStatusSubresource(falco).Build()
+			r := NewReconciler(cl, scheme, events.NewFakeRecorder(10), false,
+				WithLabelFilter(instance.NewLabelFilter(tt.excluded)))
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(falco)})
+			require.NoError(t, err)
+
+			ds := &appsv1.DaemonSet{}
+			require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(falco), ds))
+			cr := &rbacv1.ClusterRole{}
+			require.NoError(t, cl.Get(context.Background(),
+				client.ObjectKey{Name: resources.GenerateUniqueName(falco.Name, falco.Namespace)}, cr))
+
+			for _, k := range tt.wantAbsent {
+				assert.NotContains(t, cr.Labels, k, "ClusterRole must not carry %s", k)
+				assert.NotContains(t, ds.Labels, k, "DaemonSet metadata must not carry %s", k)
+				assert.NotContains(t, ds.Spec.Template.Labels, k, "pod template must not carry %s", k)
+			}
+			for k, v := range tt.wantPodTmpl {
+				assert.Equal(t, v, ds.Spec.Template.Labels[k], "pod template label %s", k)
+			}
+
+			// The pod template must always remain a superset of the immutable selector.
+			require.NotEmpty(t, ds.Spec.Selector.MatchLabels)
+			for k, v := range ds.Spec.Selector.MatchLabels {
+				assert.Equal(t, v, ds.Spec.Template.Labels[k], "pod template must satisfy selector key %s", k)
+			}
+
+			// The Falco resource itself must keep its labels (filter is in-memory only).
+			srv := &instancev1alpha1.Falco{}
+			require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(falco), srv))
+			for _, k := range tt.wantCRKeeps {
+				assert.Contains(t, srv.Labels, k, "Falco resource must retain %s", k)
 			}
 		})
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,3 +161,24 @@ env:
 ```
 
 Default: `docker.io/falcosecurity/artifact-operator:latest`
+
+## Excluding labels from propagation
+
+The operator copies the labels of a `Falco` (or `Component`) resource onto the resources it generates.
+Some external tools add their own labels to the resources they manage and rely on them to decide which objects they own.
+When such a label is copied onto a generated resource, the tool may treat that resource as one of its own and remove it when it is not part of its desired state.
+Namespaced resources are protected by their `OwnerReference`, but cluster-scoped resources (`ClusterRole`, `ClusterRoleBinding`) cannot carry one, so they may be removed and recreated repeatedly.
+
+The `--excluded-labels` flag lists label keys the operator must not copy from the resource's `metadata.labels` onto the resources it generates.
+Matching keys are dropped wherever the operator would propagate them — including the workload metadata and its pod template — while pod selector labels are always preserved.
+Labels you set explicitly (for example in `spec.podTemplateSpec.metadata.labels`) are left untouched.
+The `*` wildcard is supported and the flag may be repeated.
+
+The Helm chart exposes this as the `excludedLabels` array. It is empty by default — add the label keys your environment requires:
+
+```yaml
+excludedLabels:
+  - argocd.argoproj.io/instance
+  - kustomize.toolkit.fluxcd.io/name
+  - kustomize.toolkit.fluxcd.io/namespace
+```

--- a/internal/pkg/instance/ensure_test.go
+++ b/internal/pkg/instance/ensure_test.go
@@ -291,71 +291,80 @@ func TestPrepareResource_InputValidation(t *testing.T) {
 	}
 }
 
-func TestPrepareResource_NamespacedResource(t *testing.T) {
+func TestPrepareResource(t *testing.T) {
 	scheme := testScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	ownerCM := builders.NewConfigMap().WithName("test-owner").
-		WithNamespace("default").
-		WithLabels(map[string]string{"app": "test"}).Build()
-	ownerCM.UID = "test-uid"
+	// newOwner builds a ConfigMap owner with the given labels, optionally with a
+	// UID so that SetControllerReference succeeds.
+	newOwner := func(labels map[string]string, withUID bool) *corev1.ConfigMap {
+		cm := builders.NewConfigMap().WithName("test-owner").WithNamespace("default").
+			WithLabels(labels).Build()
+		if withUID {
+			cm.UID = "test-uid"
+		}
+		return cm
+	}
 
-	resource := builders.NewService().
-		WithNamespace(ownerCM.Namespace).
-		WithLabels(ownerCM.Labels).Build()
+	clusterRoleName := resources.GenerateUniqueName("test-owner", "default")
 
-	result, err := PrepareResource(cl, ownerCM, resource, GenerateOptions{
-		SetControllerRef: true,
-		IsClusterScoped:  false,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
+	tests := []struct {
+		name           string
+		owner          client.Object
+		resource       runtime.Object
+		options        GenerateOptions
+		wantErr        string
+		wantKind       string
+		wantAPIVersion string
+		wantName       string
+		wantLabels     map[string]string
+	}{
+		{
+			name:           "namespaced resource keeps its name and labels",
+			owner:          newOwner(map[string]string{"app": "test"}, true),
+			resource:       builders.NewService().WithNamespace("default").WithLabels(map[string]string{"app": "test"}).Build(),
+			options:        GenerateOptions{SetControllerRef: true},
+			wantKind:       "Service",
+			wantAPIVersion: "v1",
+			wantName:       "test-owner",
+			wantLabels:     map[string]string{"app": "test"},
+		},
+		{
+			name:           "cluster-scoped resource gets a unique name",
+			owner:          newOwner(map[string]string{"app": "test"}, false),
+			resource:       builders.NewClusterRole().WithName(clusterRoleName).WithLabels(map[string]string{"app": "test"}).Build(),
+			options:        GenerateOptions{IsClusterScoped: true},
+			wantKind:       "ClusterRole",
+			wantAPIVersion: "rbac.authorization.k8s.io/v1",
+			wantName:       "test-owner--default",
+			wantLabels:     map[string]string{"app": "test"},
+		},
+		{
+			name:     "controller reference failure on owner without UID",
+			owner:    newOwner(nil, false),
+			resource: builders.NewService().Build(),
+			options:  GenerateOptions{SetControllerRef: true},
+			wantErr:  "failed to set controller reference",
+		},
+	}
 
-	assert.Equal(t, "Service", result.GetKind())
-	assert.Equal(t, "v1", result.GetAPIVersion())
-	assert.Equal(t, "test-owner", result.GetName())
-	assert.Equal(t, map[string]string{"app": "test"}, result.GetLabels())
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := PrepareResource(cl, tt.owner, tt.resource, tt.options)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
 
-func TestPrepareResource_ClusterScopedResource(t *testing.T) {
-	scheme := testScheme(t)
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	ownerCM := builders.NewConfigMap().WithName("test-owner").WithNamespace("default").
-		WithLabels(map[string]string{"app": "test"}).Build()
-
-	resource := builders.NewClusterRole().
-		WithName(resources.GenerateUniqueName(ownerCM.Name, ownerCM.Namespace)).
-		WithLabels(ownerCM.Labels).Build()
-
-	result, err := PrepareResource(cl, ownerCM, resource, GenerateOptions{
-		SetControllerRef: false,
-		IsClusterScoped:  true,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-
-	assert.Equal(t, "ClusterRole", result.GetKind())
-	assert.Equal(t, "rbac.authorization.k8s.io/v1", result.GetAPIVersion())
-	assert.Equal(t, "test-owner--default", result.GetName())
-	assert.Equal(t, map[string]string{"app": "test"}, result.GetLabels())
-}
-
-func TestPrepareResource_ControllerRefFailure(t *testing.T) {
-	scheme := testScheme(t)
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	// Owner without UID causes SetControllerReference to fail.
-	ownerCM := builders.NewConfigMap().WithName("test-owner").WithNamespace("default").Build()
-
-	resource := builders.NewService().Build()
-
-	_, err := PrepareResource(cl, ownerCM, resource, GenerateOptions{
-		SetControllerRef: true,
-		IsClusterScoped:  false,
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to set controller reference")
+			assert.Equal(t, tt.wantKind, result.GetKind())
+			assert.Equal(t, tt.wantAPIVersion, result.GetAPIVersion())
+			assert.Equal(t, tt.wantName, result.GetName())
+			assert.Equal(t, tt.wantLabels, result.GetLabels())
+		})
+	}
 }
 
 func TestEnsureResource(t *testing.T) {

--- a/internal/pkg/instance/labels.go
+++ b/internal/pkg/instance/labels.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package instance
+
+import "strings"
+
+// LabelFilter excludes label keys matching any of its glob patterns from being
+// propagated onto operator-generated resources. A pattern supports the '*'
+// wildcard, which matches any sequence of characters (including '/'); every
+// other character is matched literally. The zero value excludes nothing.
+type LabelFilter struct {
+	patterns []string
+}
+
+// NewLabelFilter builds a LabelFilter from the given glob patterns. Empty or
+// whitespace-only patterns are ignored.
+func NewLabelFilter(patterns []string) LabelFilter {
+	cleaned := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		if p = strings.TrimSpace(p); p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+	return LabelFilter{patterns: cleaned}
+}
+
+// Enabled reports whether the filter has any pattern configured.
+func (f LabelFilter) Enabled() bool {
+	return len(f.patterns) > 0
+}
+
+// Matches reports whether the given label key matches any configured pattern.
+func (f LabelFilter) Matches(key string) bool {
+	for _, p := range f.patterns {
+		if matchGlob(p, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// Apply returns a copy of labels with every key matching the filter removed.
+// The input is returned unchanged when the filter is disabled or labels is
+// empty. It returns nil when filtering removes every entry.
+func (f LabelFilter) Apply(labels map[string]string) map[string]string {
+	if !f.Enabled() || len(labels) == 0 {
+		return labels
+	}
+
+	filtered := make(map[string]string, len(labels))
+	for k, v := range labels {
+		if !f.Matches(k) {
+			filtered[k] = v
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+// matchGlob reports whether s matches pattern, where '*' matches any sequence of
+// characters (including '/') and every other character is matched literally.
+func matchGlob(pattern, s string) bool {
+	// Fast path: a pattern without a wildcard is an exact match.
+	if !strings.Contains(pattern, "*") {
+		return pattern == s
+	}
+
+	var (
+		px, sx         int
+		starPx, starSx = -1, -1
+	)
+	for sx < len(s) {
+		switch {
+		case px < len(pattern) && pattern[px] == '*':
+			// Record the wildcard position and assume it matches nothing yet.
+			starPx, starSx = px, sx
+			px++
+		case px < len(pattern) && pattern[px] == s[sx]:
+			px++
+			sx++
+		case starPx != -1:
+			// Backtrack: let the last wildcard consume one more character.
+			px = starPx + 1
+			starSx++
+			sx = starSx
+		default:
+			return false
+		}
+	}
+
+	// Trailing wildcards in the pattern match the empty string.
+	for px < len(pattern) && pattern[px] == '*' {
+		px++
+	}
+	return px == len(pattern)
+}

--- a/internal/pkg/instance/labels_test.go
+++ b/internal/pkg/instance/labels_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{name: "exact match", pattern: "argocd.argoproj.io/instance", key: "argocd.argoproj.io/instance", want: true},
+		{name: "exact mismatch", pattern: "argocd.argoproj.io/instance", key: "argocd.argoproj.io/secret-type", want: false},
+		{name: "trailing wildcard matches suffix", pattern: "kustomize.toolkit.fluxcd.io/*", key: "kustomize.toolkit.fluxcd.io/name", want: true},
+		{name: "trailing wildcard crosses slash", pattern: "kustomize.toolkit.fluxcd.io/*", key: "kustomize.toolkit.fluxcd.io/namespace", want: true},
+		{name: "trailing wildcard matches empty", pattern: "prefix/*", key: "prefix/", want: true},
+		{name: "wildcard does not match different prefix", pattern: "kustomize.toolkit.fluxcd.io/*", key: "argocd.argoproj.io/instance", want: false},
+		{name: "leading wildcard", pattern: "*/instance", key: "argocd.argoproj.io/instance", want: true},
+		{name: "leading wildcard crosses slash", pattern: "*instance", key: "app.kubernetes.io/instance", want: true},
+		{name: "middle wildcard", pattern: "app.*.io/name", key: "app.kubernetes.io/name", want: true},
+		{name: "multiple wildcards", pattern: "*.fluxcd.io/*", key: "kustomize.toolkit.fluxcd.io/name", want: true},
+		{name: "bare wildcard matches anything", pattern: "*", key: "any/label-key", want: true},
+		{name: "bare wildcard matches empty", pattern: "*", key: "", want: true},
+		{name: "no wildcard empty mismatch", pattern: "x", key: "", want: false},
+		{name: "literal mismatch with wildcard present", pattern: "a*c", key: "axd", want: false},
+		{name: "wildcard greedy backtrack", pattern: "a*c", key: "abcbc", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchGlob(tt.pattern, tt.key))
+		})
+	}
+}
+
+func TestNewLabelFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		patterns    []string
+		wantEnabled bool
+	}{
+		{name: "nil patterns", patterns: nil, wantEnabled: false},
+		{name: "empty slice", patterns: []string{}, wantEnabled: false},
+		{name: "only blanks", patterns: []string{"", "   "}, wantEnabled: false},
+		{name: "blanks are trimmed away", patterns: []string{" argocd.argoproj.io/instance ", ""}, wantEnabled: true},
+		{name: "valid patterns", patterns: []string{"argocd.argoproj.io/instance"}, wantEnabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewLabelFilter(tt.patterns)
+			assert.Equal(t, tt.wantEnabled, f.Enabled())
+		})
+	}
+}
+
+func TestLabelFilterMatches(t *testing.T) {
+	f := NewLabelFilter([]string{"argocd.argoproj.io/instance", "kustomize.toolkit.fluxcd.io/*"})
+
+	assert.True(t, f.Matches("argocd.argoproj.io/instance"))
+	assert.True(t, f.Matches("kustomize.toolkit.fluxcd.io/name"))
+	assert.False(t, f.Matches("app.kubernetes.io/name"))
+	assert.False(t, NewLabelFilter(nil).Matches("anything"))
+}
+
+func TestLabelFilterApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		labels   map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "disabled filter returns input unchanged",
+			patterns: nil,
+			labels:   map[string]string{"argocd.argoproj.io/instance": "falco", "app": "falco"},
+			want:     map[string]string{"argocd.argoproj.io/instance": "falco", "app": "falco"},
+		},
+		{
+			name:     "nil labels returned as-is",
+			patterns: []string{"argocd.argoproj.io/instance"},
+			labels:   nil,
+			want:     nil,
+		},
+		{
+			name:     "removes matching tracking label, keeps the rest",
+			patterns: []string{"argocd.argoproj.io/instance"},
+			labels:   map[string]string{"argocd.argoproj.io/instance": "falco", "app.kubernetes.io/name": "falco"},
+			want:     map[string]string{"app.kubernetes.io/name": "falco"},
+		},
+		{
+			name:     "wildcard removes flux labels",
+			patterns: []string{"kustomize.toolkit.fluxcd.io/*"},
+			labels: map[string]string{
+				"kustomize.toolkit.fluxcd.io/name":      "falco",
+				"kustomize.toolkit.fluxcd.io/namespace": "falco-system",
+				"team":                                  "secops",
+			},
+			want: map[string]string{"team": "secops"},
+		},
+		{
+			name:     "nothing matches returns equivalent map",
+			patterns: []string{"argocd.argoproj.io/instance"},
+			labels:   map[string]string{"app.kubernetes.io/name": "falco"},
+			want:     map[string]string{"app.kubernetes.io/name": "falco"},
+		},
+		{
+			name:     "removing every label returns nil",
+			patterns: []string{"*"},
+			labels:   map[string]string{"a": "1", "b": "2"},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewLabelFilter(tt.patterns).Apply(tt.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

/area chart

> /area pkg

> /area api

/area docs

**What this PR does / why we need it**:

The operator copies the labels of a `Falco`/`Component` resource onto every resource it generates. When the source resource carries a label that an external tool uses to track the objects it manages, that label is propagated to the generated resources too. For cluster-scoped resources (`ClusterRole`, `ClusterRoleBinding`), which cannot carry an `OwnerReference`, this makes such tools consider them managed and remove them when they are not part of their desired state; the operator then recreates them, resulting in a repeated removal/recreation cycle.

This PR adds a new `--excluded-labels` flag (repeatable, `*` wildcard supported) listing label keys that must not be propagated onto generated resources. Filtering is applied at the single server-side-apply choke point and only affects the resource's top-level `metadata.labels`; workload selectors and pod template labels are never touched, so it is safe for already-running workloads. The Helm chart exposes it as the `excludedLabels` array, pre-populated with the tracking labels of common GitOps tools, so the issue is fixed out of the box.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #349 

**Special notes for your reviewer**:
