### PR TITLE
chore(instance): bump default Falco version to 0.44.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For the complete walkthrough, see the [Getting Started guide](docs/getting-start
 | [Architecture](docs/architecture.md) | Components, interactions, design |
 | [CRD Reference](docs/crds/) | Full reference for all Custom Resources |
 | [Configuration](docs/configuration.md) | Defaults and customization |
+| [Version Matrix](docs/version-matrix.md) | Default Falco version per operator release |
 | [Migration Guide](docs/migration-guide.md) | Index of migration chapters |
 | [Contributing](docs/contributing.md) | Development, testing, PR guidelines |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Complete documentation for the [Falco Operator](https://github.com/falcosecurity
 | [Getting Started](getting-started.md) | Deploy Falco and add rules in minutes |
 | [Architecture](architecture.md) | Components, interactions, and design decisions |
 | [Configuration](configuration.md) | Default settings and customization |
+| [Version Matrix](version-matrix.md) | Default Falco version installed by each operator release |
 | [Migration Guide](migration-guide.md) | Index of migration chapters |
 | [Contributing](contributing.md) | Development setup, testing, and PR guidelines |
 

--- a/docs/crds/falco.md
+++ b/docs/crds/falco.md
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: falco
-          image: falcosecurity/falco:0.44.0
+          image: falcosecurity/falco:0.44.1
           resources:
             requests:
               cpu: 200m

--- a/docs/version-matrix.md
+++ b/docs/version-matrix.md
@@ -1,0 +1,20 @@
+# Version Matrix
+
+This page tracks the **default Falco version** the operator installs for each Falco Operator release.
+
+When a `Falco` resource does not pin a version (via `spec.version` or an explicit image in `spec.podTemplateSpec`), the operator deploys the default Falco version listed below. The default is defined by `FalcoTag` in [`internal/pkg/image/const.go`](../internal/pkg/image/const.go).
+
+Each row marks the operator version that introduced a given default; `+` means that default applies from that version onward, until the next row.
+
+| Falco Operator | Default Falco |
+|----------------|---------------|
+| v0.0.1+        | 0.41.0        |
+| v0.2.0+        | 0.43.0        |
+| v0.3.0+        | 0.44.0        |
+| v0.3.1+        | 0.44.1        |
+
+> The operator version is the released operator image tag (which matches the Helm chart `appVersion`). You can always override the Falco version per instance — see [Configuration](configuration.md) and the [Falco CRD reference](crds/falco.md).
+
+## For maintainers
+
+When changing the default Falco version, update `FalcoTag` in `internal/pkg/image/const.go` and add a row to the table above using the operator version that will ship the change. The table must be updated in the same PR, before the release tag is pushed.

--- a/internal/pkg/image/const.go
+++ b/internal/pkg/image/const.go
@@ -25,7 +25,7 @@ const (
 	// FalcoImage the default image name used for Falco.
 	FalcoImage = "falco"
 	// FalcoTag the default tag used for Falco.
-	FalcoTag = "0.44.0"
+	FalcoTag = "0.44.1"
 
 	// MetacollectorImage the default image name used for k8s-metacollector.
 	MetacollectorImage = "k8s-metacollector"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

/area docs

**What this PR does / why we need it**:

Bumps the default Falco version installed by the operator from `0.44.0` to `0.44.1`.

It also adds a Version Matrix doc (`docs/version-matrix.md`) mapping each operator release to the default Falco version it installs, so users can follow the operator/Falco version history over time.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
