### PR TITLE
fix(artifact): prevent reconcile storm from status condition churn

### DIFF
--- a/api/artifact/v1alpha1/config_types.go
+++ b/api/artifact/v1alpha1/config_types.go
@@ -76,7 +76,3 @@ type ConfigList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Config `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Config{}, &ConfigList{})
-}

--- a/api/artifact/v1alpha1/doc.go
+++ b/api/artifact/v1alpha1/doc.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=artifact.falcosecurity.dev
+package v1alpha1

--- a/api/artifact/v1alpha1/groupversion_info.go
+++ b/api/artifact/v1alpha1/groupversion_info.go
@@ -14,14 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
-// +kubebuilder:object:generate=true
-// +groupName=artifact.falcosecurity.dev
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +27,19 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "artifact.falcosecurity.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// addKnownTypes registers the artifact v1alpha1 types with the given scheme.
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(GroupVersion,
+		&Config{}, &ConfigList{},
+		&Plugin{}, &PluginList{},
+		&Rulesfile{}, &RulesfileList{},
+	)
+	metav1.AddToGroupVersion(s, GroupVersion)
+	return nil
+}

--- a/api/artifact/v1alpha1/plugin_types.go
+++ b/api/artifact/v1alpha1/plugin_types.go
@@ -14,8 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
-
 package v1alpha1
 
 import (
@@ -84,8 +82,4 @@ type PluginList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Plugin `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(&Plugin{}, &PluginList{})
 }

--- a/api/artifact/v1alpha1/rulesfile_types.go
+++ b/api/artifact/v1alpha1/rulesfile_types.go
@@ -14,8 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package v1alpha1 contains API Schema definitions for the artifact v1alpha1 API group.
-
 package v1alpha1
 
 import (
@@ -79,8 +77,4 @@ type RulesfileList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Rulesfile `json:"items"`
-}
-
-func init() {
-	SchemeBuilder.Register(&Rulesfile{}, &RulesfileList{})
 }

--- a/api/instance/v1alpha1/component_types.go
+++ b/api/instance/v1alpha1/component_types.go
@@ -124,7 +124,3 @@ type ComponentList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Component `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Component{}, &ComponentList{})
-}

--- a/api/instance/v1alpha1/doc.go
+++ b/api/instance/v1alpha1/doc.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package v1alpha1 contains API Schema definitions for the instance v1alpha1 API group.
+// +kubebuilder:object:generate=true
+// +groupName=instance.falcosecurity.dev
+package v1alpha1

--- a/api/instance/v1alpha1/falco_types.go
+++ b/api/instance/v1alpha1/falco_types.go
@@ -128,7 +128,3 @@ type FalcoList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Falco `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Falco{}, &FalcoList{})
-}

--- a/api/instance/v1alpha1/groupversion_info.go
+++ b/api/instance/v1alpha1/groupversion_info.go
@@ -14,14 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package v1alpha1 contains API Schema definitions for the instance v1alpha1 API group.
-// +kubebuilder:object:generate=true
-// +groupName=instance.falcosecurity.dev
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +27,18 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "instance.falcosecurity.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// addKnownTypes registers the instance v1alpha1 types with the given scheme.
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(GroupVersion,
+		&Component{}, &ComponentList{},
+		&Falco{}, &FalcoList{},
+	)
+	metav1.AddToGroupVersion(s, GroupVersion)
+	return nil
+}

--- a/controllers/artifact/config/controller.go
+++ b/controllers/artifact/config/controller.go
@@ -225,14 +225,17 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 	logger := log.FromContext(ctx)
 	p := config.Spec.Priority
 
-	// Clean up conditions before ensuring the config.
-	apimeta.RemoveStatusCondition(&config.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
-
 	// Store inline config if specified.
 	// spec.config is stored as JSON by the API server; convert to YAML before writing to disk.
 	configData, err := common.JSONRawToYAML(config.Spec.Config)
 	if err != nil {
-		return fmt.Errorf("converting inline config to YAML: %w", err)
+		logger.Error(err, "unable to convert inline config to YAML")
+		artifact.RecordWarning(r.recorder, config, artifact.ReasonInlineConfigStoreFailed, artifact.MessageFormatConfigStoreFailed, err.Error())
+		apimeta.SetStatusCondition(&config.Status.Conditions, common.NewProgrammedCondition(
+			metav1.ConditionFalse, artifact.ReasonInlineConfigStoreFailed,
+			fmt.Sprintf(artifact.MessageFormatConfigStoreFailed, err.Error()), gen,
+		))
+		return err
 	}
 
 	inlineAction, err := r.artifactManager.StoreFromInLineYaml(ctx, config.Name, p, configData, artifact.TypeConfig)

--- a/controllers/artifact/config/controller_integration_test.go
+++ b/controllers/artifact/config/controller_integration_test.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
+)
+
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	cl, stop, err := testutil.StartEnvtest(artifactv1alpha1.AddToScheme)
+	if err != nil {
+		ctrllog.Log.Error(err, "Failed to start envtest")
+		os.Exit(1)
+	}
+	k8sClient = cl
+	code := m.Run()
+	stop()
+	os.Exit(code)
+}
+
+// newIntegrationReconciler builds a reconciler backed by the real API server but with an
+// in-memory filesystem, so reconciles touch the cluster but not the disk.
+func newIntegrationReconciler() *ConfigReconciler {
+	am := artifact.NewManagerWithOptions(k8sClient, testutil.TestNamespace,
+		artifact.WithFS(filesystem.NewMockFileSystem()),
+	)
+	return &ConfigReconciler{
+		Client:          k8sClient,
+		Scheme:          k8sClient.Scheme(),
+		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
+		finalizer:       common.FormatFinalizerName(configFinalizerPrefix, testutil.TestNodeName),
+		artifactManager: am,
+		nodeName:        testutil.TestNodeName,
+		namespace:       testutil.TestNamespace,
+	}
+}
+
+func createConfig(t *testing.T, ctx context.Context, c *artifactv1alpha1.Config) *artifactv1alpha1.Config {
+	t.Helper()
+	require.NoError(t, k8sClient.Create(ctx, c))
+	t.Cleanup(func() { testutil.CleanupObject(t, ctx, k8sClient, c) })
+	return c
+}
+
+func configConditions(o client.Object) *[]metav1.Condition {
+	return &o.(*artifactv1alpha1.Config).Status.Conditions
+}
+
+func applyConfigStatus(ctx context.Context, o client.Object) error {
+	return controllerhelper.PatchStatusSSA(ctx, k8sClient, k8sClient.Scheme(), o, fieldManager)
+}
+
+func TestIntegration_Config_SteadyStateReconcileIsQuiet(t *testing.T) {
+	ctx := context.Background()
+	c := createConfig(t, ctx, &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: "quiet", Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.ConfigSpec{
+			Config:   &apiextensionsv1.JSON{Raw: []byte(`{"engine":{"kind":"modern_ebpf"}}`)},
+			Priority: 50,
+		},
+	})
+	testutil.AssertReconcileQuiet(t, ctx, newIntegrationReconciler(), k8sClient,
+		client.ObjectKeyFromObject(c), &artifactv1alpha1.Config{}, 5, 5,
+		configConditions,
+		func(o client.Object) error { return applyConfigStatus(ctx, o) },
+	)
+}
+
+func TestIntegration_Config_StatusApplyNoOpThenChange(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "ssa-semantics", Namespace: testutil.TestNamespace}
+	createConfig(t, ctx, &artifactv1alpha1.Config{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}})
+
+	// Apply both conditions so the no-op contract is exercised on a multi-entry conditions list
+	// (listType=map keyed by type), not just a single condition.
+	applyConditions := func(programmed metav1.ConditionStatus, reason, msg string) error {
+		cur := &artifactv1alpha1.Config{}
+		if err := k8sClient.Get(ctx, key, cur); err != nil {
+			return err
+		}
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewProgrammedCondition(programmed, reason, msg, cur.GetGeneration()))
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewResolvedRefsCondition(metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, cur.GetGeneration()))
+		return applyConfigStatus(ctx, cur)
+	}
+
+	testutil.AssertSSAApplyNoOpThenChange(t, ctx, k8sClient, key, &artifactv1alpha1.Config{},
+		func() error {
+			return applyConditions(metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed)
+		},
+		func() error {
+			return applyConditions(metav1.ConditionFalse, artifact.ReasonInlineConfigStoreFailed, "store failed")
+		},
+	)
+
+	// Sanity: both conditions are present and Programmed reflects the final mutation.
+	final := &artifactv1alpha1.Config{}
+	require.NoError(t, k8sClient.Get(ctx, key, final))
+	require.Equal(t, metav1.ConditionFalse,
+		apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionProgrammed.String()).Status)
+	require.NotNil(t, apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionResolvedRefs.String()))
+}

--- a/controllers/artifact/config/controller_test.go
+++ b/controllers/artifact/config/controller_test.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -857,8 +859,10 @@ func TestEnsureConfig(t *testing.T) {
 					Priority: 50,
 				},
 			},
-			wantErr:    true,
-			wantEvents: []string{},
+			wantErr: true,
+			wantConditions: []testutil.ConditionExpect{
+				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonInlineConfigStoreFailed},
+			},
 		},
 		{
 			name: "failure sets error condition on inline content",
@@ -944,6 +948,46 @@ func TestEnsureConfig(t *testing.T) {
 				}
 				assert.ElementsMatch(t, tt.wantFiles, gotContents)
 			}
+		})
+	}
+}
+
+// TestEnsureConfig_ProgrammedLastTransitionTime verifies LastTransitionTime stays put on a
+// steady-state reconcile and only moves on a real status transition.
+func TestEnsureConfig_ProgrammedLastTransitionTime(t *testing.T) {
+	pinned := metav1.NewTime(time.Now().Add(-time.Hour))
+	tests := []struct {
+		name          string
+		initialStatus metav1.ConditionStatus
+		wantPreserved bool
+	}{
+		{name: "steady state preserves timestamp", initialStatus: metav1.ConditionTrue, wantPreserved: true},
+		{name: "real transition restamps timestamp", initialStatus: metav1.ConditionFalse, wantPreserved: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newTestReconciler(t)
+			config := &artifactv1alpha1.Config{
+				ObjectMeta: metav1.ObjectMeta{Name: testConfigName, Namespace: testutil.TestNamespace, Generation: 1},
+				Spec:       artifactv1alpha1.ConfigSpec{Priority: 50},
+				Status: artifactv1alpha1.ConfigStatus{
+					Conditions: []metav1.Condition{{
+						Type:               commonv1alpha1.ConditionProgrammed.String(),
+						Status:             tt.initialStatus,
+						Reason:             artifact.ReasonProgrammed,
+						Message:            artifact.MessageProgrammed,
+						LastTransitionTime: pinned,
+					}},
+				},
+			}
+
+			require.NoError(t, r.ensureConfig(context.Background(), config))
+
+			cond := apimeta.FindStatusCondition(config.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+			require.NotNil(t, cond)
+			require.Equal(t, metav1.ConditionTrue, cond.Status)
+			require.Equal(t, tt.wantPreserved, cond.LastTransitionTime.Equal(&pinned))
 		})
 	}
 }

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -214,8 +214,6 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 	logger := log.FromContext(ctx)
 	var err error
 
-	apimeta.RemoveStatusCondition(&plugin.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
-
 	ociAction, err := r.artifactManager.StoreFromOCI(ctx, plugin.Name, priority.DefaultPriority, artifact.TypePlugin, plugin.Spec.OCIArtifact)
 	if err != nil {
 		logger.Error(err, "unable to store plugin artifact")
@@ -325,9 +323,6 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 	r.crToConfigName[plugin.Name] = configName
 
 	r.PluginsConfig.addConfig(r.artifactManager, plugin)
-
-	// Clean up conditions before ensuring the plugin config.
-	apimeta.RemoveStatusCondition(&plugin.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
 
 	pluginConfigString, err := r.PluginsConfig.toString()
 	if err != nil {

--- a/controllers/artifact/plugin/controller_integration_test.go
+++ b/controllers/artifact/plugin/controller_integration_test.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
+)
+
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	cl, stop, err := testutil.StartEnvtest(artifactv1alpha1.AddToScheme)
+	if err != nil {
+		ctrllog.Log.Error(err, "Failed to start envtest")
+		os.Exit(1)
+	}
+	k8sClient = cl
+	code := m.Run()
+	stop()
+	os.Exit(code)
+}
+
+// newIntegrationReconciler builds a reconciler backed by the real API server but with an
+// in-memory filesystem and OCI puller, so reconciles touch the cluster but not the disk/registry.
+func newIntegrationReconciler() *PluginReconciler {
+	am := artifact.NewManagerWithOptions(k8sClient, testutil.TestNamespace,
+		artifact.WithFS(filesystem.NewMockFileSystem()),
+		artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+	)
+	return &PluginReconciler{
+		Client:          k8sClient,
+		Scheme:          k8sClient.Scheme(),
+		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
+		finalizer:       common.FormatFinalizerName(pluginFinalizerPrefix, testutil.TestNodeName),
+		artifactManager: am,
+		PluginsConfig:   &PluginsConfig{},
+		nodeName:        testutil.TestNodeName,
+		crToConfigName:  make(map[string]string),
+	}
+}
+
+func createPlugin(t *testing.T, ctx context.Context, p *artifactv1alpha1.Plugin) *artifactv1alpha1.Plugin {
+	t.Helper()
+	require.NoError(t, k8sClient.Create(ctx, p))
+	t.Cleanup(func() { testutil.CleanupObject(t, ctx, k8sClient, p) })
+	return p
+}
+
+func pluginConditions(o client.Object) *[]metav1.Condition {
+	return &o.(*artifactv1alpha1.Plugin).Status.Conditions
+}
+
+func applyPluginStatus(ctx context.Context, o client.Object) error {
+	return controllerhelper.PatchStatusSSA(ctx, k8sClient, k8sClient.Scheme(), o, fieldManager)
+}
+
+func TestIntegration_Plugin_SteadyStateReconcileIsQuiet(t *testing.T) {
+	ctx := context.Background()
+	p := createPlugin(t, ctx, &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "quiet", Namespace: testutil.TestNamespace},
+	})
+	testutil.AssertReconcileQuiet(t, ctx, newIntegrationReconciler(), k8sClient,
+		client.ObjectKeyFromObject(p), &artifactv1alpha1.Plugin{}, 5, 5,
+		pluginConditions,
+		func(o client.Object) error { return applyPluginStatus(ctx, o) },
+	)
+}
+
+func TestIntegration_Plugin_StatusApplyNoOpThenChange(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "ssa-semantics", Namespace: testutil.TestNamespace}
+	createPlugin(t, ctx, &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}})
+
+	// Apply both conditions so the no-op contract is exercised on a multi-entry conditions list
+	// (listType=map keyed by type), not just a single condition.
+	applyConditions := func(programmed metav1.ConditionStatus, reason, msg string) error {
+		cur := &artifactv1alpha1.Plugin{}
+		if err := k8sClient.Get(ctx, key, cur); err != nil {
+			return err
+		}
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewProgrammedCondition(programmed, reason, msg, cur.GetGeneration()))
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewResolvedRefsCondition(metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, cur.GetGeneration()))
+		return applyPluginStatus(ctx, cur)
+	}
+
+	testutil.AssertSSAApplyNoOpThenChange(t, ctx, k8sClient, key, &artifactv1alpha1.Plugin{},
+		func() error {
+			return applyConditions(metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed)
+		},
+		func() error {
+			return applyConditions(metav1.ConditionFalse, artifact.ReasonOCIArtifactStoreFailed, "store failed")
+		},
+	)
+
+	// Sanity: both conditions are present and Programmed reflects the final mutation.
+	final := &artifactv1alpha1.Plugin{}
+	require.NoError(t, k8sClient.Get(ctx, key, final))
+	require.Equal(t, metav1.ConditionFalse,
+		apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionProgrammed.String()).Status)
+	require.NotNil(t, apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionResolvedRefs.String()))
+}

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -757,6 +759,45 @@ func TestEnsurePlugin(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestEnsurePlugin_ProgrammedLastTransitionTime verifies LastTransitionTime stays put on a
+// steady-state reconcile and only moves on a real status transition.
+func TestEnsurePlugin_ProgrammedLastTransitionTime(t *testing.T) {
+	pinned := metav1.NewTime(time.Now().Add(-time.Hour))
+	tests := []struct {
+		name          string
+		initialStatus metav1.ConditionStatus
+		wantPreserved bool
+	}{
+		{name: "steady state preserves timestamp", initialStatus: metav1.ConditionTrue, wantPreserved: true},
+		{name: "real transition restamps timestamp", initialStatus: metav1.ConditionFalse, wantPreserved: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newTestReconciler(t)
+			plugin := &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: testPluginName, Namespace: testutil.TestNamespace},
+				Status: artifactv1alpha1.PluginStatus{
+					Conditions: []metav1.Condition{{
+						Type:               commonv1alpha1.ConditionProgrammed.String(),
+						Status:             tt.initialStatus,
+						Reason:             artifact.ReasonProgrammed,
+						Message:            artifact.MessageProgrammed,
+						LastTransitionTime: pinned,
+					}},
+				},
+			}
+
+			require.NoError(t, r.ensurePlugin(context.Background(), plugin))
+
+			cond := apimeta.FindStatusCondition(plugin.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+			require.NotNil(t, cond)
+			require.Equal(t, metav1.ConditionTrue, cond.Status)
+			require.Equal(t, tt.wantPreserved, cond.LastTransitionTime.Equal(&pinned))
 		})
 	}
 }

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -226,9 +226,6 @@ func (r *RulesfileReconciler) ensureRulesfile(ctx context.Context, rulesfile *ar
 	logger := log.FromContext(ctx)
 	p := rulesfile.Spec.Priority
 
-	// Clean up conditions before ensuring the rulesfile.
-	apimeta.RemoveStatusCondition(&rulesfile.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
-
 	// Store OCI artifact if specified; passing nil removes any previously stored OCI artifact.
 	ociAction, err := r.artifactManager.StoreFromOCI(ctx, rulesfile.Name, p, artifact.TypeRulesfile, rulesfile.Spec.OCIArtifact)
 	if err != nil {
@@ -247,7 +244,13 @@ func (r *RulesfileReconciler) ensureRulesfile(ctx context.Context, rulesfile *ar
 	var inlineRulesData *string
 	inlineRulesData, err = common.JSONRawToYAML(rulesfile.Spec.InlineRules)
 	if err != nil {
-		return fmt.Errorf("converting inline rules to YAML: %w", err)
+		logger.Error(err, "unable to convert inline rules to YAML")
+		artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonInlineRulesStoreFailed, artifact.MessageFormatInlineRulesStoreFailed, err.Error())
+		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, common.NewProgrammedCondition(
+			metav1.ConditionFalse, artifact.ReasonInlineRulesStoreFailed,
+			fmt.Sprintf(artifact.MessageFormatInlineRulesStoreFailed, err.Error()), gen,
+		))
+		return err
 	}
 
 	inlineAction, err := r.artifactManager.StoreFromInLineYaml(ctx, rulesfile.Name, p, inlineRulesData, artifact.TypeRulesfile)

--- a/controllers/artifact/rulesfile/controller_integration_test.go
+++ b/controllers/artifact/rulesfile/controller_integration_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rulesfile
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+	"github.com/falcosecurity/falco-operator/internal/pkg/startupgate"
+)
+
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	cl, stop, err := testutil.StartEnvtest(artifactv1alpha1.AddToScheme)
+	if err != nil {
+		ctrllog.Log.Error(err, "Failed to start envtest")
+		os.Exit(1)
+	}
+	k8sClient = cl
+	code := m.Run()
+	stop()
+	os.Exit(code)
+}
+
+// newIntegrationReconciler builds a reconciler backed by the real API server but with an
+// in-memory filesystem and OCI puller, so reconciles touch the cluster but not the disk/registry.
+func newIntegrationReconciler() *RulesfileReconciler {
+	am := artifact.NewManagerWithOptions(k8sClient, testutil.TestNamespace,
+		artifact.WithFS(filesystem.NewMockFileSystem()),
+		artifact.WithOCIPuller(&puller.MockOCIPuller{}),
+	)
+	return &RulesfileReconciler{
+		Client:          k8sClient,
+		Scheme:          k8sClient.Scheme(),
+		recorder:        events.NewFakeRecorder(100),
+		gate:            startupgate.NoopGateRecorder{},
+		finalizer:       common.FormatFinalizerName(rulesfileFinalizerPrefix, testutil.TestNodeName),
+		artifactManager: am,
+		nodeName:        testutil.TestNodeName,
+		namespace:       testutil.TestNamespace,
+	}
+}
+
+func createRulesfile(t *testing.T, ctx context.Context, rf *artifactv1alpha1.Rulesfile) *artifactv1alpha1.Rulesfile {
+	t.Helper()
+	require.NoError(t, k8sClient.Create(ctx, rf))
+	t.Cleanup(func() { testutil.CleanupObject(t, ctx, k8sClient, rf) })
+	return rf
+}
+
+func rulesfileConditions(o client.Object) *[]metav1.Condition {
+	return &o.(*artifactv1alpha1.Rulesfile).Status.Conditions
+}
+
+func applyRulesfileStatus(ctx context.Context, o client.Object) error {
+	return controllerhelper.PatchStatusSSA(ctx, k8sClient, k8sClient.Scheme(), o, fieldManager)
+}
+
+func TestIntegration_Rulesfile_SteadyStateReconcileIsQuiet(t *testing.T) {
+	ctx := context.Background()
+	rf := createRulesfile(t, ctx, &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "quiet", Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			InlineRules: &apiextensionsv1.JSON{Raw: []byte(`[{"rule":"r","desc":"d","condition":"always_true","output":"o","priority":"WARNING"}]`)},
+		},
+	})
+	testutil.AssertReconcileQuiet(t, ctx, newIntegrationReconciler(), k8sClient,
+		client.ObjectKeyFromObject(rf), &artifactv1alpha1.Rulesfile{}, 5, 5,
+		rulesfileConditions,
+		func(o client.Object) error { return applyRulesfileStatus(ctx, o) },
+	)
+}
+
+func TestIntegration_Rulesfile_StatusApplyNoOpThenChange(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "ssa-semantics", Namespace: testutil.TestNamespace}
+	createRulesfile(t, ctx, &artifactv1alpha1.Rulesfile{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}})
+
+	// Apply both conditions so the no-op contract is exercised on a multi-entry conditions list
+	// (listType=map keyed by type), not just a single condition.
+	applyConditions := func(programmed metav1.ConditionStatus, reason, msg string) error {
+		cur := &artifactv1alpha1.Rulesfile{}
+		if err := k8sClient.Get(ctx, key, cur); err != nil {
+			return err
+		}
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewProgrammedCondition(programmed, reason, msg, cur.GetGeneration()))
+		apimeta.SetStatusCondition(&cur.Status.Conditions,
+			common.NewResolvedRefsCondition(metav1.ConditionTrue, artifact.ReasonReferenceResolved, artifact.MessageReferencesResolved, cur.GetGeneration()))
+		return applyRulesfileStatus(ctx, cur)
+	}
+
+	testutil.AssertSSAApplyNoOpThenChange(t, ctx, k8sClient, key, &artifactv1alpha1.Rulesfile{},
+		func() error {
+			return applyConditions(metav1.ConditionTrue, artifact.ReasonProgrammed, artifact.MessageProgrammed)
+		},
+		func() error {
+			return applyConditions(metav1.ConditionFalse, artifact.ReasonInlineRulesStoreFailed, "store failed")
+		},
+	)
+
+	// Sanity: both conditions are present and Programmed reflects the final mutation.
+	final := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, k8sClient.Get(ctx, key, final))
+	require.Equal(t, metav1.ConditionFalse,
+		apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionProgrammed.String()).Status)
+	require.NotNil(t, apimeta.FindStatusCondition(final.Status.Conditions, commonv1alpha1.ConditionResolvedRefs.String()))
+}

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -733,8 +735,10 @@ func TestEnsureRulesfile(t *testing.T) {
 					InlineRules: &apiextensionsv1.JSON{Raw: []byte("\t")},
 				},
 			},
-			wantErr:    true,
-			wantEvents: []string{},
+			wantErr: true,
+			wantConditions: []testutil.ConditionExpect{
+				{Type: commonv1alpha1.ConditionProgrammed.String(), Status: metav1.ConditionFalse, Reason: artifact.ReasonInlineRulesStoreFailed},
+			},
 		},
 		{
 			name: "inline rules store failure sets condition",
@@ -941,6 +945,48 @@ func TestEnsureRulesfile(t *testing.T) {
 				require.NoError(t, err)
 				assert.Empty(t, entries, "expected rulesfile dir to be empty after cleanup")
 			}
+		})
+	}
+}
+
+// TestEnsureRulesfile_ProgrammedLastTransitionTime verifies LastTransitionTime stays put on a
+// steady-state reconcile and only moves on a real status transition.
+func TestEnsureRulesfile_ProgrammedLastTransitionTime(t *testing.T) {
+	pinned := metav1.NewTime(time.Now().Add(-time.Hour))
+	tests := []struct {
+		name          string
+		initialStatus metav1.ConditionStatus
+		wantPreserved bool
+	}{
+		{name: "steady state preserves timestamp", initialStatus: metav1.ConditionTrue, wantPreserved: true},
+		{name: "real transition restamps timestamp", initialStatus: metav1.ConditionFalse, wantPreserved: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newTestReconciler(t)
+			rf := &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: testRulesfileName, Namespace: testutil.TestNamespace},
+				Spec: artifactv1alpha1.RulesfileSpec{
+					InlineRules: &apiextensionsv1.JSON{Raw: []byte(testInlineRulesJSON)},
+				},
+				Status: artifactv1alpha1.RulesfileStatus{
+					Conditions: []metav1.Condition{{
+						Type:               commonv1alpha1.ConditionProgrammed.String(),
+						Status:             tt.initialStatus,
+						Reason:             artifact.ReasonProgrammed,
+						Message:            artifact.MessageProgrammed,
+						LastTransitionTime: pinned,
+					}},
+				},
+			}
+
+			require.NoError(t, r.ensureRulesfile(context.Background(), rf))
+
+			cond := apimeta.FindStatusCondition(rf.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+			require.NotNil(t, cond)
+			require.Equal(t, metav1.ConditionTrue, cond.Status)
+			require.Equal(t, tt.wantPreserved, cond.LastTransitionTime.Equal(&pinned))
 		})
 	}
 }

--- a/controllers/testutil/envtest.go
+++ b/controllers/testutil/envtest.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// StartEnvtest boots an envtest API server with the project CRDs installed and a freshly built
+// scheme (Kubernetes built-ins plus the given adders), returning a client and a stop function to
+// defer. The scheme is local to this call, never the client-go global, so concurrent suites and
+// repeated calls cannot contaminate one another.
+func StartEnvtest(adders ...func(*runtime.Scheme) error) (client.Client, func(), error) {
+	ctrllog.SetLogger(zap.New(zap.WriteTo(io.Discard), zap.UseDevMode(true)))
+
+	s := runtime.NewScheme()
+	for _, add := range append([]func(*runtime.Scheme) error{clientgoscheme.AddToScheme}, adders...) {
+		if err := add(s); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{CRDDirPath()},
+		ErrorIfCRDPathMissing: true,
+	}
+	if dir := GetFirstFoundEnvTestBinaryDir(); dir != "" {
+		env.BinaryAssetsDirectory = dir
+	}
+
+	cfg, err := env.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: s})
+	if err != nil {
+		_ = env.Stop()
+		return nil, nil, err
+	}
+
+	stop := func() {
+		if err := env.Stop(); err != nil {
+			ctrllog.Log.Error(err, "failed to stop envtest")
+		}
+	}
+	return cl, stop, nil
+}
+
+// CleanupObject removes finalizers (retrying on conflict) and deletes obj, tolerating an
+// already-deleted object. Use it from t.Cleanup so a finalized object never strands and blocks
+// a later test reusing the same name.
+func CleanupObject(t *testing.T, ctx context.Context, cl client.Client, obj client.Object) {
+	t.Helper()
+	key := client.ObjectKeyFromObject(obj)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fetched := obj.DeepCopyObject().(client.Object)
+		if err := cl.Get(ctx, key, fetched); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		if len(fetched.GetFinalizers()) == 0 {
+			return nil
+		}
+		fetched.SetFinalizers(nil)
+		return cl.Update(ctx, fetched)
+	})
+	require.NoError(t, err, "cleanup: stripping finalizers from %s", key)
+
+	if err := cl.Delete(ctx, obj); err != nil && !k8serrors.IsNotFound(err) {
+		require.NoError(t, err, "cleanup: deleting %s", key)
+	}
+}
+
+// AssertReconcileQuiet settles the object via repeated reconciles until its resourceVersion stops
+// changing, then backdates every status condition's LastTransitionTime so a per-reconcile
+// re-stamp becomes observable regardless of wall-clock (second) granularity (a fast in-process
+// test would otherwise hide it), and finally asserts that further reconciles move neither
+// resourceVersion nor any condition timestamp. Drift in either is the reconcile-storm signature.
+//
+// obj is a non-nil empty typed object used for fetching. conditions returns a pointer to obj's
+// status conditions slice; applyStatus persists obj's status under the controller's field manager.
+func AssertReconcileQuiet(
+	t *testing.T,
+	ctx context.Context,
+	r reconcile.Reconciler,
+	cl client.Client,
+	key types.NamespacedName,
+	obj client.Object,
+	maxSettle, checkRounds int,
+	conditions func(obj client.Object) *[]metav1.Condition,
+	applyStatus func(obj client.Object) error,
+) {
+	t.Helper()
+	req := reconcile.Request{NamespacedName: key}
+
+	// Settle until two consecutive reconciles leave resourceVersion unchanged (bounded by
+	// maxSettle), so the backdate below never lands while the object is still converging.
+	prev := ""
+	settled := false
+	for range maxSettle {
+		_, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "settle reconcile failed")
+		require.NoError(t, cl.Get(ctx, key, obj))
+		rv := obj.GetResourceVersion()
+		if rv == prev {
+			settled = true
+			break
+		}
+		prev = rv
+	}
+	require.Truef(t, settled, "object did not converge within %d reconciles", maxSettle)
+
+	// Rfc3339Copy truncates to second precision to match what the API server persists.
+	old := metav1.NewTime(time.Now().Add(-time.Hour)).Rfc3339Copy()
+	require.NoError(t, cl.Get(ctx, key, obj))
+	conds := conditions(obj)
+	require.NotEmpty(t, *conds, "no status conditions to guard after settle")
+	for i := range *conds {
+		(*conds)[i].LastTransitionTime = old
+	}
+	require.NoError(t, applyStatus(obj))
+
+	require.NoError(t, cl.Get(ctx, key, obj))
+	baselineRV := obj.GetResourceVersion()
+	assertAllBackdated(t, *conditions(obj), old, "backdate did not take")
+
+	for i := range checkRounds {
+		_, err := r.Reconcile(ctx, req)
+		require.NoErrorf(t, err, "steady-state reconcile %d failed", i+1)
+		require.NoError(t, cl.Get(ctx, key, obj))
+		require.Equalf(t, baselineRV, obj.GetResourceVersion(),
+			"resourceVersion changed on steady-state reconcile %d (reconcile-storm regression)", i+1)
+		assertAllBackdatedf(t, *conditions(obj), old,
+			"a condition timestamp re-stamped on steady-state reconcile %d (reconcile-storm regression)", i+1)
+	}
+}
+
+func assertAllBackdated(t *testing.T, conds []metav1.Condition, old metav1.Time, msg string) {
+	t.Helper()
+	for _, c := range conds {
+		ltt := c.LastTransitionTime
+		require.Truef(t, ltt.Equal(&old), "%s: condition %q has %v, want %v", msg, c.Type, ltt, old)
+	}
+}
+
+func assertAllBackdatedf(t *testing.T, conds []metav1.Condition, old metav1.Time, format string, args ...any) {
+	t.Helper()
+	for _, c := range conds {
+		ltt := c.LastTransitionTime
+		require.Truef(t, ltt.Equal(&old), format+" (condition %q = %v)", append(args, c.Type, ltt)...)
+	}
+}
+
+// AssertSSAApplyNoOpThenChange proves the server-side-apply contract the steady-state quiet relies
+// on: re-applying identical status content does not bump resourceVersion (no watch event), while a
+// real change does. apply must be idempotent; mutate must change the status. obj is a non-nil empty
+// typed object used for fetching. RV-equality holds only because status writes use client.Apply
+// with ForceOwnership; a switch to Status().Update would bump resourceVersion every apply.
+func AssertSSAApplyNoOpThenChange(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	key types.NamespacedName,
+	obj client.Object,
+	apply func() error,
+	mutate func() error,
+) {
+	t.Helper()
+
+	require.NoError(t, apply())
+	require.NoError(t, cl.Get(ctx, key, obj))
+	rv := obj.GetResourceVersion()
+
+	require.NoError(t, apply())
+	require.NoError(t, cl.Get(ctx, key, obj))
+	require.Equal(t, rv, obj.GetResourceVersion(),
+		"identical status apply must be a server-side no-op (no resourceVersion bump)")
+
+	require.NoError(t, mutate())
+	require.NoError(t, cl.Get(ctx, key, obj))
+	require.NotEqual(t, rv, obj.GetResourceVersion(),
+		"a real status change must bump resourceVersion")
+}

--- a/internal/pkg/managedfields/extract.go
+++ b/internal/pkg/managedfields/extract.go
@@ -53,7 +53,7 @@ func ExtractAsUnstructured(obj runtime.Object, fieldManager string) (*unstructur
 	}
 
 	fieldset := &fieldpath.Set{}
-	if err := fieldset.FromJSON(bytes.NewReader(fieldsEntry.FieldsV1.Raw)); err != nil {
+	if err := fieldset.FromJSON(bytes.NewReader(fieldsEntry.FieldsV1.GetRawBytes())); err != nil {
 		return nil, fmt.Errorf("error parsing FieldsV1 JSON: %w", err)
 	}
 

--- a/internal/pkg/managedfields/prune.go
+++ b/internal/pkg/managedfields/prune.go
@@ -18,6 +18,7 @@ package managedfields
 
 import (
 	"reflect"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -59,8 +60,8 @@ func pruneEmptyFields(m map[string]any) {
 			}
 
 			// Remove empty maps from slice (in reverse order to maintain correct indices)
-			for i := len(emptyIndices) - 1; i >= 0; i-- {
-				idx := emptyIndices[i]
+			for _, v := range slices.Backward(emptyIndices) {
+				idx := v
 				val = append(val[:idx], val[idx+1:]...)
 			}
 

--- a/internal/pkg/resources/forge_test.go
+++ b/internal/pkg/resources/forge_test.go
@@ -231,13 +231,14 @@ func TestGenerateWorkload(t *testing.T) {
 					// Non-native sidecar: should be in containers with nil RestartPolicy.
 					var foundSidecar bool
 					for _, c := range podSpec.Containers {
-						if c.Name == tt.wantSidecarName {
-							foundSidecar = true
-							assert.Equal(t, version.ArtifactOperatorImage, c.Image, "sidecar should have the correct image")
-							assert.Nil(t, c.RestartPolicy, "non-native sidecar should have nil RestartPolicy")
-							assertArtifactOperatorReadinessProbes(t, &c)
-							break
+						if c.Name != tt.wantSidecarName {
+							continue
 						}
+						foundSidecar = true
+						assert.Equal(t, version.ArtifactOperatorImage, c.Image, "sidecar should have the correct image")
+						assert.Nil(t, c.RestartPolicy, "non-native sidecar should have nil RestartPolicy")
+						assertArtifactOperatorReadinessProbes(t, &c)
+						break
 					}
 					assert.True(t, foundSidecar, "non-native sidecar %s not found in containers", tt.wantSidecarName)
 					// Should NOT be in initContainers.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

/area artifact-operator

> /area chart

/area pkg

/area api

> /area docs

**What this PR does / why we need it**:

On multi-node clusters the artifact-operator (a per-node DaemonSet) could fall into a self-amplifying, cluster-wide reconcile storm on steady-state artifact CRs (Plugin/Config/Rulesfile): with no spec change, the reconcile rate jumped from a calm baseline to tens of thousands/min and hammered the API server for minutes to over an hour.

Root cause: every reconcile re-stamped the `Programmed` condition's `LastTransitionTime` (the condition was removed and re-set on each pass), so each pass produced a real status write. With every per-node instance writing the same status field, any write fanned a watch event out to all N instances, which re-stamped and re-wrote again — a positive feedback loop that only damps on very small clusters (where a full fan-out wave happens to land in the same wall-clock second).

The fix makes the steady-state status idempotent: the condition is updated in place so `LastTransitionTime` only moves on a real status transition. Once the computed status is byte-identical, the server-side-apply becomes a no-op (no resourceVersion bump, no watch event), so reconciles converge and go quiet at any node count.

The PR also carries two scoped, behavior-neutral cleanups:
- modernize the `api/.../v1alpha1` packages: adopt the repo-wide `doc.go` convention and migrate off the deprecated controller-runtime `scheme.Builder` to the apimachinery scheme builder;
- resolve pre-existing lint findings in internal packages.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #356 

**Special notes for your reviewer**:
