### PR TITLE
fix(chart): add coordination.k8s.io/leases RBAC for leader election

### DIFF
--- a/chart/falco-operator/files/ClusterRole.yaml
+++ b/chart/falco-operator/files/ClusterRole.yaml
@@ -82,6 +82,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices

--- a/controllers/instance/falco/controller.go
+++ b/controllers/instance/falco/controller.go
@@ -105,6 +105,7 @@ func NewReconciler(cl client.Client, scheme *runtime.Scheme, recorder events.Eve
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;update
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area chart

**What this PR does / why we need it**:

When `--leader-elect=true` is enabled, leader election fails because the ClusterRole lacks leases permissions. This PR adds the missing permission to the ClusterRole.

**Which issue(s) this PR fixes**:

Fixes #365

**Special notes for your reviewer**:
None