### PR TITLE
feat(controllerhelper): add enqueue, log constructor, node listing, and finalizer reconciliation helpers

### DIFF
--- a/controllers/instance/reference/configmap/controller.go
+++ b/controllers/instance/reference/configmap/controller.go
@@ -82,7 +82,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if err := controllerhelper.EnsureInUseFinalizer(
-		ctx, r.Client, r.Scheme, common.ConfigmapInUseFinalizer, ControllerName, cm, referenced); err != nil {
+		ctx, r.Client, common.ConfigmapInUseFinalizer, cm, referenced); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -102,6 +102,7 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findConfigMapsForConfig),
 		).
 		Named(ControllerName).
+		WithLogConstructor(controllerhelper.LogConstructorFor(mgr.GetLogger(), mgr.GetScheme(), ControllerName, &corev1.ConfigMap{})).
 		Complete(r)
 }
 

--- a/controllers/instance/reference/configmap/controller_test.go
+++ b/controllers/instance/reference/configmap/controller_test.go
@@ -151,7 +151,7 @@ func TestConfigMapReconciler_Reconcile(t *testing.T) {
 			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "cm5"}},
 		},
 		{
-			name: "Apply error propagates",
+			name: "Patch error propagates",
 			objects: []client.Object{newCM("cm6"), &artifactv1alpha1.Rulesfile{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf3"},
 				Spec: artifactv1alpha1.RulesfileSpec{
@@ -159,12 +159,12 @@ func TestConfigMapReconciler_Reconcile(t *testing.T) {
 				},
 			}},
 			intercept: interceptor.Funcs{
-				Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
-					return errors.New("apply failed")
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return errors.New("patch failed")
 				},
 			},
 			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "cm6"}},
-			wantErr: "apply failed",
+			wantErr: "patch failed",
 		},
 		{
 			name:    "Get error (not NotFound)",
@@ -188,7 +188,8 @@ func TestConfigMapReconciler_Reconcile(t *testing.T) {
 			for _, e := range index.All {
 				builder = builder.WithIndex(e.Object, e.Field, e.ExtractValueFn)
 			}
-			if tt.intercept.Get != nil || tt.intercept.List != nil || tt.intercept.Apply != nil || tt.intercept.Delete != nil {
+			if tt.intercept.Get != nil || tt.intercept.List != nil || tt.intercept.Apply != nil ||
+				tt.intercept.Delete != nil || tt.intercept.Update != nil || tt.intercept.Patch != nil {
 				builder = builder.WithInterceptorFuncs(tt.intercept)
 			}
 			cl := builder.Build()

--- a/controllers/instance/reference/secret/controller.go
+++ b/controllers/instance/reference/secret/controller.go
@@ -78,7 +78,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if err := controllerhelper.EnsureInUseFinalizer(
-		ctx, r.Client, r.Scheme, common.SecretInUseFinalizer, ControllerName, secret, referenced); err != nil {
+		ctx, r.Client, common.SecretInUseFinalizer, secret, referenced); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -98,6 +98,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findSecretsForPlugin),
 		).
 		Named(ControllerName).
+		WithLogConstructor(controllerhelper.LogConstructorFor(mgr.GetLogger(), mgr.GetScheme(), ControllerName, &corev1.Secret{})).
 		Complete(r)
 }
 

--- a/controllers/instance/reference/secret/controller_test.go
+++ b/controllers/instance/reference/secret/controller_test.go
@@ -196,18 +196,18 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec7"}},
 		},
 		{
-			name: "Apply error propagates",
+			name: "Patch error propagates",
 			objects: []client.Object{newSecret("sec7"), &artifactv1alpha1.Rulesfile{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "rf3"},
 				Spec:       artifactv1alpha1.RulesfileSpec{OCIArtifact: ociWithSecret("sec7")},
 			}},
 			intercept: interceptor.Funcs{
-				Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
-					return errors.New("apply failed")
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return errors.New("patch failed")
 				},
 			},
 			request: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "default", Name: "sec7"}},
-			wantErr: "apply failed",
+			wantErr: "patch failed",
 		},
 		{
 			name:    "Get error (not NotFound)",
@@ -231,7 +231,8 @@ func TestSecretReconciler_Reconcile(t *testing.T) {
 			for _, e := range index.All {
 				builder = builder.WithIndex(e.Object, e.Field, e.ExtractValueFn)
 			}
-			if tt.intercept.Get != nil || tt.intercept.List != nil || tt.intercept.Apply != nil || tt.intercept.Delete != nil {
+			if tt.intercept.Get != nil || tt.intercept.List != nil || tt.intercept.Apply != nil ||
+				tt.intercept.Delete != nil || tt.intercept.Update != nil || tt.intercept.Patch != nil {
 				builder = builder.WithInterceptorFuncs(tt.intercept)
 			}
 			cl := builder.Build()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/falcosecurity/falco-operator
 go 1.26.0
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/image-spec v1.1.1
@@ -12,6 +13,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	oras.land/oras-go/v2 v2.6.2
 	sigs.k8s.io/controller-runtime v0.24.1
@@ -93,7 +95,6 @@ require (
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -286,7 +287,6 @@ require (
 	k8s.io/apiserver v0.36.3 // indirect
 	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/helm v2.14.3+incompatible // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.3 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect

--- a/internal/pkg/controllerhelper/enqueue.go
+++ b/internal/pkg/controllerhelper/enqueue.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper
+
+import (
+	"context"
+	"fmt"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// EnqueueAllOfType lists every object of list's type and returns one reconcile.Request per item, for use in
+// handler.EnqueueRequestsFromMapFunc watches that re-evaluate every parent artifact (Plugin/Rulesfile/Config)
+// on an unrelated event (e.g. a Node's labels changing). list must be a pointer to an empty list (e.g.
+// &artifactv1alpha1.PluginList{}); it is populated in place by the List call. Optional opts (e.g.
+// client.InNamespace) narrow the listing.
+func EnqueueAllOfType(ctx context.Context, cl client.Client, list client.ObjectList, opts ...client.ListOption) []reconcile.Request {
+	if err := cl.List(ctx, list, opts...); err != nil {
+		log.FromContext(ctx).Error(err, "unable to list for re-enqueue", "type", fmt.Sprintf("%T", list))
+		return nil
+	}
+	items, err := apimeta.ExtractList(list)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "unable to extract list items for re-enqueue", "type", fmt.Sprintf("%T", list))
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(obj)})
+	}
+	return reqs
+}

--- a/internal/pkg/controllerhelper/enqueue_test.go
+++ b/internal/pkg/controllerhelper/enqueue_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+)
+
+func TestEnqueueAllOfType_ReturnsOneRequestPerItem(t *testing.T) {
+	s := newArtifactScheme(t)
+	p1 := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "container", Namespace: "default"}}
+	p2 := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json", Namespace: "other"}}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(p1, p2).Build()
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.PluginList{})
+
+	require.Len(t, reqs, 2)
+	names := []string{reqs[0].Name, reqs[1].Name}
+	assert.Contains(t, names, "container")
+	assert.Contains(t, names, "json")
+}
+
+func TestEnqueueAllOfType_EmptyList(t *testing.T) {
+	s := newArtifactScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.PluginList{})
+	assert.Empty(t, reqs)
+}
+
+func TestEnqueueAllOfType_ListError(t *testing.T) {
+	s := newArtifactScheme(t)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return fmt.Errorf("list error")
+			},
+		}).
+		Build()
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.PluginList{})
+	assert.Nil(t, reqs)
+}
+
+// stubListClient is a client.Client that only implements List; every other method panics via the
+// embedded nil interface if called.
+type stubListClient struct {
+	client.Client
+	listFunc func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+}
+
+func (s *stubListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return s.listFunc(ctx, list, opts...)
+}
+
+// plainItem implements runtime.Object (via *plainItem) but not metav1.Object, so it fails the
+// client.Object type assertion inside EnqueueAllOfType.
+type plainItem struct {
+	metav1.TypeMeta
+}
+
+func (p *plainItem) DeepCopyObject() runtime.Object {
+	return &plainItem{TypeMeta: p.TypeMeta}
+}
+
+// plainItemList is a minimal client.ObjectList whose Items are plainItem, not client.Object.
+type plainItemList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+	Items []plainItem
+}
+
+func (l *plainItemList) DeepCopyObject() runtime.Object {
+	items := make([]plainItem, len(l.Items))
+	copy(items, l.Items)
+	return &plainItemList{TypeMeta: l.TypeMeta, ListMeta: l.ListMeta, Items: items}
+}
+
+func TestEnqueueAllOfType_ExtractListError(t *testing.T) {
+	// noItemsList has no Items field at all, so apimeta.ExtractList fails with "not a list".
+	cl := &stubListClient{listFunc: func(context.Context, client.ObjectList, ...client.ListOption) error {
+		return nil
+	}}
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &noItemsList{})
+	assert.Nil(t, reqs)
+}
+
+func TestEnqueueAllOfType_SkipsItemsThatAreNotClientObjects(t *testing.T) {
+	cl := &stubListClient{listFunc: func(context.Context, client.ObjectList, ...client.ListOption) error {
+		return nil // Items are pre-populated on the list passed below; nothing to do here.
+	}}
+
+	list := &plainItemList{Items: []plainItem{{}}}
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, list)
+	assert.Empty(t, reqs)
+}
+
+// noItemsList is a client.ObjectList with no Items field, so apimeta.ExtractList fails.
+type noItemsList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+}
+
+func (l *noItemsList) DeepCopyObject() runtime.Object {
+	return &noItemsList{TypeMeta: l.TypeMeta, ListMeta: l.ListMeta}
+}

--- a/internal/pkg/controllerhelper/finalizer.go
+++ b/internal/pkg/controllerhelper/finalizer.go
@@ -19,15 +19,28 @@ package controllerhelper
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// patchFinalizer adds (add=true) or removes (add=false) finalizer on obj, then applies the
+// change via a MergeFrom patch. obj is mutated in place. Callers classify/handle the returned
+// error themselves.
+func patchFinalizer(ctx context.Context, cl client.Client, obj client.Object, finalizer string, add bool) error {
+	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object)) //nolint:forcetypeassert // client.Object always satisfies this
+
+	if add {
+		controllerutil.AddFinalizer(obj, finalizer)
+	} else {
+		controllerutil.RemoveFinalizer(obj, finalizer)
+	}
+
+	return cl.Patch(ctx, obj, patch)
+}
 
 // EnsureFinalizer adds the given finalizer to obj if not already present.
 // Returns (true, nil) when the finalizer was just added, (false, nil) if already present,
@@ -40,9 +53,7 @@ func EnsureFinalizer(ctx context.Context, cl client.Client, finalizer string, ob
 	logger := log.FromContext(ctx)
 	logger.V(3).Info("Setting finalizer", "finalizer", finalizer)
 
-	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
-	controllerutil.AddFinalizer(obj, finalizer)
-	if err := cl.Patch(ctx, obj, patch); err != nil {
+	if err := patchFinalizer(ctx, cl, obj, finalizer, true); err != nil {
 		if k8serrors.IsConflict(err) {
 			logger.V(3).Info("Conflict while setting finalizer, will retry")
 			return false, err
@@ -55,42 +66,153 @@ func EnsureFinalizer(ctx context.Context, cl client.Client, finalizer string, ob
 	return true, nil
 }
 
-// EnsureInUseFinalizer adds or removes a single finalizer on obj via server-side apply,
-// based on whether the object is currently referenced (isReferenced).
+// EnsureInUseFinalizer adds or removes a single finalizer on obj based on whether the object is
+// currently referenced (isReferenced): the finalizer is added when isReferenced is true, and
+// removed when it's false. obj is re-fetched before the check so the decision is made against
+// the object's current server state, not whatever the caller happened to be holding.
 //
-// When isReferenced is true the finalizer is added; when false it is removed.
 // A no-op guard avoids any API call when the current state already matches the desired state.
-func EnsureInUseFinalizer(ctx context.Context, c client.Client, scheme *runtime.Scheme,
-	finalizer, fieldManager string, obj client.Object, isReferenced bool) error {
+// A NotFound from the initial Get, and a NotFound or Conflict from the patch, are treated as
+// nothing left to do rather than errors, since another actor already removed or changed the
+// object.
+func EnsureInUseFinalizer(ctx context.Context, c client.Client, finalizer string, obj client.Object, isReferenced bool) error {
 	logger := log.FromContext(ctx)
 
+	current := obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("re-fetching %s/%s before updating finalizer: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
 	// Nothing to do when state already matches.
-	if isReferenced == controllerutil.ContainsFinalizer(obj, finalizer) {
+	if isReferenced == controllerutil.ContainsFinalizer(current, finalizer) {
 		return nil
 	}
 
-	gvk, err := apiutil.GVKForObject(obj, scheme)
-	if err != nil {
-		return fmt.Errorf("resolving GVK for %T: %w", obj, err)
-	}
-
-	u := &unstructured.Unstructured{}
-	u.SetGroupVersionKind(gvk)
-	u.SetName(obj.GetName())
-	u.SetNamespace(obj.GetNamespace())
-
 	if isReferenced {
 		logger.Info("Adding in-use finalizer", "finalizer", finalizer)
-		u.SetFinalizers([]string{finalizer})
 	} else {
 		logger.Info("Removing in-use finalizer", "finalizer", finalizer)
-		u.SetFinalizers([]string{})
 	}
 
-	applyOpts := []client.ApplyOption{client.ForceOwnership, client.FieldOwner(fieldManager)}
-	if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(u), applyOpts...); err != nil {
-		return fmt.Errorf("applying finalizer on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	if err := patchFinalizer(ctx, c, current, finalizer, isReferenced); err != nil {
+		if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
+			logger.V(3).Info("Object gone or changed before finalizer update landed, skipping", "err", err)
+			return nil
+		}
+		return fmt.Errorf("updating finalizer on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 	}
 
 	return nil
+}
+
+// legacyParentFinalizerPrefixes are the finalizer prefixes that pre node-object artifact
+// operators placed directly on parent Plugin/Rulesfile/Config objects, one per node
+// ("<kind>.artifact.falcosecurity.dev/finalizer-<nodeName>"). Nothing removes them anymore,
+// so the instance-operator aggregators strip them on sight.
+var legacyParentFinalizerPrefixes = []string{
+	"rulesfile.artifact.falcosecurity.dev/finalizer-",
+	"plugin.artifact.falcosecurity.dev/finalizer-",
+	"config.artifact.falcosecurity.dev/finalizer-",
+}
+
+// ReconcileInUseFinalizer reconciles the full finalizer set of a parent artifact: it
+// strips legacy per-node finalizers (legacyParentFinalizerPrefixes) and adds/removes the
+// given in-use finalizer based on isReferenced. The object is re-fetched first so the
+// decision is made against current server state; unknown (foreign) finalizers are
+// preserved.
+//
+// Both additions and removals go through a single MergeFrom patch that replaces the whole
+// finalizer list. That is deliberate, not incidental: SSA cannot remove elements of
+// metadata.finalizers (a listType=set field) that are owned or co-owned by other managers,
+// since applying the same value only adds the applier as a co-owner, it never strips the
+// previous owner. A merge patch is the only form that can evict another manager's entries
+// (e.g. a legacy per-node finalizer left by an old operator version), so this function uses
+// it uniformly for both directions rather than switching mechanisms by direction.
+//
+// Use this only on objects whose finalizers are meant to be managed by the calling
+// controller (the artifact CRDs). For shared core resources (Secrets, ConfigMaps) use
+// EnsureInUseFinalizer instead, which only touches its own finalizer.
+//
+// A no-op guard avoids any API call when the current state already matches the desired
+// state. A NotFound from the initial Get, and a NotFound or Conflict from the patch, are
+// treated as nothing left to do rather than errors, mirroring EnsureInUseFinalizer.
+func ReconcileInUseFinalizer(ctx context.Context, c client.Client,
+	obj client.Object, finalizer string, isReferenced bool,
+) error {
+	logger := log.FromContext(ctx)
+
+	current := obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("re-fetching %s/%s before updating finalizer: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	desired := make([]string, 0, len(current.GetFinalizers())+1)
+	for _, f := range current.GetFinalizers() {
+		if isLegacyParentFinalizer(f) {
+			logger.Info("Removing legacy per-node finalizer", "finalizer", f)
+			continue
+		}
+		if f != finalizer {
+			desired = append(desired, f)
+		}
+	}
+	if isReferenced {
+		desired = append(desired, finalizer)
+	}
+
+	// Nothing to do when state already matches (finalizers are order-independent).
+	if finalizerSetsEqual(desired, current.GetFinalizers()) {
+		return nil
+	}
+
+	base := current.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
+	current.SetFinalizers(desired)
+	if err := c.Patch(ctx, current, client.MergeFrom(base)); err != nil {
+		return swallowGoneOrConflict(ctx, err, obj)
+	}
+	return nil
+}
+
+// swallowGoneOrConflict returns nil when err is NotFound or Conflict (the object is gone
+// or changed underneath us; a later reconcile settles it), and a wrapped error otherwise.
+func swallowGoneOrConflict(ctx context.Context, err error, obj client.Object) error {
+	if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
+		log.FromContext(ctx).V(3).Info("Object gone or changed before finalizer update landed, skipping", "err", err)
+		return nil
+	}
+	return fmt.Errorf("updating finalizers on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+}
+
+// finalizerSetsEqual reports whether a and b contain the same finalizers, ignoring order.
+func finalizerSetsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]struct{}, len(b))
+	for _, f := range b {
+		set[f] = struct{}{}
+	}
+	for _, f := range a {
+		if _, ok := set[f]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// isLegacyParentFinalizer reports whether f carries one of the legacy per-node finalizer
+// prefixes placed on parent artifacts by pre node-object artifact operators.
+func isLegacyParentFinalizer(f string) bool {
+	for _, prefix := range legacyParentFinalizerPrefixes {
+		if strings.HasPrefix(f, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pkg/controllerhelper/finalizer_envtest_test.go
+++ b/internal/pkg/controllerhelper/finalizer_envtest_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+)
+
+// These tests run against a real API server (envtest) to prove the merge-patch contract of
+// ReconcileInUseFinalizer: removal of finalizers left by another manager, and no-op reconciles
+// not bumping resourceVersion. Neither is faithfully reproduced by the fake client.
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	cl, stop, err := testutil.StartEnvtest()
+	if err != nil {
+		ctrllog.Log.Error(err, "Failed to start envtest")
+		os.Exit(1)
+	}
+	k8sClient = cl
+	code := m.Run()
+	stop()
+	os.Exit(code)
+}
+
+// createFinalizerCM creates a ConfigMap carrying finalizers through a plain create,
+// so the finalizer elements are owned by an update manager. This is exactly how finalizers
+// left behind by old operator versions (or kubectl) look on a real object.
+func createFinalizerCM(t *testing.T, ctx context.Context, name string, finalizers ...string) *corev1.ConfigMap {
+	t.Helper()
+	cm := &corev1.ConfigMap{}
+	cm.Name = name
+	cm.Namespace = "default"
+	cm.Finalizers = finalizers
+	require.NoError(t, k8sClient.Create(ctx, cm))
+	t.Cleanup(func() { testutil.CleanupObject(t, ctx, k8sClient, cm) })
+	return cm
+}
+
+func TestReconcileInUseFinalizer_Removals(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		initial        []string
+		isReferenced   bool
+		wantFinalizers []string
+	}{
+		{
+			name:           "isReferenced=false, in-use finalizer present -> removed",
+			initial:        []string{testFinalizer},
+			isReferenced:   false,
+			wantFinalizers: nil,
+		},
+		{
+			name: "strips all legacy per-node finalizers, keeps foreign and in-use",
+			initial: []string{
+				testLegacyRulesfileFinalizer, testFinalizer,
+				testLegacyPluginFinalizer, testForeignFinalizer, testLegacyConfigFinalizer,
+			},
+			isReferenced:   true,
+			wantFinalizers: []string{testFinalizer, testForeignFinalizer},
+		},
+		{
+			name:           "strips legacy finalizer and adds in-use in one reconcile",
+			initial:        []string{testLegacyPluginFinalizer},
+			isReferenced:   true,
+			wantFinalizers: []string{testFinalizer},
+		},
+		{
+			name:           "strips the last (legacy) finalizer, list left empty",
+			initial:        []string{testLegacyConfigFinalizer},
+			isReferenced:   false,
+			wantFinalizers: nil,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := createFinalizerCM(t, ctx, fmt.Sprintf("ssa-finalizer-%d", i), tt.initial...)
+
+			require.NoError(t, controllerhelper.ReconcileInUseFinalizer(
+				ctx, k8sClient, cm, testFinalizer, tt.isReferenced))
+
+			got := &corev1.ConfigMap{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cm), got))
+			assert.ElementsMatch(t, tt.wantFinalizers, got.Finalizers)
+
+			// A second call must be a no-op: the state already matches the desired state.
+			require.NoError(t, controllerhelper.ReconcileInUseFinalizer(
+				ctx, k8sClient, cm, testFinalizer, tt.isReferenced))
+			rv := got.ResourceVersion
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(cm), got))
+			assert.Equal(t, rv, got.ResourceVersion, "second reconcile must not write")
+		})
+	}
+}

--- a/internal/pkg/controllerhelper/finalizer_test.go
+++ b/internal/pkg/controllerhelper/finalizer_test.go
@@ -41,8 +41,6 @@ import (
 const (
 	testFinalizerInUse = "test.example.com/in-use"
 	testFinalizer      = "test.example.com/finalizer"
-
-	testFieldManager = "test-field-manager"
 )
 
 func newFinalizerScheme(t *testing.T) *runtime.Scheme {
@@ -150,7 +148,7 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 		initialCM      *corev1.ConfigMap
 		isReferenced   bool
 		setupFn        func(t *testing.T, cl client.Client, s *runtime.Scheme)
-		interceptApply func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error
+		interceptPatch func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
 		wantErr        bool
 		wantFinalizer  bool
 	}{
@@ -167,8 +165,6 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 			wantFinalizer: true,
 		},
 		{
-			// The finalizer must have been added via SSA (by the same field manager)
-			// for SSA to be able to remove it. setupFn establishes that ownership first.
 			name:      "isReferenced=false, finalizer present -> removes finalizer",
 			initialCM: newFinalizerCM(),
 			setupFn: func(t *testing.T, cl client.Client, s *runtime.Scheme) {
@@ -177,7 +173,7 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 				require.NoError(t, cl.Get(context.Background(),
 					types.NamespacedName{Name: "my-cm", Namespace: "default"}, cm))
 				require.NoError(t, controllerhelper.EnsureInUseFinalizer(
-					context.Background(), cl, s, testFinalizer, testFieldManager, cm, true))
+					context.Background(), cl, testFinalizer, cm, true))
 			},
 			isReferenced:  false,
 			wantFinalizer: false,
@@ -189,9 +185,9 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 			wantFinalizer: false,
 		},
 		{
-			name:      "apply error propagates",
+			name:      "patch error propagates",
 			initialCM: newFinalizerCM(),
-			interceptApply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+			interceptPatch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 				return fmt.Errorf("server unavailable")
 			},
 			isReferenced: true,
@@ -203,9 +199,9 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newFinalizerScheme(t)
 			builder := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.initialCM)
-			if tt.interceptApply != nil {
+			if tt.interceptPatch != nil {
 				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
-					Apply: tt.interceptApply,
+					Patch: tt.interceptPatch,
 				})
 			}
 			cl := builder.Build()
@@ -220,7 +216,7 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 				types.NamespacedName{Name: tt.initialCM.Name, Namespace: tt.initialCM.Namespace}, fetched))
 
 			err := controllerhelper.EnsureInUseFinalizer(
-				context.Background(), cl, s, testFinalizer, testFieldManager, fetched, tt.isReferenced)
+				context.Background(), cl, testFinalizer, fetched, tt.isReferenced)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -235,6 +231,240 @@ func TestEnsureInUseFinalizer(t *testing.T) {
 
 			hasFinalizer := slices.Contains(result.Finalizers, testFinalizer)
 			assert.Equal(t, tt.wantFinalizer, hasFinalizer)
+		})
+	}
+}
+
+func TestEnsureInUseFinalizer_GetNotFound(t *testing.T) {
+	s := newFinalizerScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build() // object never created
+
+	err := controllerhelper.EnsureInUseFinalizer(
+		context.Background(), cl, testFinalizer, newFinalizerCM(), true)
+	require.NoError(t, err, "object already gone is treated as nothing to do, not an error")
+}
+
+func TestEnsureInUseFinalizer_GetOtherError(t *testing.T) {
+	s := newFinalizerScheme(t)
+	cm := newFinalizerCM()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return fmt.Errorf("api server unavailable")
+			},
+		}).
+		Build()
+
+	err := controllerhelper.EnsureInUseFinalizer(context.Background(), cl, testFinalizer, cm, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api server unavailable")
+}
+
+func TestEnsureInUseFinalizer_PatchNotFoundOrConflictSwallowed(t *testing.T) {
+	for _, mkErr := range []struct {
+		name string
+		err  error
+	}{
+		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm")},
+		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict"))},
+	} {
+		t.Run(mkErr.name, func(t *testing.T) {
+			s := newFinalizerScheme(t)
+			cm := newFinalizerCM()
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(cm).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+						return mkErr.err
+					},
+				}).
+				Build()
+
+			err := controllerhelper.EnsureInUseFinalizer(context.Background(), cl, testFinalizer, cm, true)
+			require.NoError(t, err, "%s on Patch must be swallowed, not propagated", mkErr.name)
+		})
+	}
+}
+
+const (
+	testLegacyRulesfileFinalizer = "rulesfile.artifact.falcosecurity.dev/finalizer-node-1"
+	testLegacyPluginFinalizer    = "plugin.artifact.falcosecurity.dev/finalizer-node-2"
+	testLegacyConfigFinalizer    = "config.artifact.falcosecurity.dev/finalizer-node-3"
+	testForeignFinalizer         = "other.example.com/keep-me"
+)
+
+func TestReconcileInUseFinalizer(t *testing.T) {
+	// NOTE: the SSA path (pure additions) and the no-op guard are also verified against a
+	// real API server in finalizer_envtest_test.go, since the fake client does not fully
+	// implement SSA ownership semantics for metadata.finalizers.
+	tests := []struct {
+		name           string
+		initialCM      *corev1.ConfigMap
+		isReferenced   bool
+		interceptPatch func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+		wantErr        bool
+		wantFinalizers []string
+	}{
+		{
+			name:           "isReferenced=true, no finalizer -> adds finalizer",
+			initialCM:      newFinalizerCM(),
+			isReferenced:   true,
+			wantFinalizers: []string{testFinalizer},
+		},
+		{
+			name:           "isReferenced=true, finalizer already present -> no-op, returns nil",
+			initialCM:      newFinalizerCM(testFinalizer),
+			isReferenced:   true,
+			wantFinalizers: []string{testFinalizer},
+		},
+		{
+			name:           "isReferenced=false, finalizer present -> removes finalizer, list left empty",
+			initialCM:      newFinalizerCM(testFinalizer),
+			isReferenced:   false,
+			wantFinalizers: nil,
+		},
+		{
+			name:           "isReferenced=false, no finalizer -> no-op, returns nil",
+			initialCM:      newFinalizerCM(),
+			isReferenced:   false,
+			wantFinalizers: nil,
+		},
+		{
+			name: "strips all legacy per-node finalizers, keeps foreign and in-use",
+			initialCM: newFinalizerCM(
+				testLegacyRulesfileFinalizer, testFinalizer,
+				testLegacyPluginFinalizer, testForeignFinalizer, testLegacyConfigFinalizer),
+			isReferenced:   true,
+			wantFinalizers: []string{testForeignFinalizer, testFinalizer},
+		},
+		{
+			name:           "strips legacy finalizer and adds in-use in one reconcile",
+			initialCM:      newFinalizerCM(testLegacyPluginFinalizer),
+			isReferenced:   true,
+			wantFinalizers: []string{testFinalizer},
+		},
+		{
+			name:           "strips the last (legacy) finalizer, list left empty",
+			initialCM:      newFinalizerCM(testLegacyConfigFinalizer),
+			isReferenced:   false,
+			wantFinalizers: nil,
+		},
+		{
+			// Removal takes the MergeFrom path (c.Patch), so the Patch interceptor fires.
+			name:      "patch error propagates on removal",
+			initialCM: newFinalizerCM(testFinalizer),
+			interceptPatch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("server unavailable")
+			},
+			isReferenced: false,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newFinalizerScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.initialCM)
+			if tt.interceptPatch != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Patch: tt.interceptPatch,
+				})
+			}
+			cl := builder.Build()
+
+			err := controllerhelper.ReconcileInUseFinalizer(
+				context.Background(), cl, tt.initialCM, testFinalizer, tt.isReferenced)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			result := &corev1.ConfigMap{}
+			require.NoError(t, cl.Get(context.Background(),
+				types.NamespacedName{Name: tt.initialCM.Name, Namespace: tt.initialCM.Namespace}, result))
+			assert.Equal(t, tt.wantFinalizers, result.Finalizers)
+		})
+	}
+}
+
+func TestReconcileInUseFinalizer_NoOpGuardSkipsApply(t *testing.T) {
+	s := newFinalizerScheme(t)
+	cm := newFinalizerCM(testFinalizer, testForeignFinalizer)
+	patchCalls := 0
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patchCalls++
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	err := controllerhelper.ReconcileInUseFinalizer(
+		context.Background(), cl, cm, testFinalizer, true)
+	require.NoError(t, err)
+	assert.Equal(t, 0, patchCalls, "no API call expected when finalizer state already matches")
+}
+
+func TestReconcileInUseFinalizer_GetNotFound(t *testing.T) {
+	s := newFinalizerScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build() // object never created
+
+	err := controllerhelper.ReconcileInUseFinalizer(
+		context.Background(), cl, newFinalizerCM(), testFinalizer, true)
+	require.NoError(t, err, "object already gone is treated as nothing to do, not an error")
+}
+
+func TestReconcileInUseFinalizer_GetOtherError(t *testing.T) {
+	s := newFinalizerScheme(t)
+	cm := newFinalizerCM()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return fmt.Errorf("api server unavailable")
+			},
+		}).
+		Build()
+
+	err := controllerhelper.ReconcileInUseFinalizer(
+		context.Background(), cl, cm, testFinalizer, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api server unavailable")
+}
+
+func TestReconcileInUseFinalizer_ApplyNotFoundOrConflictSwallowed(t *testing.T) {
+	for _, mkErr := range []struct {
+		name string
+		err  error
+	}{
+		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm")},
+		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict"))},
+	} {
+		t.Run(mkErr.name, func(t *testing.T) {
+			s := newFinalizerScheme(t)
+			cm := newFinalizerCM()
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(cm).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+						return mkErr.err
+					},
+				}).
+				Build()
+
+			err := controllerhelper.ReconcileInUseFinalizer(
+				context.Background(), cl, cm, testFinalizer, true)
+			require.NoError(t, err, "%s on patch must be swallowed, not propagated", mkErr.name)
 		})
 	}
 }

--- a/internal/pkg/controllerhelper/logconstructor.go
+++ b/internal/pkg/controllerhelper/logconstructor.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// LogConstructorFor returns a controller-runtime-compatible LogConstructor that
+// enriches the logger with controller metadata and a typed KRef key for the
+// reconciled object. Unlike controller-runtime's default, it omits the flat
+// "name" and "namespace" keys that duplicate the information already present
+// in the typed KRef key, and it names the logger after the controller (via
+// WithName, populating the dedicated "logger" field most log backends key on
+// for filtering) in addition to the "controller" key-value controller-runtime's
+// own default constructor already sets.
+//
+// Pass the same controllerName used in Named(...) and the same obj type used
+// in For(...) for the controller being set up.
+func LogConstructorFor(logger logr.Logger, scheme *runtime.Scheme, controllerName string, obj client.Object) func(*reconcile.Request) logr.Logger {
+	gvks, _, _ := scheme.ObjectKinds(obj)
+	gvk := gvks[0]
+	base := logger.WithName(controllerName).WithValues(
+		"controller", controllerName,
+		"controllerGroup", gvk.Group,
+		"controllerKind", gvk.Kind,
+	)
+	return func(req *reconcile.Request) logr.Logger {
+		if req == nil {
+			return base
+		}
+		return base.WithValues(gvk.Kind, klog.KRef(req.Namespace, req.Name))
+	}
+}

--- a/internal/pkg/controllerhelper/logconstructor_test.go
+++ b/internal/pkg/controllerhelper/logconstructor_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerhelper_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+)
+
+// kvSink is a minimal logr.LogSink that accumulates WithValues key-value pairs and the
+// hierarchical name built up via WithName (dot-joined, matching logr's own convention).
+type kvSink struct {
+	kvs  []any
+	name string
+}
+
+func (s *kvSink) Init(_ logr.RuntimeInfo)           {}
+func (s *kvSink) Enabled(_ int) bool                { return true }
+func (s *kvSink) Info(_ int, _ string, _ ...any)    {}
+func (s *kvSink) Error(_ error, _ string, _ ...any) {}
+func (s *kvSink) WithName(name string) logr.LogSink {
+	newName := name
+	if s.name != "" {
+		newName = s.name + "." + name
+	}
+	return &kvSink{kvs: s.kvs, name: newName}
+}
+func (s *kvSink) WithValues(kvs ...any) logr.LogSink {
+	merged := make([]any, len(s.kvs)+len(kvs))
+	copy(merged, s.kvs)
+	copy(merged[len(s.kvs):], kvs)
+	return &kvSink{kvs: merged, name: s.name}
+}
+
+// loggerKeys extracts the string keys from a logger's accumulated WithValues pairs.
+func loggerKeys(logger logr.Logger) map[string]bool {
+	sink, ok := logger.GetSink().(*kvSink)
+	if !ok {
+		return nil
+	}
+	m := make(map[string]bool, len(sink.kvs)/2)
+	for i := 0; i+1 < len(sink.kvs); i += 2 {
+		if k, ok := sink.kvs[i].(string); ok {
+			m[k] = true
+		}
+	}
+	return m
+}
+
+// loggerName returns the hierarchical name built up via WithName.
+func loggerName(logger logr.Logger) string {
+	sink, ok := logger.GetSink().(*kvSink)
+	if !ok {
+		return ""
+	}
+	return sink.name
+}
+
+func TestLogConstructorFor_withRequest(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	logger := logr.New(&kvSink{})
+	fn := controllerhelper.LogConstructorFor(logger, scheme, "my-controller", &corev1.ConfigMap{})
+
+	req := &reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-cm", Namespace: "default"},
+	}
+	result := fn(req)
+	k := loggerKeys(result)
+
+	assert.Equal(t, "my-controller", loggerName(result), "logger must be named after the controller")
+	assert.True(t, k["controller"], "expected 'controller' key")
+	assert.True(t, k["controllerGroup"], "expected 'controllerGroup' key")
+	assert.True(t, k["controllerKind"], "expected 'controllerKind' key")
+	assert.True(t, k["ConfigMap"], "expected typed Kind key 'ConfigMap'")
+	assert.False(t, k["name"], "must not emit flat 'name' key")
+	assert.False(t, k["namespace"], "must not emit flat 'namespace' key")
+}
+
+func TestLogConstructorFor_nilRequest(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	logger := logr.New(&kvSink{})
+	fn := controllerhelper.LogConstructorFor(logger, scheme, "my-controller", &corev1.ConfigMap{})
+
+	result := fn(nil)
+	k := loggerKeys(result)
+
+	assert.Equal(t, "my-controller", loggerName(result), "logger must be named after the controller even for a nil request")
+	assert.True(t, k["controller"])
+	assert.False(t, k["ConfigMap"], "nil request must not add typed Kind key")
+	assert.False(t, k["name"])
+	assert.False(t, k["namespace"])
+}

--- a/internal/pkg/controllerhelper/node.go
+++ b/internal/pkg/controllerhelper/node.go
@@ -18,6 +18,7 @@ package controllerhelper
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 )
 
 // ClearFinalizersIfNodeGone checks whether nodeName still exists in the cluster.
@@ -56,6 +59,77 @@ func ClearFinalizersIfNodeGone(ctx context.Context, cl client.Client, nodeName s
 		return pErr
 	}
 	return nil
+}
+
+// ListMatchingNodes returns all nodes matching the given label selector.
+// A nil selector matches all nodes.
+func ListMatchingNodes(ctx context.Context, cl client.Client, sel *metav1.LabelSelector) ([]corev1.Node, error) {
+	nodeList := &corev1.NodeList{}
+	var listOpts []client.ListOption
+	if sel != nil {
+		selector, err := metav1.LabelSelectorAsSelector(sel)
+		if err != nil {
+			return nil, fmt.Errorf("invalid node selector: %w", err)
+		}
+		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
+	}
+	if err := cl.List(ctx, nodeList, listOpts...); err != nil {
+		return nil, err
+	}
+	return nodeList.Items, nil
+}
+
+// ListMatchingFalcoNodes returns the subset of nodes that (a) match sel and (b) have at least
+// one Running Falco pod scheduled on them across all Falco CRs in namespace. In DaemonSet mode
+// every matching node has a Falco pod, so the result equals ListMatchingNodes. In Deployment mode
+// only the node(s) hosting a scheduled Falco pod are returned. Nodes excluded by taints or
+// tolerations that prevent Falco from running there are correctly omitted in both modes.
+func ListMatchingFalcoNodes(ctx context.Context, cl client.Client, sel *metav1.LabelSelector, namespace string) ([]corev1.Node, error) {
+	nodes, err := ListMatchingNodes(ctx, cl, sel)
+	if err != nil {
+		return nil, err
+	}
+
+	falcoNodes, err := listFalcoRunningNodeNames(ctx, cl, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := nodes[:0]
+	for i := range nodes {
+		if _, ok := falcoNodes[nodes[i].Name]; ok {
+			filtered = append(filtered, nodes[i])
+		}
+	}
+	return filtered, nil
+}
+
+// listFalcoRunningNodeNames lists all Falco CRs in namespace and returns the set of node names
+// that currently have a Running pod for any of them.
+func listFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace string) (map[string]struct{}, error) {
+	falcoList := &instancev1alpha1.FalcoList{}
+	if err := cl.List(ctx, falcoList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list Falco CRs for node filtering: %w", err)
+	}
+
+	running := make(map[string]struct{})
+	for i := range falcoList.Items {
+		name := falcoList.Items[i].Name
+		podList := &corev1.PodList{}
+		if err := cl.List(ctx, podList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{"app.kubernetes.io/instance": name},
+		); err != nil {
+			return nil, fmt.Errorf("list pods for Falco %q: %w", name, err)
+		}
+		for j := range podList.Items {
+			pod := &podList.Items[j]
+			if pod.Status.Phase == corev1.PodRunning && pod.Spec.NodeName != "" {
+				running[pod.Spec.NodeName] = struct{}{}
+			}
+		}
+	}
+	return running, nil
 }
 
 // NodeMatchesSelector checks if a selector matches the node labels.

--- a/internal/pkg/controllerhelper/node_test.go
+++ b/internal/pkg/controllerhelper/node_test.go
@@ -130,6 +130,59 @@ func TestClearFinalizersIfNodeGone_PatchError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestListMatchingNodes_NilSelectorMatchesAll(t *testing.T) {
+	s := newNodeScheme(t)
+	n1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+	n2 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"pool": "gpu"}}}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(n1, n2).Build()
+
+	nodes, err := controllerhelper.ListMatchingNodes(context.Background(), cl, nil)
+	require.NoError(t, err)
+	assert.Len(t, nodes, 2)
+}
+
+func TestListMatchingNodes_SelectorMatchesSubset(t *testing.T) {
+	s := newNodeScheme(t)
+	n1 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"pool": "gpu"}}}
+	n2 := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"pool": "cpu"}}}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(n1, n2).Build()
+
+	nodes, err := controllerhelper.ListMatchingNodes(context.Background(), cl,
+		&metav1.LabelSelector{MatchLabels: map[string]string{"pool": "gpu"}})
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, "node1", nodes[0].Name)
+}
+
+func TestListMatchingNodes_InvalidSelector(t *testing.T) {
+	s := newNodeScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+	_, err := controllerhelper.ListMatchingNodes(context.Background(), cl, &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "key1", Operator: "NotAnOperator"},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid node selector")
+}
+
+func TestListMatchingNodes_ListError(t *testing.T) {
+	s := newNodeScheme(t)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return fmt.Errorf("api server unavailable")
+			},
+		}).
+		Build()
+
+	_, err := controllerhelper.ListMatchingNodes(context.Background(), cl, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api server unavailable")
+}
+
 func TestNodeMatchesSelector(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

 /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

Finishes the shared controllerhelper toolkit that the per-artifact-type aggregator controllers (Config, Plugin, Rulesfile) will build on:

- EnqueueAllOfType (enqueue.go): re-enqueues every parent artifact of a type on Node/Pod watch events.
- LogConstructorFor (logconstructor.go): structured per-reconcile logger construction, reused here to give the reference controllers real reconcile-scoped logging.
- ListMatchingNodes / ListMatchingFalcoNodes (node.go): selects nodes that actually run a Falco pod, not just nodes matching a label selector.
- ReconcileInUseFinalizer (finalizer.go): reconciles a parent artifact's full finalizer set in one patch, stripping legacy per-node finalizers left by pre node-object operator versions while adding/removing the in-use finalizer. EnsureInUseFinalizer is refactored alongside it to use the same merge-patch mechanism instead of server-side apply, which requires updating its two existing callers (the configmap and secret reference controllers) to the new signature.

Still no controller wiring for Config/Plugin/Rulesfile.



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
