### PR TITLE
feat(instance): wire up the Config node-object aggregator controller

### DIFF
--- a/api/artifact/v1alpha1/config_types.go
+++ b/api/artifact/v1alpha1/config_types.go
@@ -48,6 +48,11 @@ type ConfigStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	// ObservedGeneration is the .metadata.generation that the instance operator has fully
+	// processed (node objects synced, status patched). Per-node artifact operators defer
+	// reconciliation until this equals metadata.generation.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/chart/falco-operator/crds/artifact.falcosecurity.dev_configs.yaml
+++ b/chart/falco-operator/crds/artifact.falcosecurity.dev_configs.yaml
@@ -194,6 +194,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the .metadata.generation that the instance operator has fully
+                  processed (node objects synced, status patched). Per-node artifact operators defer
+                  reconciliation until this equals metadata.generation.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/chart/falco-operator/files/ClusterRole.yaml
+++ b/chart/falco-operator/files/ClusterRole.yaml
@@ -69,6 +69,26 @@ rules:
 - apiGroups:
   - artifact.falcosecurity.dev
   resources:
+  - artifactnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - artifact.falcosecurity.dev
+  resources:
+  - artifactnodes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - artifact.falcosecurity.dev
+  resources:
   - configs
   - configs/status
   - plugins
@@ -81,6 +101,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - artifact.falcosecurity.dev
+  resources:
+  - configs/finalizers
+  verbs:
+  - patch
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/cmd/instance/main.go
+++ b/cmd/instance/main.go
@@ -37,6 +37,7 @@ import (
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+	artifactconfigctr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/config"
 	"github.com/falcosecurity/falco-operator/controllers/instance/component"
 	"github.com/falcosecurity/falco-operator/controllers/instance/falco"
 	configmapctr "github.com/falcosecurity/falco-operator/controllers/instance/reference/configmap"
@@ -265,6 +266,13 @@ func main() {
 		mgr.GetClient(), mgr.GetScheme(),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", secretctr.ControllerName)
+		os.Exit(1)
+	}
+
+	if err := artifactconfigctr.NewConfigAggregatorReconciler(
+		mgr.GetClient(), mgr.GetScheme(),
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", artifactconfigctr.ControllerName)
 		os.Exit(1)
 	}
 

--- a/controllers/instance/artifact/config/controller.go
+++ b/controllers/instance/artifact/config/controller.go
@@ -50,7 +50,11 @@ func NewConfigAggregatorReconciler(cl client.Client, scheme *runtime.Scheme) *Co
 
 // ConfigAggregatorReconciler manages ArtifactNode objects and aggregates their
 // conditions into the parent Config status.
-//
+type ConfigAggregatorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
 // +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs/status,verbs=patch;update
 // +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs/finalizers,verbs=patch;update
@@ -59,10 +63,6 @@ func NewConfigAggregatorReconciler(cl client.Client, scheme *runtime.Scheme) *Co
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
-type ConfigAggregatorReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
-}
 
 // Reconcile reconciles a Config: ensures ArtifactNode objects exist for matching nodes,
 // removes stale ones, and writes the aggregate conditions back to the Config.
@@ -114,17 +114,6 @@ func (r *ConfigAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	// Ensure the in-use finalizer is present when node objects exist.
-	// The SSA variant also strips any legacy per-node finalizers left by old operators.
-	hasNodes := len(matchingNodes) > 0
-	if err := controllerhelper.ReconcileInUseFinalizer(
-		ctx, r.Client, config,
-		controllerhelper.NodeObjectsInUseFinalizer,
-		hasNodes,
-	); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Re-fetch node objects (some may have just been created) to compute the aggregate.
 	existingNodes, err = controllerhelper.ListOwnedNodes(ctx, r.Client, config.Namespace, config.Name, controllerhelper.KindConfig)
 	if err != nil {
@@ -132,9 +121,34 @@ func (r *ConfigAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	logger.V(1).Info("Re-listed ArtifactNode objects after sync", "count", len(existingNodes.Items))
 
+	// Keep the parent alive when children are desired or until every existing child is
+	// physically gone. The desired-node check also covers a just-created child that the
+	// informer cache may not expose in the immediate re-list yet.
+	if err := controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, config,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		len(matchingNodes) > 0 || len(existingNodes.Items) > 0,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// A stale or terminating child no longer represents the desired assignment and must not
+	// keep its last condition in the aggregate while deletion is pending.
+	activeNodes := &artifactv1alpha1.ArtifactNodeList{}
+	for i := range existingNodes.Items {
+		nodeObject := &existingNodes.Items[i]
+		if !nodeObject.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if _, ok := desired[nodeObject.Spec.NodeName]; !ok {
+			continue
+		}
+		activeNodes.Items = append(activeNodes.Items, *nodeObject)
+	}
+
 	oldStatus := config.Status.DeepCopy()
 	config.Status.ObservedGeneration = config.Generation
-	controllerhelper.ComputeAggregateConditions(ctx, config, &config.Status.Conditions, existingNodes)
+	controllerhelper.ComputeAggregateConditions(ctx, config, &config.Status.Conditions, activeNodes)
 	if !apiequality.Semantic.DeepEqual(*oldStatus, config.Status) {
 		return ctrl.Result{}, controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, config, ControllerName)
 	}

--- a/controllers/instance/artifact/config/controller.go
+++ b/controllers/instance/artifact/config/controller.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config implements the Config node-object aggregator controller.
+// It runs in the instance operator (singleton Deployment) and is responsible for:
+//   - Creating one ArtifactNode per cluster node that matches the Config selector.
+//   - Deleting ArtifactNode objects when a node no longer matches.
+//   - Aggregating per-node conditions into the parent Config status (sole writer).
+//   - Managing the NodeObjectsInUseFinalizer on the parent Config.
+package config
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+)
+
+// ControllerName identifies this controller in logs and as the SSA field manager.
+const ControllerName = "instance-artifact-config"
+
+// NewConfigAggregatorReconciler returns a new ConfigAggregatorReconciler.
+func NewConfigAggregatorReconciler(cl client.Client, scheme *runtime.Scheme) *ConfigAggregatorReconciler {
+	return &ConfigAggregatorReconciler{Client: cl, Scheme: scheme}
+}
+
+// ConfigAggregatorReconciler manages ArtifactNode objects and aggregates their
+// conditions into the parent Config status.
+//
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs/status,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=configs/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
+type ConfigAggregatorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// Reconcile reconciles a Config: ensures ArtifactNode objects exist for matching nodes,
+// removes stale ones, and writes the aggregate conditions back to the Config.
+func (r *ConfigAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling Config")
+
+	config := &artifactv1alpha1.Config{}
+	if err := r.Get(ctx, req.NamespacedName, config); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !config.DeletionTimestamp.IsZero() {
+		logger.V(1).Info("Config marked for deletion, running cleanup")
+		return ctrl.Result{}, r.handleDeletion(ctx, config)
+	}
+
+	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, config.Spec.Selector, config.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed matching nodes", "count", len(matchingNodes))
+
+	existingNodes, err := controllerhelper.ListOwnedNodes(ctx, r.Client, config.Namespace, config.Name, controllerhelper.KindConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed existing ArtifactNode objects", "count", len(existingNodes.Items))
+
+	desired := make(map[string]struct{}, len(matchingNodes))
+	for i := range matchingNodes {
+		desired[matchingNodes[i].Name] = struct{}{}
+	}
+
+	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desired); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// No network-bound work happens between here and node creation, so the DeletionTimestamp
+	// check at the top of Reconcile is still valid.
+
+	// Ensure an ArtifactNode exists for each matching node.
+	configGVK := artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindConfig)
+	for i := range matchingNodes {
+		if err := controllerhelper.EnsureNodeObject(
+			ctx, r.Client, config, configGVK, controllerhelper.ArtifactKindConfig, matchingNodes[i].Name,
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Ensure the in-use finalizer is present when node objects exist.
+	// The SSA variant also strips any legacy per-node finalizers left by old operators.
+	hasNodes := len(matchingNodes) > 0
+	if err := controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, config,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		hasNodes,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Re-fetch node objects (some may have just been created) to compute the aggregate.
+	existingNodes, err = controllerhelper.ListOwnedNodes(ctx, r.Client, config.Namespace, config.Name, controllerhelper.KindConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Re-listed ArtifactNode objects after sync", "count", len(existingNodes.Items))
+
+	oldStatus := config.Status.DeepCopy()
+	config.Status.ObservedGeneration = config.Generation
+	controllerhelper.ComputeAggregateConditions(ctx, config, &config.Status.Conditions, existingNodes)
+	if !apiequality.Semantic.DeepEqual(*oldStatus, config.Status) {
+		return ctrl.Result{}, controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, config, ControllerName)
+	}
+	return ctrl.Result{}, nil
+}
+
+// handleDeletion deletes all ArtifactNode objects so each per-node artifact operator can clean up and
+// remove its own finalizer (skipping this would deadlock: GC cascade only fires after the owner is
+// deleted, but the in-use finalizer keeps the owner alive).
+func (r *ConfigAggregatorReconciler) handleDeletion(ctx context.Context, config *artifactv1alpha1.Config) error {
+	existing, err := controllerhelper.ListOwnedNodes(ctx, r.Client, config.Namespace, config.Name, controllerhelper.KindConfig)
+	if err != nil {
+		return err
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	if err != nil {
+		return err
+	}
+	if nodesRemaining {
+		return nil
+	}
+
+	return controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, config,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		false,
+	)
+}
+
+// SetupWithManager registers this controller with the manager.
+func (r *ConfigAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&artifactv1alpha1.Config{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return !obj.GetDeletionTimestamp().IsZero()
+			}),
+		))).
+		Watches(&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.ConfigList{})
+			}),
+		).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.ConfigList{}, client.InNamespace(pod.GetNamespace()))
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
+				return ok
+			})),
+		).
+		Watches(&artifactv1alpha1.ArtifactNode{},
+			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Config{}),
+		).
+		Named(ControllerName).
+		WithLogConstructor(controllerhelper.LogConstructorFor(mgr.GetLogger(), mgr.GetScheme(), ControllerName, &artifactv1alpha1.Config{})).
+		Complete(r)
+}

--- a/controllers/instance/artifact/config/controller_test.go
+++ b/controllers/instance/artifact/config/controller_test.go
@@ -1,0 +1,681 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+)
+
+const testConfigName = "test-config"
+
+func testConfigNodeName() string {
+	return controllerhelper.NodeObjectName(controllerhelper.ArtifactKindConfig, testConfigName, testutil.TestNodeName)
+}
+
+func newTestNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testutil.TestNodeName},
+	}
+}
+
+func newTestConfig(opts ...func(*artifactv1alpha1.Config)) *artifactv1alpha1.Config {
+	c := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: testConfigName, Namespace: testutil.TestNamespace},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+func withConfigSelector(key, value string) func(*artifactv1alpha1.Config) {
+	return func(c *artifactv1alpha1.Config) {
+		c.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{key: value},
+		}
+	}
+}
+
+func newTestConfigNode(opts ...func(*artifactv1alpha1.ArtifactNode)) *artifactv1alpha1.ArtifactNode {
+	isController := true
+	n := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigNodeName(),
+			Namespace: testutil.TestNamespace,
+			Labels:    controllerhelper.NodeObjectLabels(controllerhelper.ArtifactKindConfig, testConfigName, testutil.TestNodeName),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: artifactv1alpha1.GroupVersion.String(),
+				Kind:       "Config",
+				Name:       testConfigName,
+				Controller: &isController,
+			}},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*ConfigAggregatorReconciler, client.Client) {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	return NewConfigAggregatorReconciler(cl, s), cl
+}
+
+func newTestReconcilerWithScheme(t *testing.T, s *runtime.Scheme, objs ...client.Object) (*ConfigAggregatorReconciler, client.Client) {
+	t.Helper()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	return NewConfigAggregatorReconciler(cl, s), cl
+}
+
+// addInUseFinalizer adds the node-objects-in-use finalizer to config via server-side apply.
+func addInUseFinalizer(t *testing.T, cl client.Client, config *artifactv1alpha1.Config) {
+	t.Helper()
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), config))
+	require.NoError(t, controllerhelper.EnsureInUseFinalizer(
+		context.Background(), cl,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		config, true,
+	))
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), config))
+}
+
+const testFalcoName = "test-falco"
+
+func newTestFalco() *instancev1alpha1.Falco {
+	return &instancev1alpha1.Falco{
+		ObjectMeta: metav1.ObjectMeta{Name: testFalcoName, Namespace: testutil.TestNamespace},
+	}
+}
+
+func newRunningFalcoPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "falco-pod",
+			Namespace: testutil.TestNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/instance": testFalcoName},
+		},
+		Spec:   corev1.PodSpec{NodeName: testutil.TestNodeName},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestReconcile_NotFound(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	result, err := r.Reconcile(context.Background(), testutil.Request("nonexistent"))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcile_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return fmt.Errorf("api server error")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+}
+
+func TestReconcile_DeletionNoNodeObjects(t *testing.T) {
+	// A finalizer makes cl.Delete set DeletionTimestamp on the object rather than removing it.
+	config := newTestConfig(func(c *artifactv1alpha1.Config) {
+		c.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	r, cl := newTestReconciler(t, config)
+
+	require.NoError(t, cl.Delete(context.Background(), config))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// No ConfigNodes should exist.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletionWithNodeObjects(t *testing.T) {
+	// A finalizer makes cl.Delete set DeletionTimestamp on the object rather than removing it.
+	config := newTestConfig(func(c *artifactv1alpha1.Config) {
+		c.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	configNode := newTestConfigNode()
+	r, cl := newTestReconciler(t, config, configNode)
+
+	require.NoError(t, cl.Delete(context.Background(), config))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// ConfigNode should be deleted.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_NoMatchingNodes(t *testing.T) {
+	config := newTestConfig()
+	r, cl := newTestReconciler(t, config)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// No ConfigNodes should exist.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+
+	// Status should have Programmed=Unknown (no nodes assigned).
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+}
+
+func TestReconcile_CreatesNodeObject(t *testing.T) {
+	config := newTestConfig()
+	node := newTestNode()
+	r, cl := newTestReconciler(t, config, node, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// ConfigNode should be created.
+	configNode := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testConfigNodeName(), Namespace: testutil.TestNamespace},
+		configNode))
+	assert.Equal(t, testutil.TestNodeName, configNode.Spec.NodeName)
+
+	// In-use finalizer should be added to the Config.
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestReconcile_NodeObjectAlreadyExists(t *testing.T) {
+	config := newTestConfig()
+	node := newTestNode()
+	existingConfigNode := newTestConfigNode()
+	r, cl := newTestReconciler(t, config, node, existingConfigNode, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Exactly one ConfigNode should exist (idempotent).
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Len(t, nodeList.Items, 1)
+}
+
+func TestReconcile_NoFalcoPod_NoNodeObject(t *testing.T) {
+	// Node matches the artifact selector but no Falco pod is running on it.
+	config := newTestConfig()
+	node := newTestNode()
+	r, cl := newTestReconciler(t, config, node) // no Falco CR or pod
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletesStaleNodeObject(t *testing.T) {
+	// Config targets nodes with label env=prod, but the existing ConfigNode is for a plain node.
+	config := newTestConfig(withConfigSelector("env", "prod"))
+	staleNode := newTestConfigNode()
+	// The node exists but does NOT have the env=prod label.
+	plainNode := newTestNode()
+	r, cl := newTestReconciler(t, config, staleNode, plainNode)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Stale ConfigNode should be gone.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_ListMatchingNodesError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	listCallCount := 0
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NodeList); ok {
+					listCallCount++
+					if listCallCount == 1 {
+						return fmt.Errorf("node list failed")
+					}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node list failed")
+}
+
+func TestReconcile_ListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("config node list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config node list failed")
+}
+
+func TestReconcile_EnsureNodeObjectCreateError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	node := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config, node, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return fmt.Errorf("create failed")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create failed")
+}
+
+func TestReconcile_EnsureInUseFinalizerError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	node := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config, node, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("patch failed")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+}
+
+func TestHandleDeletion_NoNodeObjects(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	_, cl := newTestReconcilerWithScheme(t, s, config)
+	addInUseFinalizer(t, cl, config)
+
+	r := NewConfigAggregatorReconciler(cl, s)
+	err := r.handleDeletion(context.Background(), config)
+	require.NoError(t, err)
+
+	// Finalizer should be removed.
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	assert.NotContains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestHandleDeletion_NodeObjectsPresent(t *testing.T) {
+	config := newTestConfig()
+	configNode := newTestConfigNode()
+	r, cl := newTestReconciler(t, config, configNode)
+
+	err := r.handleDeletion(context.Background(), config)
+	require.NoError(t, err)
+
+	// ConfigNode should be deleted.
+	node := &artifactv1alpha1.ArtifactNode{}
+	err = cl.Get(context.Background(),
+		types.NamespacedName{Name: testConfigNodeName(), Namespace: testutil.TestNamespace}, node)
+	assert.Error(t, err)
+}
+
+func TestHandleDeletion_NodeObjectsBeingDeleted(t *testing.T) {
+	config := newTestConfig()
+	configNode := newTestConfigNode(func(n *artifactv1alpha1.ArtifactNode) {
+		now := metav1.Now()
+		n.DeletionTimestamp = &now
+		n.Finalizers = []string{"some-finalizer"} // keeps the object in the fake client after deletion
+	})
+	r, _ := newTestReconciler(t, config, configNode)
+
+	// Should return nil and wait (not remove finalizer).
+	err := r.handleDeletion(context.Background(), config)
+	require.NoError(t, err)
+}
+
+func TestHandleDeletion_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	err := r.handleDeletion(context.Background(), config)
+	require.Error(t, err)
+}
+
+func TestHandleDeletion_DeleteError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	configNode := newTestConfigNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config, configNode).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return fmt.Errorf("delete error")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	err := r.handleDeletion(context.Background(), config)
+	require.Error(t, err)
+}
+
+func TestEnsureNodeObject_AlreadyExists(t *testing.T) {
+	config := newTestConfig()
+	existing := newTestConfigNode()
+	r, cl := newTestReconciler(t, config, existing)
+
+	// Should be a no-op.
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, config,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindConfig), controllerhelper.ArtifactKindConfig, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	// Still exactly one ConfigNode.
+	list := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), list))
+	assert.Len(t, list.Items, 1)
+}
+
+func TestEnsureNodeObject_Creates(t *testing.T) {
+	config := newTestConfig()
+	r, cl := newTestReconciler(t, config)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, config,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindConfig), controllerhelper.ArtifactKindConfig, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	created := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testConfigNodeName(), Namespace: testutil.TestNamespace}, created))
+	assert.Equal(t, testutil.TestNodeName, created.Spec.NodeName)
+	assert.Equal(t, testConfigName, created.Labels[controllerhelper.LabelArtifactParent])
+}
+
+func TestEnsureNodeObject_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("get error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, config,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindConfig), controllerhelper.ArtifactKindConfig, testutil.TestNodeName)
+	require.Error(t, err)
+}
+
+func TestUpdateAggregateConditions_Empty(t *testing.T) {
+	config := newTestConfig()
+	r, cl := newTestReconciler(t, config)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	err := controllerhelper.UpdateAggregateConditions(
+		context.Background(), r.Client, r.Scheme, config, &config.Status.Conditions, nodeList, ControllerName,
+	)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+	assert.Equal(t, "NoNodesAssigned", cond.Reason)
+}
+
+func TestUpdateAggregateConditions_WithNodeConditions(t *testing.T) {
+	config := newTestConfig()
+	r, cl := newTestReconciler(t, config)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{
+		Items: []artifactv1alpha1.ArtifactNode{
+			{
+				Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+				Status: artifactv1alpha1.ArtifactNodeStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    commonv1alpha1.ConditionProgrammed.String(),
+							Status:  metav1.ConditionTrue,
+							Reason:  "Programmed",
+							Message: "ok",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := controllerhelper.UpdateAggregateConditions(
+		context.Background(), r.Client, r.Scheme, config, &config.Status.Conditions, nodeList, ControllerName,
+	)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+}
+
+func TestFindConfigsForNode(t *testing.T) {
+	config := newTestConfig()
+	r, _ := newTestReconciler(t, config)
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), r.Client, &artifactv1alpha1.ConfigList{})
+	require.Len(t, reqs, 1)
+	assert.Equal(t, testConfigName, reqs[0].Name)
+	assert.Equal(t, testutil.TestNamespace, reqs[0].Namespace)
+}
+
+func TestFindConfigsForNode_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ConfigList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.ConfigList{})
+	assert.Nil(t, reqs)
+}
+
+func TestFindConfigsForNode_EmptyList(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), r.Client, &artifactv1alpha1.ConfigList{})
+	assert.Empty(t, reqs)
+}
+
+// ── Reconcile remaining error paths ─────────────────────────────────────────
+
+func TestReconcile_DeleteStaleNodeError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	// Selector requires env=prod; existing ConfigNode is for a node without that label → stale.
+	config := newTestConfig(withConfigSelector("env", "prod"))
+	staleNode := newTestConfigNode()
+	plainNode := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config, staleNode, plainNode).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("delete failed")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+}
+
+func TestReconcile_SecondListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	config := newTestConfig()
+	node := newTestNode()
+	configNode := newTestConfigNode() // makes ensureNodeObject a no-op
+	var listCount int
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config, node, configNode).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					listCount++
+					if listCount == 2 {
+						return fmt.Errorf("second list error")
+					}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewConfigAggregatorReconciler(cl, s)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.Error(t, err)
+}

--- a/controllers/instance/artifact/config/controller_test.go
+++ b/controllers/instance/artifact/config/controller_test.go
@@ -302,6 +302,43 @@ func TestReconcile_DeletesStaleNodeObject(t *testing.T) {
 	assert.Empty(t, nodeList.Items)
 }
 
+func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) {
+	config := newTestConfig(
+		withConfigSelector("env", "prod"),
+		func(c *artifactv1alpha1.Config) {
+			c.Finalizers = []string{controllerhelper.NodeObjectsInUseFinalizer}
+		},
+	)
+	staleNode := newTestConfigNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"artifact.example.com/node-cleanup"}
+		n.Status.Conditions = []metav1.Condition{{
+			Type:    commonv1alpha1.ConditionProgrammed.String(),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Programmed",
+			Message: "old result",
+		}}
+	})
+	r, cl := newTestReconciler(t, config, staleNode, newTestNode())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	terminating := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(staleNode), terminating))
+	assert.False(t, terminating.DeletionTimestamp.IsZero(), "the node-side finalizer keeps the stale child terminating")
+
+	got := &artifactv1alpha1.Config{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(config), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer,
+		"the parent must stay alive until the terminating child is physically gone")
+	condition := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+	assert.Equal(t, "NoNodesAssigned", condition.Reason,
+		"the stale child's last successful result must not remain in the aggregate")
+}
+
 func TestReconcile_ListMatchingNodesError(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	config := newTestConfig()

--- a/internal/pkg/controllerhelper/finalizer.go
+++ b/internal/pkg/controllerhelper/finalizer.go
@@ -28,10 +28,11 @@ import (
 )
 
 // patchFinalizer adds (add=true) or removes (add=false) finalizer on obj, then applies the
-// change via a MergeFrom patch. obj is mutated in place. Callers classify/handle the returned
-// error themselves.
+// change via an optimistic-lock MergeFrom patch. obj is mutated in place. Callers
+// classify/handle the returned error themselves.
 func patchFinalizer(ctx context.Context, cl client.Client, obj client.Object, finalizer string, add bool) error {
-	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object)) //nolint:forcetypeassert // client.Object always satisfies this
+	base := obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
+	patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
 
 	if add {
 		controllerutil.AddFinalizer(obj, finalizer)
@@ -72,9 +73,8 @@ func EnsureFinalizer(ctx context.Context, cl client.Client, finalizer string, ob
 // the object's current server state, not whatever the caller happened to be holding.
 //
 // A no-op guard avoids any API call when the current state already matches the desired state.
-// A NotFound from the initial Get, and a NotFound or Conflict from the patch, are treated as
-// nothing left to do rather than errors, since another actor already removed or changed the
-// object.
+// A NotFound from the initial Get or patch is treated as nothing left to do. A Conflict is
+// returned so controller-runtime retries from the latest finalizer set.
 func EnsureInUseFinalizer(ctx context.Context, c client.Client, finalizer string, obj client.Object, isReferenced bool) error {
 	logger := log.FromContext(ctx)
 
@@ -98,8 +98,8 @@ func EnsureInUseFinalizer(ctx context.Context, c client.Client, finalizer string
 	}
 
 	if err := patchFinalizer(ctx, c, current, finalizer, isReferenced); err != nil {
-		if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
-			logger.V(3).Info("Object gone or changed before finalizer update landed, skipping", "err", err)
+		if k8serrors.IsNotFound(err) {
+			logger.V(3).Info("Object gone before finalizer update landed, skipping", "err", err)
 			return nil
 		}
 		return fmt.Errorf("updating finalizer on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
@@ -137,8 +137,8 @@ var legacyParentFinalizerPrefixes = []string{
 // EnsureInUseFinalizer instead, which only touches its own finalizer.
 //
 // A no-op guard avoids any API call when the current state already matches the desired
-// state. A NotFound from the initial Get, and a NotFound or Conflict from the patch, are
-// treated as nothing left to do rather than errors, mirroring EnsureInUseFinalizer.
+// state. A NotFound from the initial Get or patch is treated as nothing left to do. A
+// Conflict is returned so controller-runtime retries without losing a concurrent finalizer.
 func ReconcileInUseFinalizer(ctx context.Context, c client.Client,
 	obj client.Object, finalizer string, isReferenced bool,
 ) error {
@@ -173,20 +173,15 @@ func ReconcileInUseFinalizer(ctx context.Context, c client.Client,
 
 	base := current.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
 	current.SetFinalizers(desired)
-	if err := c.Patch(ctx, current, client.MergeFrom(base)); err != nil {
-		return swallowGoneOrConflict(ctx, err, obj)
+	patch := client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+	if err := c.Patch(ctx, current, patch); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.V(3).Info("Object gone before finalizer update landed, skipping", "err", err)
+			return nil
+		}
+		return fmt.Errorf("updating finalizers on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 	}
 	return nil
-}
-
-// swallowGoneOrConflict returns nil when err is NotFound or Conflict (the object is gone
-// or changed underneath us; a later reconcile settles it), and a wrapped error otherwise.
-func swallowGoneOrConflict(ctx context.Context, err error, obj client.Object) error {
-	if k8serrors.IsNotFound(err) || k8serrors.IsConflict(err) {
-		log.FromContext(ctx).V(3).Info("Object gone or changed before finalizer update landed, skipping", "err", err)
-		return nil
-	}
-	return fmt.Errorf("updating finalizers on %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 }
 
 // finalizerSetsEqual reports whether a and b contain the same finalizers, ignoring order.

--- a/internal/pkg/controllerhelper/finalizer_test.go
+++ b/internal/pkg/controllerhelper/finalizer_test.go
@@ -122,7 +122,9 @@ func TestEnsureFinalizer(t *testing.T) {
 			}
 			cl := builder.Build()
 
-			added, err := controllerhelper.EnsureFinalizer(context.Background(), cl, testFinalizer, tt.obj)
+			live := &corev1.ConfigMap{}
+			require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(tt.obj), live))
+			added, err := controllerhelper.EnsureFinalizer(context.Background(), cl, testFinalizer, live)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -262,13 +264,14 @@ func TestEnsureInUseFinalizer_GetOtherError(t *testing.T) {
 	assert.Contains(t, err.Error(), "api server unavailable")
 }
 
-func TestEnsureInUseFinalizer_PatchNotFoundOrConflictSwallowed(t *testing.T) {
+func TestEnsureInUseFinalizer_PatchErrors(t *testing.T) {
 	for _, mkErr := range []struct {
-		name string
-		err  error
+		name    string
+		err     error
+		wantErr bool
 	}{
-		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm")},
-		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict"))},
+		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm"), false},
+		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict")), true},
 	} {
 		t.Run(mkErr.name, func(t *testing.T) {
 			s := newFinalizerScheme(t)
@@ -284,7 +287,56 @@ func TestEnsureInUseFinalizer_PatchNotFoundOrConflictSwallowed(t *testing.T) {
 				Build()
 
 			err := controllerhelper.EnsureInUseFinalizer(context.Background(), cl, testFinalizer, cm, true)
-			require.NoError(t, err, "%s on Patch must be swallowed, not propagated", mkErr.name)
+			if mkErr.wantErr {
+				require.Error(t, err)
+				assert.True(t, k8serrors.IsConflict(err), "Conflict must be returned so the reconcile is retried")
+				return
+			}
+			require.NoError(t, err, "NotFound on Patch is benign because the object is already gone")
+		})
+	}
+}
+
+func TestInUseFinalizerPatchesUseOptimisticLock(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(client.Client, *corev1.ConfigMap) error
+	}{
+		{
+			name: "EnsureInUseFinalizer",
+			run: func(cl client.Client, cm *corev1.ConfigMap) error {
+				return controllerhelper.EnsureInUseFinalizer(context.Background(), cl, testFinalizer, cm, true)
+			},
+		},
+		{
+			name: "ReconcileInUseFinalizer",
+			run: func(cl client.Client, cm *corev1.ConfigMap) error {
+				return controllerhelper.ReconcileInUseFinalizer(context.Background(), cl, cm, testFinalizer, true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newFinalizerScheme(t)
+			cm := newFinalizerCM()
+			sawResourceVersion := false
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(cm).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						data, err := patch.Data(obj)
+						require.NoError(t, err)
+						sawResourceVersion = assert.Contains(t, string(data), `"resourceVersion":`,
+							"optimistic-lock patch must carry the version read before changing finalizers")
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			require.NoError(t, tt.run(cl, cm))
+			assert.True(t, sawResourceVersion)
 		})
 	}
 }
@@ -297,9 +349,9 @@ const (
 )
 
 func TestReconcileInUseFinalizer(t *testing.T) {
-	// NOTE: the SSA path (pure additions) and the no-op guard are also verified against a
-	// real API server in finalizer_envtest_test.go, since the fake client does not fully
-	// implement SSA ownership semantics for metadata.finalizers.
+	// NOTE: finalizer removal and the no-op guard are also verified against a real API
+	// server in finalizer_envtest_test.go, since fake-client patch behavior is not a
+	// complete substitute for apiserver semantics.
 	tests := []struct {
 		name           string
 		initialCM      *corev1.ConfigMap
@@ -392,7 +444,7 @@ func TestReconcileInUseFinalizer(t *testing.T) {
 	}
 }
 
-func TestReconcileInUseFinalizer_NoOpGuardSkipsApply(t *testing.T) {
+func TestReconcileInUseFinalizer_NoOpGuardSkipsPatch(t *testing.T) {
 	s := newFinalizerScheme(t)
 	cm := newFinalizerCM(testFinalizer, testForeignFinalizer)
 	patchCalls := 0
@@ -441,13 +493,14 @@ func TestReconcileInUseFinalizer_GetOtherError(t *testing.T) {
 	assert.Contains(t, err.Error(), "api server unavailable")
 }
 
-func TestReconcileInUseFinalizer_ApplyNotFoundOrConflictSwallowed(t *testing.T) {
+func TestReconcileInUseFinalizer_PatchErrors(t *testing.T) {
 	for _, mkErr := range []struct {
-		name string
-		err  error
+		name    string
+		err     error
+		wantErr bool
 	}{
-		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm")},
-		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict"))},
+		{"NotFound", k8serrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "my-cm"), false},
+		{"Conflict", k8serrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "my-cm", fmt.Errorf("conflict")), true},
 	} {
 		t.Run(mkErr.name, func(t *testing.T) {
 			s := newFinalizerScheme(t)
@@ -464,7 +517,12 @@ func TestReconcileInUseFinalizer_ApplyNotFoundOrConflictSwallowed(t *testing.T) 
 
 			err := controllerhelper.ReconcileInUseFinalizer(
 				context.Background(), cl, cm, testFinalizer, true)
-			require.NoError(t, err, "%s on patch must be swallowed, not propagated", mkErr.name)
+			if mkErr.wantErr {
+				require.Error(t, err)
+				assert.True(t, k8serrors.IsConflict(err), "Conflict must be returned so the reconcile is retried")
+				return
+			}
+			require.NoError(t, err, "NotFound on Patch is benign because the object is already gone")
 		})
 	}
 }

--- a/internal/pkg/index/index.go
+++ b/internal/pkg/index/index.go
@@ -36,7 +36,7 @@ type Entry struct {
 }
 
 // All aggregates all field indexes defined in this package.
-var All []Entry = append(append(ConfigIndexes, RulesfileIndexes...), PluginIndexes...)
+var All []Entry = append(append(append(ConfigIndexes, RulesfileIndexes...), PluginIndexes...), ArtifactNodeIndexes...)
 
 // IndexByConfigMapRef returns a client.IndexerFunc that indexes objects by their ConfigMapRef name.
 // The getRef function extracts the ConfigMapRef from the typed object; return nil when not set.

--- a/internal/pkg/index/index_test.go
+++ b/internal/pkg/index/index_test.go
@@ -67,10 +67,11 @@ func TestIndexByConfigMapRef(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	expected := make([]index.Entry, 0, len(index.ConfigIndexes)+len(index.RulesfileIndexes)+len(index.PluginIndexes))
+	expected := make([]index.Entry, 0, len(index.ConfigIndexes)+len(index.RulesfileIndexes)+len(index.PluginIndexes)+len(index.ArtifactNodeIndexes))
 	expected = append(expected, index.ConfigIndexes...)
 	expected = append(expected, index.RulesfileIndexes...)
 	expected = append(expected, index.PluginIndexes...)
+	expected = append(expected, index.ArtifactNodeIndexes...)
 	require.Len(t, index.All, len(expected), "All must contain exactly one entry per resource index")
 
 	for i, entry := range index.All {

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -158,6 +158,11 @@ var FalcoDefaults = &InstanceDefaults{
 			Resources: []string{"configs/status", "rulesfiles/status", "plugins/status"},
 			Verbs:     []string{"get", "update", "patch"},
 		},
+		{
+			APIGroups: []string{artifactv1alpha1.GroupVersion.Group},
+			Resources: []string{"artifactnodes"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	},
 	VolumeMounts: []corev1.VolumeMount{
 		{Name: "root-falco-fs", MountPath: "/root/.falco"},

--- a/internal/pkg/resources/generator_test.go
+++ b/internal/pkg/resources/generator_test.go
@@ -17,6 +17,7 @@
 package resources
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,9 +180,9 @@ func TestGenerateRole(t *testing.T) {
 		wantRuleCount int
 	}{
 		{
-			name:          "falco role has 5 rules",
+			name:          "falco role has 6 rules",
 			defs:          FalcoDefaults,
-			wantRuleCount: 5,
+			wantRuleCount: 6,
 		},
 		{
 			name:          "metacollector role has no rules",
@@ -217,6 +218,21 @@ func TestGenerateRole(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFalcoRoleAllowsArtifactNodeCache(t *testing.T) {
+	role := GenerateRole(testObject(), FalcoDefaults).(*rbacv1.Role) //nolint:forcetypeassert // generator contract
+
+	var resourceRule *rbacv1.PolicyRule
+	for i := range role.Rules {
+		rule := &role.Rules[i]
+		if slices.Contains(rule.Resources, "artifactnodes") {
+			resourceRule = rule
+		}
+	}
+
+	require.NotNil(t, resourceRule, "the artifact-operator cache needs list/watch access to ArtifactNodes")
+	assert.ElementsMatch(t, []string{"get", "list", "watch"}, resourceRule.Verbs)
 }
 
 func TestGenerateRoleBinding(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:
Introduces the first of the per-artifact-type instance-operator
aggregator controllers described in the per-node sub-CRD design:
ConfigAggregatorReconciler (controllers/instance/artifact/config)
creates one ArtifactNode per cluster node running Falco that matches
a Config's selector, deletes stale ones, and aggregates their
conditions into the parent Config's status. It never writes to a
node's own ArtifactNode status; that is the per-node artifact
operator's job in a later PR.

Also:
- Registers ArtifactNodeIndexes in index.All so ListOwnedNodes'
  field-selector-based List actually works once the manager starts.
- Adds ConfigStatus.ObservedGeneration, needed by the aggregator to
  record which generation it has fully synced.
- Wires the controller into cmd/instance/main.go.

Plugin and Rulesfile follow the same pattern in later PRs; they also
need artifact-fetching machinery this one doesn't.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
Depends on: #382 382