### PR TITLE
feat(artifact): add centralized blob cache and EnsureBlob

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/falcosecurity/falco-operator
 go 1.26.0
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
@@ -56,7 +57,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect

--- a/internal/pkg/artifact/compat.go
+++ b/internal/pkg/artifact/compat.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"slices"
 	"sort"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
@@ -38,9 +39,11 @@ func ComputeOCIArtifactSpecHash(ociArtifact *commonv1alpha1.OCIArtifact) (string
 	return hex.EncodeToString(h[:]), nil
 }
 
-// DeduplicateArtifactMeta removes duplicate requirements and dependencies by name,
-// keeping the most restrictive (highest) version when the same name appears more than once.
-// Results are sorted by name.
+// DeduplicateArtifactMeta removes semantically redundant requirements and dependency groups.
+// Monotonic requirements with the same name are collapsed to the strictest version, while
+// incompatible plugin API majors and unparsable versions are preserved for the compatibility
+// checker to reject. Dependency alternatives are OR-ed within a group, while distinct groups
+// are AND-ed by Falco, so only identical dependency groups can be safely removed.
 func DeduplicateArtifactMeta(meta *commonv1alpha1.ArtifactMeta) {
 	meta.Requirements = deduplicateRequirements(meta.Requirements)
 	meta.Dependencies = deduplicateDependencies(meta.Dependencies)
@@ -50,23 +53,59 @@ func deduplicateRequirements(reqs []commonv1alpha1.ArtifactMetaRequirement) []co
 	if len(reqs) <= 1 {
 		return reqs
 	}
-	byName := make(map[string]string, len(reqs)) // name -> strictest version seen
+	result := make([]commonv1alpha1.ArtifactMetaRequirement, 0, len(reqs))
 	for _, req := range reqs {
-		current, exists := byName[req.Name]
-		if !exists {
-			byName[req.Name] = req.Version
-			continue
+		merged := false
+		for i := range result {
+			current := result[i]
+			if current.Name != req.Name {
+				continue
+			}
+			if current.Version == req.Version {
+				merged = true
+				break
+			}
+
+			if req.Name == compat.CapabilityPluginAPIVersion {
+				newAtLeast, newErr := compat.SemverMajorCompatible(req.Version, current.Version)
+				currentAtLeast, currentErr := compat.SemverMajorCompatible(current.Version, req.Version)
+				switch {
+				case newErr != nil || currentErr != nil:
+					// Preserve invalid versions so the compatibility checker can report them.
+					continue
+				case newAtLeast:
+					result[i] = req
+					merged = true
+				case currentAtLeast:
+					merged = true
+				default:
+					// Different plugin API majors are incompatible, not ordered.
+					continue
+				}
+				if merged {
+					break
+				}
+				continue
+			}
+
+			if atLeast, err := compat.SemverAtLeast(req.Version, current.Version); err == nil {
+				if atLeast {
+					result[i] = req
+				}
+				merged = true
+				break
+			}
 		}
-		// Replace if the new version is strictly higher; on parse error keep existing.
-		if atLeast, err := compat.SemverAtLeast(req.Version, current); err == nil && atLeast {
-			byName[req.Name] = req.Version
+		if !merged {
+			result = append(result, req)
 		}
 	}
-	result := make([]commonv1alpha1.ArtifactMetaRequirement, 0, len(byName))
-	for name, version := range byName {
-		result = append(result, commonv1alpha1.ArtifactMetaRequirement{Name: name, Version: version})
-	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Version < result[j].Version
+	})
 	return result
 }
 
@@ -103,25 +142,64 @@ func AppendConfigLayerRequirements(meta *commonv1alpha1.ArtifactMeta, fetched *p
 }
 
 func deduplicateDependencies(deps []commonv1alpha1.ArtifactMetaDependency) []commonv1alpha1.ArtifactMetaDependency {
-	if len(deps) <= 1 {
+	if len(deps) == 0 {
 		return deps
 	}
-	byName := make(map[string]commonv1alpha1.ArtifactMetaDependency, len(deps))
+	result := make([]commonv1alpha1.ArtifactMetaDependency, 0, len(deps))
 	for _, dep := range deps {
-		current, exists := byName[dep.Name]
-		if !exists {
-			byName[dep.Name] = dep
-			continue
+		dep = canonicalizeDependency(dep)
+		duplicate := false
+		for _, current := range result {
+			if dep.Name == current.Name && dep.Version == current.Version &&
+				slices.Equal(dep.Alternatives, current.Alternatives) {
+				duplicate = true
+				break
+			}
 		}
-		// Replace if the new primary version is strictly higher; alternatives travel with it.
-		if atLeast, err := compat.SemverAtLeast(dep.Version, current.Version); err == nil && atLeast {
-			byName[dep.Name] = dep
+		if !duplicate {
+			result = append(result, dep)
 		}
 	}
-	result := make([]commonv1alpha1.ArtifactMetaDependency, 0, len(byName))
-	for _, dep := range byName {
-		result = append(result, dep)
-	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	sort.Slice(result, func(i, j int) bool { return dependencyLess(result[i], result[j]) })
 	return result
+}
+
+func canonicalizeDependency(dep commonv1alpha1.ArtifactMetaDependency) commonv1alpha1.ArtifactMetaDependency {
+	if len(dep.Alternatives) == 0 {
+		dep.Alternatives = nil
+		return dep
+	}
+
+	alternatives := append([]commonv1alpha1.ArtifactMetaDependencyVariant(nil), dep.Alternatives...)
+	sort.Slice(alternatives, func(i, j int) bool {
+		if alternatives[i].Name != alternatives[j].Name {
+			return alternatives[i].Name < alternatives[j].Name
+		}
+		return alternatives[i].Version < alternatives[j].Version
+	})
+	dep.Alternatives = alternatives[:0]
+	for _, alternative := range alternatives {
+		if len(dep.Alternatives) == 0 || dep.Alternatives[len(dep.Alternatives)-1] != alternative {
+			dep.Alternatives = append(dep.Alternatives, alternative)
+		}
+	}
+	return dep
+}
+
+func dependencyLess(a, b commonv1alpha1.ArtifactMetaDependency) bool {
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	if a.Version != b.Version {
+		return a.Version < b.Version
+	}
+	for i := range min(len(a.Alternatives), len(b.Alternatives)) {
+		if a.Alternatives[i].Name != b.Alternatives[i].Name {
+			return a.Alternatives[i].Name < b.Alternatives[i].Name
+		}
+		if a.Alternatives[i].Version != b.Alternatives[i].Version {
+			return a.Alternatives[i].Version < b.Alternatives[i].Version
+		}
+	}
+	return len(a.Alternatives) < len(b.Alternatives)
 }

--- a/internal/pkg/artifact/compat_test.go
+++ b/internal/pkg/artifact/compat_test.go
@@ -80,13 +80,43 @@ func TestDeduplicateArtifactMeta(t *testing.T) {
 			wantDeps: nil,
 		},
 		{
+			name: "incompatible plugin API majors are preserved",
+			input: commonv1alpha1.ArtifactMeta{
+				Requirements: []commonv1alpha1.ArtifactMetaRequirement{
+					req("plugin_api_version", "3.0.0"),
+					req("plugin_api_version", "2.0.0"),
+					req("plugin_api_version", "2.1.0"),
+				},
+			},
+			wantReqs: []commonv1alpha1.ArtifactMetaRequirement{
+				req("plugin_api_version", "2.1.0"),
+				req("plugin_api_version", "3.0.0"),
+			},
+			wantDeps: nil,
+		},
+		{
+			name: "invalid requirement is preserved while valid versions are collapsed",
+			input: commonv1alpha1.ArtifactMeta{
+				Requirements: []commonv1alpha1.ArtifactMetaRequirement{
+					req("engine_version_semver", "invalid"),
+					req("engine_version_semver", "0.62.0"),
+					req("engine_version_semver", "0.57.0"),
+				},
+			},
+			wantReqs: []commonv1alpha1.ArtifactMetaRequirement{
+				req("engine_version_semver", "0.62.0"),
+				req("engine_version_semver", "invalid"),
+			},
+			wantDeps: nil,
+		},
+		{
 			name:     "single dependency unchanged",
 			input:    commonv1alpha1.ArtifactMeta{Dependencies: []commonv1alpha1.ArtifactMetaDependency{dep("json", "0.7.0")}},
 			wantReqs: nil,
 			wantDeps: []commonv1alpha1.ArtifactMetaDependency{dep("json", "0.7.0")},
 		},
 		{
-			name: "duplicate dependency keeps strictest (higher) version with its alternatives",
+			name: "same primary dependency in distinct groups is preserved",
 			input: commonv1alpha1.ArtifactMeta{
 				Dependencies: []commonv1alpha1.ArtifactMetaDependency{
 					dep("json", "0.7.0"),
@@ -95,7 +125,44 @@ func TestDeduplicateArtifactMeta(t *testing.T) {
 				},
 			},
 			wantDeps: []commonv1alpha1.ArtifactMetaDependency{
+				dep("json", "0.7.0"),
+				dep("json", "0.8.0"),
 				dep("json", "0.9.0", commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alt", Version: "1.0.0"}),
+			},
+		},
+		{
+			name: "identical dependency groups and alternatives are deduplicated",
+			input: commonv1alpha1.ArtifactMeta{
+				Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+					dep("json", "0.7.0",
+						commonv1alpha1.ArtifactMetaDependencyVariant{Name: "zeta", Version: "2.0.0"},
+						commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"},
+						commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"},
+					),
+					dep("json", "0.7.0",
+						commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"},
+						commonv1alpha1.ArtifactMetaDependencyVariant{Name: "zeta", Version: "2.0.0"},
+					),
+				},
+			},
+			wantDeps: []commonv1alpha1.ArtifactMetaDependency{
+				dep("json", "0.7.0",
+					commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"},
+					commonv1alpha1.ArtifactMetaDependencyVariant{Name: "zeta", Version: "2.0.0"},
+				),
+			},
+		},
+		{
+			name: "same primary and version with different alternatives is preserved",
+			input: commonv1alpha1.ArtifactMeta{
+				Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+					dep("json", "0.7.0", commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"}),
+					dep("json", "0.7.0", commonv1alpha1.ArtifactMetaDependencyVariant{Name: "zeta", Version: "2.0.0"}),
+				},
+			},
+			wantDeps: []commonv1alpha1.ArtifactMetaDependency{
+				dep("json", "0.7.0", commonv1alpha1.ArtifactMetaDependencyVariant{Name: "alpha", Version: "1.0.0"}),
+				dep("json", "0.7.0", commonv1alpha1.ArtifactMetaDependencyVariant{Name: "zeta", Version: "2.0.0"}),
 			},
 		},
 		{
@@ -124,7 +191,10 @@ func TestDeduplicateArtifactMeta(t *testing.T) {
 				},
 			},
 			wantReqs: []commonv1alpha1.ArtifactMetaRequirement{req("engine_version_semver", "0.62.0")},
-			wantDeps: []commonv1alpha1.ArtifactMetaDependency{dep("json", "0.9.0")},
+			wantDeps: []commonv1alpha1.ArtifactMetaDependency{
+				dep("json", "0.7.0"),
+				dep("json", "0.9.0"),
+			},
 		},
 	}
 

--- a/internal/pkg/artifact/manager_ensure_blob.go
+++ b/internal/pkg/artifact/manager_ensure_blob.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/common"
+	"github.com/falcosecurity/falco-operator/internal/pkg/credentials"
+)
+
+// EnsureBlob ensures the OCI binary for ociArt/platform is present in the blob cache.
+// If the blob already exists (digest + platform match), the path is returned immediately.
+// Otherwise the binary is pulled from the registry, extracted, and written atomically.
+//
+// Pass knownDigest when the caller already resolved the digest (e.g. from
+// Status.ArtifactMeta.Digest set by fetchAndCacheArtifactMeta) to skip the
+// redundant ResolveDigest registry call. Pass an empty string to resolve it here.
+//
+// For platform-specific artifacts (plugins) supply goos and goarch; for platform-agnostic
+// artifacts (rulesfiles) pass empty strings. The pull still uses the server's own platform
+// to satisfy the puller API, but the cached blob has no platform suffix.
+func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArtifact, artifactType Type,
+	goos, goarch string, cache *artifactcache.Cache, knownDigest string,
+) (string, error) {
+	logger := log.FromContext(ctx)
+
+	secretRef := authSecretRef(ociArt)
+	authSecret, err := am.fetchOCIAuthSecret(ctx, secretRef)
+	if err != nil {
+		return "", fmt.Errorf("fetch auth secret: %w", err)
+	}
+	creds, err := credentials.FromSecret(ResolveRegistryHost(ociArt), authSecret)
+	if err != nil {
+		return "", fmt.Errorf("derive credentials: %w", err)
+	}
+
+	ref := ResolveReference(ociArt)
+	opts := ResolveRegistryOptions(ociArt)
+
+	digest := knownDigest
+	if digest == "" {
+		digest, err = am.ociPuller.ResolveDigest(ctx, ref, creds, opts)
+		if err != nil {
+			return "", fmt.Errorf("resolve digest for %q: %w", ref, err)
+		}
+	}
+
+	blobPath := artifactcache.BlobPath(cache.Dir(), string(artifactType), ref, digest, goos, goarch)
+
+	if cache.BlobExists(blobPath) {
+		logger.V(2).Info("Blob already cached", "ref", ref, "digest", digest, "blob", blobPath)
+		return blobPath, nil
+	}
+
+	pullGOOS, pullGOARCH := goos, goarch
+	if pullGOOS == "" || pullGOARCH == "" {
+		pullGOOS, pullGOARCH = runtime.GOOS, runtime.GOARCH
+	}
+
+	logger.Info("Pulling OCI blob", "ref", ref, "os", pullGOOS, "arch", pullGOARCH)
+
+	var buf bytes.Buffer
+	res, err := am.ociPuller.Pull(ctx, ref, pullGOOS, pullGOARCH, creds, opts, &buf)
+	if err != nil {
+		return "", fmt.Errorf("pull %q (%s/%s): %w", ref, pullGOOS, pullGOARCH, err)
+	}
+	if res == nil {
+		return "", fmt.Errorf("puller returned nil result for %q", ref)
+	}
+	if !isExpectedOCIArtifactType(artifactType, res.Type) {
+		return "", fmt.Errorf("pulled OCI artifact type %q does not match expected %q", res.Type, artifactType)
+	}
+
+	file, err := common.ExtractSingleFileFromTarGz(ctx, &buf, 0)
+	if err != nil {
+		return "", fmt.Errorf("extract from OCI layer %q: %w", ref, err)
+	}
+
+	if err := artifactcache.Store(blobPath, file.Content, file.Perm); err != nil {
+		return "", err
+	}
+
+	logger.Info("OCI blob cached", "ref", ref, "digest", digest, "blob", blobPath)
+	return blobPath, nil
+}

--- a/internal/pkg/artifact/manager_ensure_blob.go
+++ b/internal/pkg/artifact/manager_ensure_blob.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"oras.land/oras-go/v2/registry"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
@@ -37,6 +38,8 @@ import (
 // Pass knownDigest when the caller already resolved the digest (e.g. from
 // Status.ArtifactMeta.Digest set by fetchAndCacheArtifactMeta) to skip the
 // redundant ResolveDigest registry call. Pass an empty string to resolve it here.
+// The actual pull is always pinned to that digest so a mutable tag cannot change
+// between resolution and download.
 //
 // For platform-specific artifacts (plugins) supply goos and goarch; for platform-agnostic
 // artifacts (rulesfiles) pass empty strings. The pull still uses the server's own platform
@@ -44,6 +47,10 @@ import (
 func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArtifact, artifactType Type,
 	goos, goarch string, cache *artifactcache.Cache, knownDigest string,
 ) (string, error) {
+	if artifactType == TypePlugin && (goos == "" || goarch == "") {
+		return "", fmt.Errorf("plugin artifact requires both OS and architecture")
+	}
+
 	logger := log.FromContext(ctx)
 
 	secretRef := authSecretRef(ociArt)
@@ -66,6 +73,10 @@ func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArt
 			return "", fmt.Errorf("resolve digest for %q: %w", ref, err)
 		}
 	}
+	pullRef, err := pinReferenceToDigest(ref, digest)
+	if err != nil {
+		return "", fmt.Errorf("pin reference %q to digest %q: %w", ref, digest, err)
+	}
 
 	blobPath := artifactcache.BlobPath(cache.Dir(), string(artifactType), ref, digest, goos, goarch)
 
@@ -82,12 +93,15 @@ func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArt
 	logger.Info("Pulling OCI blob", "ref", ref, "os", pullGOOS, "arch", pullGOARCH)
 
 	var buf bytes.Buffer
-	res, err := am.ociPuller.Pull(ctx, ref, pullGOOS, pullGOARCH, creds, opts, &buf)
+	res, err := am.ociPuller.Pull(ctx, pullRef, pullGOOS, pullGOARCH, creds, opts, &buf)
 	if err != nil {
 		return "", fmt.Errorf("pull %q (%s/%s): %w", ref, pullGOOS, pullGOARCH, err)
 	}
 	if res == nil {
 		return "", fmt.Errorf("puller returned nil result for %q", ref)
+	}
+	if res.RootDigest != digest {
+		return "", fmt.Errorf("pulled OCI artifact digest %q does not match expected digest %q for %q", res.RootDigest, digest, ref)
 	}
 	if !isExpectedOCIArtifactType(artifactType, res.Type) {
 		return "", fmt.Errorf("pulled OCI artifact type %q does not match expected %q", res.Type, artifactType)
@@ -98,10 +112,22 @@ func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArt
 		return "", fmt.Errorf("extract from OCI layer %q: %w", ref, err)
 	}
 
-	if err := artifactcache.Store(blobPath, file.Content, file.Perm); err != nil {
+	if err := cache.Store(blobPath, file.Content, file.Perm); err != nil {
 		return "", err
 	}
 
 	logger.Info("OCI blob cached", "ref", ref, "digest", digest, "blob", blobPath)
 	return blobPath, nil
+}
+
+func pinReferenceToDigest(ref, digest string) (string, error) {
+	pinned, err := registry.ParseReference(ref)
+	if err != nil {
+		return "", err
+	}
+	pinned.Reference = digest
+	if err := pinned.ValidateReferenceAsDigest(); err != nil {
+		return "", err
+	}
+	return pinned.String(), nil
 }

--- a/internal/pkg/artifact/manager_ensure_blob_test.go
+++ b/internal/pkg/artifact/manager_ensure_blob_test.go
@@ -30,6 +30,12 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 )
 
+const (
+	testDigest         = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testResolvedDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testOtherDigest    = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
 func newTestCache(t *testing.T) *artifactcache.Cache {
 	t.Helper()
 	c := artifactcache.NewCache(t.TempDir())
@@ -55,9 +61,15 @@ func TestManager_EnsureBlob(t *testing.T) {
 	}{
 		{
 			name:         "cache miss pulls and stores the blob",
-			pullResult:   &puller.RegistryResult{Type: puller.Plugin},
+			pullResult:   &puller.RegistryResult{RootDigest: testDigest, Type: puller.Plugin},
 			layerContent: layer,
-			knownDigest:  "sha256:abc",
+			knownDigest:  testDigest,
+			wantPullCall: true,
+		},
+		{
+			name:         "cache miss resolves and pins the digest before pulling",
+			pullResult:   &puller.RegistryResult{RootDigest: testResolvedDigest, Type: puller.Plugin},
+			layerContent: layer,
 			wantPullCall: true,
 		},
 		{
@@ -67,18 +79,31 @@ func TestManager_EnsureBlob(t *testing.T) {
 		},
 		{
 			name:         "pull error propagates",
-			knownDigest:  "sha256:abc",
+			knownDigest:  testDigest,
 			pullErr:      fmt.Errorf("pull failed"),
 			wantErr:      true,
 			wantPullCall: true,
 		},
 		{
 			name:         "unexpected artifact type is rejected",
-			knownDigest:  "sha256:abc",
-			pullResult:   &puller.RegistryResult{Type: puller.Rulesfile},
+			knownDigest:  testDigest,
+			pullResult:   &puller.RegistryResult{RootDigest: testDigest, Type: puller.Rulesfile},
 			layerContent: layer,
 			wantErr:      true,
 			wantPullCall: true,
+		},
+		{
+			name:         "digest returned by pull must match the cache digest",
+			knownDigest:  testDigest,
+			pullResult:   &puller.RegistryResult{RootDigest: testOtherDigest, Type: puller.Plugin},
+			layerContent: layer,
+			wantErr:      true,
+			wantPullCall: true,
+		},
+		{
+			name:        "invalid known digest is rejected before pulling",
+			knownDigest: "not-a-digest",
+			wantErr:     true,
 		},
 	}
 
@@ -89,7 +114,7 @@ func TestManager_EnsureBlob(t *testing.T) {
 			cache := newTestCache(t)
 
 			mockPuller := &puller.MockOCIPuller{
-				ResolveDigestResult: "sha256:resolved",
+				ResolveDigestResult: testResolvedDigest,
 				ResolveDigestErr:    tt.resolveErr,
 				Result:              tt.pullResult,
 				PullErr:             tt.pullErr,
@@ -109,8 +134,93 @@ func TestManager_EnsureBlob(t *testing.T) {
 				assert.FileExists(t, blobPath, "EnsureBlob must write the blob to disk")
 			}
 			assert.Equal(t, tt.wantPullCall, len(mockPuller.PullCalls) == 1)
+			if tt.wantPullCall {
+				require.Len(t, mockPuller.PullCalls, 1)
+				expectedDigest := tt.knownDigest
+				if expectedDigest == "" {
+					expectedDigest = testResolvedDigest
+				}
+				assert.Equal(t, "ghcr.io/example.com/myplugin@"+expectedDigest, mockPuller.PullCalls[0].Ref)
+			}
 		})
 	}
+}
+
+func TestManager_EnsureBlob_PluginRequiresCompletePlatform(t *testing.T) {
+	const testNamespace = "test-namespace"
+
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+	}{
+		{name: "missing OS", goarch: "amd64"},
+		{name: "missing architecture", goos: "linux"},
+		{name: "missing OS and architecture"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPuller := &puller.MockOCIPuller{}
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				testNamespace,
+				WithOCIPuller(mockPuller),
+			)
+
+			_, err := manager.EnsureBlob(
+				context.Background(),
+				&commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"}},
+				TypePlugin,
+				tt.goos,
+				tt.goarch,
+				newTestCache(t),
+				testDigest,
+			)
+
+			require.EqualError(t, err, "plugin artifact requires both OS and architecture")
+			assert.Empty(t, mockPuller.ResolveDigestCalls)
+			assert.Empty(t, mockPuller.PullCalls)
+		})
+	}
+}
+
+func TestManager_EnsureBlob_CachesPluginPlatformsSeparately(t *testing.T) {
+	const testNamespace = "test-namespace"
+
+	layer, err := puller.MakeTarGz("plugin.so", []byte("binary content"))
+	require.NoError(t, err)
+	cache := newTestCache(t)
+	mockPuller := &puller.MockOCIPuller{
+		Result:       &puller.RegistryResult{RootDigest: testDigest, Type: puller.Plugin},
+		LayerContent: layer,
+	}
+	manager := NewManagerWithOptions(
+		fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+		testNamespace,
+		WithOCIPuller(mockPuller),
+	)
+	ociArt := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"},
+	}
+
+	amd64Path, err := manager.EnsureBlob(
+		context.Background(), ociArt, TypePlugin, "linux", "amd64", cache, testDigest)
+	require.NoError(t, err)
+	arm64Path, err := manager.EnsureBlob(
+		context.Background(), ociArt, TypePlugin, "linux", "arm64", cache, testDigest)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, amd64Path, arm64Path)
+	assert.Contains(t, amd64Path, "-linux-amd64")
+	assert.Contains(t, arm64Path, "-linux-arm64")
+	assert.FileExists(t, amd64Path)
+	assert.FileExists(t, arm64Path)
+	require.Len(t, mockPuller.PullCalls, 2)
+	assert.Equal(t, "linux", mockPuller.PullCalls[0].OS)
+	assert.Equal(t, "amd64", mockPuller.PullCalls[0].Arch)
+	assert.Equal(t, "linux", mockPuller.PullCalls[1].OS)
+	assert.Equal(t, "arm64", mockPuller.PullCalls[1].Arch)
 }
 
 func TestManager_EnsureBlob_CacheHitSkipsPull(t *testing.T) {
@@ -121,14 +231,14 @@ func TestManager_EnsureBlob_CacheHitSkipsPull(t *testing.T) {
 	cache := newTestCache(t)
 
 	ociArt := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"}}
-	blobPath := artifactcache.BlobPath(cache.Dir(), string(TypePlugin), ResolveReference(ociArt), "sha256:abc", "linux", "amd64")
+	blobPath := artifactcache.BlobPath(cache.Dir(), string(TypePlugin), ResolveReference(ociArt), testDigest, "linux", "amd64")
 	require.NoError(t, artifactcache.Store(blobPath, []byte("cached content"), 0o755))
 	require.NoError(t, cache.Set(string(TypePlugin), testNamespace, "myplugin", "linux-amd64", blobPath))
 
 	mockPuller := &puller.MockOCIPuller{}
 	manager := NewManagerWithOptions(fakeClient, testNamespace, WithOCIPuller(mockPuller))
 
-	got, err := manager.EnsureBlob(context.Background(), ociArt, TypePlugin, "linux", "amd64", cache, "sha256:abc")
+	got, err := manager.EnsureBlob(context.Background(), ociArt, TypePlugin, "linux", "amd64", cache, testDigest)
 	require.NoError(t, err)
 	assert.Equal(t, blobPath, got)
 	assert.Empty(t, mockPuller.PullCalls, "cache hit must not trigger a pull")

--- a/internal/pkg/artifact/manager_ensure_blob_test.go
+++ b/internal/pkg/artifact/manager_ensure_blob_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+func newTestCache(t *testing.T) *artifactcache.Cache {
+	t.Helper()
+	c := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, c.Load())
+	return c
+}
+
+func TestManager_EnsureBlob(t *testing.T) {
+	const testNamespace = "test-namespace"
+
+	layer, err := puller.MakeTarGz("plugin.so", []byte("binary content"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		resolveErr   error
+		pullResult   *puller.RegistryResult
+		pullErr      error
+		layerContent []byte
+		knownDigest  string
+		wantErr      bool
+		wantPullCall bool
+	}{
+		{
+			name:         "cache miss pulls and stores the blob",
+			pullResult:   &puller.RegistryResult{Type: puller.Plugin},
+			layerContent: layer,
+			knownDigest:  "sha256:abc",
+			wantPullCall: true,
+		},
+		{
+			name:       "resolve digest error propagates when knownDigest is empty",
+			resolveErr: fmt.Errorf("registry unreachable"),
+			wantErr:    true,
+		},
+		{
+			name:         "pull error propagates",
+			knownDigest:  "sha256:abc",
+			pullErr:      fmt.Errorf("pull failed"),
+			wantErr:      true,
+			wantPullCall: true,
+		},
+		{
+			name:         "unexpected artifact type is rejected",
+			knownDigest:  "sha256:abc",
+			pullResult:   &puller.RegistryResult{Type: puller.Rulesfile},
+			layerContent: layer,
+			wantErr:      true,
+			wantPullCall: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := createTestScheme(t)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			cache := newTestCache(t)
+
+			mockPuller := &puller.MockOCIPuller{
+				ResolveDigestResult: "sha256:resolved",
+				ResolveDigestErr:    tt.resolveErr,
+				Result:              tt.pullResult,
+				PullErr:             tt.pullErr,
+				LayerContent:        tt.layerContent,
+			}
+			manager := NewManagerWithOptions(fakeClient, testNamespace, WithOCIPuller(mockPuller))
+
+			blobPath, err := manager.EnsureBlob(context.Background(),
+				&commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"}},
+				TypePlugin, "linux", "amd64", cache, tt.knownDigest)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, blobPath)
+				assert.FileExists(t, blobPath, "EnsureBlob must write the blob to disk")
+			}
+			assert.Equal(t, tt.wantPullCall, len(mockPuller.PullCalls) == 1)
+		})
+	}
+}
+
+func TestManager_EnsureBlob_CacheHitSkipsPull(t *testing.T) {
+	const testNamespace = "test-namespace"
+
+	scheme := createTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cache := newTestCache(t)
+
+	ociArt := &commonv1alpha1.OCIArtifact{Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"}}
+	blobPath := artifactcache.BlobPath(cache.Dir(), string(TypePlugin), ResolveReference(ociArt), "sha256:abc", "linux", "amd64")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("cached content"), 0o755))
+	require.NoError(t, cache.Set(string(TypePlugin), testNamespace, "myplugin", "linux-amd64", blobPath))
+
+	mockPuller := &puller.MockOCIPuller{}
+	manager := NewManagerWithOptions(fakeClient, testNamespace, WithOCIPuller(mockPuller))
+
+	got, err := manager.EnsureBlob(context.Background(), ociArt, TypePlugin, "linux", "amd64", cache, "sha256:abc")
+	require.NoError(t, err)
+	assert.Equal(t, blobPath, got)
+	assert.Empty(t, mockPuller.PullCalls, "cache hit must not trigger a pull")
+}

--- a/internal/pkg/artifactcache/cache.go
+++ b/internal/pkg/artifactcache/cache.go
@@ -56,24 +56,44 @@ func BlobPath(cacheDir, artifactType, ref, digest, goos, goarch string) string {
 }
 
 // Store atomically writes content to blobPath and records perm in the companion .perm file.
-// The write is atomic: content goes to a .tmp file first, then renamed into place.
+// Each writer uses a unique temporary file, then renames it into place.
+// Call Cache.Store when the write belongs to a live Cache that may be swept concurrently.
 func Store(blobPath string, content []byte, perm fs.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(blobPath), 0o750); err != nil {
 		return fmt.Errorf("create blob dir: %w", err)
 	}
-	tmp := blobPath + ".tmp"
-	if err := os.WriteFile(tmp, content, 0o600); err != nil {
-		_ = os.Remove(tmp)
+	tmp, err := os.CreateTemp(filepath.Dir(blobPath), "."+filepath.Base(blobPath)+".tmp-*")
+	if err != nil {
 		return fmt.Errorf("write blob: %w", err)
 	}
-	if err := os.Rename(tmp, blobPath); err != nil {
-		_ = os.Remove(tmp)
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmp.Write(content); err != nil {
+		return fmt.Errorf("write blob: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close blob: %w", err)
+	}
+	if err := os.Rename(tmpPath, blobPath); err != nil {
 		return fmt.Errorf("rename blob: %w", err)
 	}
 	// Best-effort: clients fall back to 0o755 if the .perm file is missing.
 	_ = os.WriteFile(blobPath+PermSuffix,
 		[]byte(strconv.FormatUint(uint64(perm), 10)), 0o600)
 	return nil
+}
+
+// Store writes a blob while holding the cache mutex so the sweeper cannot delete the same
+// path between the write and its final freshness check. Index registration remains the caller's
+// responsibility through Set.
+func (c *Cache) Store(blobPath string, content []byte, perm fs.FileMode) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return Store(blobPath, content, perm)
 }
 
 // ReadPerm reads the file mode from the companion .perm file.

--- a/internal/pkg/artifactcache/cache.go
+++ b/internal/pkg/artifactcache/cache.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package artifactcache manages the on-disk layout for the central OCI artifact cache
+// shared between the instance-level aggregator controllers (writers) and the artifact
+// HTTP server (reader). Both run as goroutines in the same process.
+//
+// Blob content is content-addressed on disk:
+//
+//	blobs/{type}/{safe-oci-ref}/{digest}-{os}-{arch}   extracted binary (plugins, platform-specific)
+//	blobs/{type}/{safe-oci-ref}/{digest}               extracted binary (rulesfiles, platform-agnostic)
+//	blobs/.../<blobname>.perm                          decimal fs.FileMode companion file
+//
+// The index mapping (namespace, name, platform) to its current blob path is owned by the
+// Cache type (index.go): an in-memory map backed by a single index.json snapshot file for
+// restart resilience, with reference-counted eviction of superseded/removed blobs and a
+// periodic Sweeper (sweep.go) as a backstop against orphans.
+package artifactcache
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	BlobsDir   = "blobs"
+	PermSuffix = ".perm"
+)
+
+// BlobPath returns the filesystem path for a cached binary blob.
+// For platform-specific artifacts (plugins) pass goos and goarch; for platform-agnostic
+// artifacts (rulesfiles) pass empty strings.
+func BlobPath(cacheDir, artifactType, ref, digest, goos, goarch string) string {
+	name := strings.ReplaceAll(digest, ":", "-")
+	if goos != "" && goarch != "" {
+		name = fmt.Sprintf("%s-%s-%s", name, goos, goarch)
+	}
+	return filepath.Join(cacheDir, BlobsDir, artifactType, RefToPath(ref), name)
+}
+
+// Store atomically writes content to blobPath and records perm in the companion .perm file.
+// The write is atomic: content goes to a .tmp file first, then renamed into place.
+func Store(blobPath string, content []byte, perm fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o750); err != nil {
+		return fmt.Errorf("create blob dir: %w", err)
+	}
+	tmp := blobPath + ".tmp"
+	if err := os.WriteFile(tmp, content, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write blob: %w", err)
+	}
+	if err := os.Rename(tmp, blobPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename blob: %w", err)
+	}
+	// Best-effort: clients fall back to 0o755 if the .perm file is missing.
+	_ = os.WriteFile(blobPath+PermSuffix,
+		[]byte(strconv.FormatUint(uint64(perm), 10)), 0o600)
+	return nil
+}
+
+// ReadPerm reads the file mode from the companion .perm file.
+// Returns 0o755 if the file is absent or cannot be parsed.
+func ReadPerm(blobPath string) fs.FileMode {
+	if data, err := os.ReadFile(blobPath + PermSuffix); err == nil { //nolint:gosec // blobPath is derived from BlobPath(), not raw external input
+		if p, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 32); err == nil {
+			return fs.FileMode(p)
+		}
+	}
+	return 0o755
+}
+
+// RefToPath converts an OCI reference to a safe directory name by replacing characters
+// that are illegal or ambiguous in filesystem paths.
+// Example: "ghcr.io/falcosecurity/plugins/cloudtrail:0.12.0" becomes "ghcr.io-falcosecurity-plugins-cloudtrail-0.12.0".
+func RefToPath(ref string) string {
+	return strings.NewReplacer("/", "-", ":", "-", "@", "-").Replace(ref)
+}

--- a/internal/pkg/artifactcache/cache_test.go
+++ b/internal/pkg/artifactcache/cache_test.go
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+)
+
+func TestBlobPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		cacheDir     string
+		artifactType string
+		ref          string
+		digest       string
+		goos, goarch string
+		want         string
+	}{
+		{
+			name:         "platform-specific artifact includes os/arch suffix",
+			cacheDir:     "cache",
+			artifactType: "plugin",
+			ref:          "ghcr.io/falcosecurity/plugins/json:0.7.0",
+			digest:       "sha256:abcdef",
+			goos:         "linux",
+			goarch:       "amd64",
+			want: filepath.Join("cache", "blobs", "plugin",
+				"ghcr.io-falcosecurity-plugins-json-0.7.0", "sha256-abcdef-linux-amd64"),
+		},
+		{
+			name:         "platform-agnostic artifact has no os/arch suffix",
+			cacheDir:     "cache",
+			artifactType: "rulesfile",
+			ref:          "ghcr.io/falcosecurity/rules/default:1.0.0",
+			digest:       "sha256:123456",
+			want: filepath.Join("cache", "blobs", "rulesfile",
+				"ghcr.io-falcosecurity-rules-default-1.0.0", "sha256-123456"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := artifactcache.BlobPath(tt.cacheDir, tt.artifactType, tt.ref, tt.digest, tt.goos, tt.goarch)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRefToPath(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "slashes and colon",
+			ref:  "ghcr.io/falcosecurity/plugins/cloudtrail:0.12.0",
+			want: "ghcr.io-falcosecurity-plugins-cloudtrail-0.12.0",
+		},
+		{
+			name: "digest reference with at-sign",
+			ref:  "ghcr.io/falcosecurity/plugins/json@sha256:abc123",
+			want: "ghcr.io-falcosecurity-plugins-json-sha256-abc123",
+		},
+		{
+			name: "no special characters is unchanged",
+			ref:  "simplename",
+			want: "simplename",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, artifactcache.RefToPath(tt.ref))
+		})
+	}
+}
+
+func TestStore(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		perm    fs.FileMode
+		// setup prepares dir and returns the blobPath to pass to Store.
+		setup func(t *testing.T, dir string) string
+		// wantErrContains, when set, means Store must fail with an error containing this text;
+		// wantPermDecimal is checked instead when it's empty.
+		wantErrContains string
+		wantPermDecimal string
+	}{
+		{
+			name:    "writes content and a decimal perm companion file",
+			content: []byte("hello world"),
+			perm:    0o750,
+			setup: func(_ *testing.T, dir string) string {
+				return filepath.Join(dir, "nested", "blob")
+			},
+			wantPermDecimal: "488", // 0o750
+		},
+		{
+			name:    "overwrites an existing blob",
+			content: []byte("v2"),
+			perm:    0o600,
+			setup: func(t *testing.T, dir string) string {
+				blobPath := filepath.Join(dir, "blob")
+				require.NoError(t, artifactcache.Store(blobPath, []byte("v1"), 0o644))
+				return blobPath
+			},
+			wantPermDecimal: "384", // 0o600
+		},
+		{
+			name:    "error when the blob directory cannot be created",
+			content: []byte("data"),
+			perm:    0o644,
+			setup: func(t *testing.T, dir string) string {
+				// "blocker" exists as a regular file, so it can't be used as a directory component.
+				blocker := filepath.Join(dir, "blocker")
+				require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+				return filepath.Join(blocker, "blob")
+			},
+			wantErrContains: "create blob dir",
+		},
+		{
+			name:    "error when the temp file cannot be written",
+			content: []byte("data"),
+			perm:    0o644,
+			setup: func(t *testing.T, dir string) string {
+				if os.Geteuid() == 0 {
+					t.Skip("permission checks are bypassed when running as root")
+				}
+				require.NoError(t, os.Chmod(dir, 0o500)) // read+execute only: no new files allowed
+				t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+				return filepath.Join(dir, "blob")
+			},
+			wantErrContains: "write blob",
+		},
+		{
+			name:    "error when the rename target is a non-empty directory",
+			content: []byte("data"),
+			perm:    0o644,
+			setup: func(t *testing.T, dir string) string {
+				blobPath := filepath.Join(dir, "blob")
+				require.NoError(t, os.Mkdir(blobPath, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(blobPath, "occupied"), []byte("x"), 0o600))
+				return blobPath
+			},
+			wantErrContains: "rename blob",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			blobPath := tt.setup(t, dir)
+
+			err := artifactcache.Store(blobPath, tt.content, tt.perm)
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				// No case leaves a usable temp file behind: either it was never created (the
+				// blob dir itself couldn't be made, so stat fails with "not a directory"), or it
+				// was created and then removed on failure (stat fails with "not exist").
+				_, statErr := os.Stat(blobPath + ".tmp")
+				assert.Error(t, statErr, "temp file must be cleaned up on failure")
+				return
+			}
+			require.NoError(t, err)
+
+			content, err := os.ReadFile(blobPath)
+			require.NoError(t, err)
+			assert.Equal(t, string(tt.content), string(content))
+
+			perm, err := os.ReadFile(blobPath + artifactcache.PermSuffix)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPermDecimal, string(perm))
+		})
+	}
+}
+
+func TestReadPerm(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, blobPath string)
+		want  fs.FileMode
+	}{
+		{
+			name: "reads a valid perm file",
+			setup: func(t *testing.T, blobPath string) {
+				require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o700))
+			},
+			want: 0o700,
+		},
+		{
+			name: "missing perm file defaults to 0o755",
+			setup: func(t *testing.T, blobPath string) {
+				require.NoError(t, os.WriteFile(blobPath, []byte("x"), 0o600)) // no .perm companion
+			},
+			want: 0o755,
+		},
+		{
+			name: "unparseable perm file defaults to 0o755",
+			setup: func(t *testing.T, blobPath string) {
+				require.NoError(t, os.WriteFile(blobPath+artifactcache.PermSuffix, []byte("not-a-number"), 0o600))
+			},
+			want: 0o755,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			blobPath := filepath.Join(dir, "blob")
+			tt.setup(t, blobPath)
+			assert.Equal(t, tt.want, artifactcache.ReadPerm(blobPath))
+		})
+	}
+}

--- a/internal/pkg/artifactcache/cache_test.go
+++ b/internal/pkg/artifactcache/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -178,11 +179,11 @@ func TestStore(t *testing.T) {
 			if tt.wantErrContains != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrContains)
-				// No case leaves a usable temp file behind: either it was never created (the
-				// blob dir itself couldn't be made, so stat fails with "not a directory"), or it
-				// was created and then removed on failure (stat fails with "not exist").
-				_, statErr := os.Stat(blobPath + ".tmp")
-				assert.Error(t, statErr, "temp file must be cleaned up on failure")
+				// No case leaves a temporary writer file behind.
+				tempFiles, globErr := filepath.Glob(filepath.Join(
+					filepath.Dir(blobPath), "."+filepath.Base(blobPath)+".tmp-*"))
+				require.NoError(t, globErr)
+				assert.Empty(t, tempFiles, "temp files must be cleaned up on failure")
 				return
 			}
 			require.NoError(t, err)
@@ -196,6 +197,34 @@ func TestStore(t *testing.T) {
 			assert.Equal(t, tt.wantPermDecimal, string(perm))
 		})
 	}
+}
+
+func TestStore_ConcurrentSamePath(t *testing.T) {
+	dir := t.TempDir()
+	blobPath := filepath.Join(dir, "blobs", "shared")
+	start := make(chan struct{})
+	errs := make(chan error, 32)
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			<-start
+			errs <- artifactcache.Store(blobPath, []byte("shared content"), 0o750)
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	content, err := os.ReadFile(blobPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("shared content"), content)
+	tempFiles, err := filepath.Glob(filepath.Join(filepath.Dir(blobPath), ".shared.tmp-*"))
+	require.NoError(t, err)
+	assert.Empty(t, tempFiles)
 }
 
 func TestReadPerm(t *testing.T) {

--- a/internal/pkg/artifactcache/index.go
+++ b/internal/pkg/artifactcache/index.go
@@ -1,0 +1,283 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const snapshotFile = "index.json"
+
+const snapshotVersion = 1
+
+// DefaultEvictionGracePeriod is how long a dereferenced blob lingers on disk, still servable via
+// BlobExists, before Sweep deletes it. It lets a delete-then-recreate of the same artifact reuse
+// the blob instead of triggering a fresh registry pull.
+const DefaultEvictionGracePeriod = 10 * time.Minute
+
+// indexKey identifies one CR's cache slot. PlatformKey is "" for rulesfiles.
+type indexKey struct {
+	ArtifactType string
+	Namespace    string
+	Name         string
+	PlatformKey  string
+}
+
+// Cache is the in-memory index of cached OCI artifact blobs, backed by a single snapshot file
+// under cacheDir for restart resilience. It is the shared coordination point between the writer
+// reconcilers (Plugin/Rulesfile aggregator controllers) and the reader (artifactserver.Server),
+// which run in the same process and share one *Cache instance. Blob content under blobs/ is
+// addressed via BlobPath/Store/ReadPerm; Cache owns the index/refcount/eviction layer on top.
+type Cache struct {
+	mu       sync.RWMutex
+	cacheDir string
+	index    map[indexKey]string // -> absolute blobPath
+	refs     map[string]int      // blobPath -> number of index entries pointing at it
+
+	// derefTimes tracks blobs whose refcount just dropped to zero, so Sweep can delete them
+	// once evictionGracePeriod has elapsed instead of derefLocked deleting them immediately.
+	// Not persisted to the snapshot: entries still pending at a crash/restart just fall back
+	// to the ordinary disk-orphan sweep path (findOrphanCandidates), which is self-healing.
+	derefTimes          map[string]time.Time
+	evictionGracePeriod time.Duration
+}
+
+// Option configures optional Cache behavior.
+type Option func(*Cache)
+
+// WithEvictionGracePeriod overrides how long a dereferenced blob lingers on disk before Sweep
+// deletes it (default DefaultEvictionGracePeriod). Zero means immediate removal: derefLocked
+// deletes the blob synchronously instead of deferring to Sweep.
+func WithEvictionGracePeriod(d time.Duration) Option {
+	return func(c *Cache) { c.evictionGracePeriod = d }
+}
+
+// NewCache creates a Cache rooted at cacheDir. Call Load once before any other method.
+func NewCache(cacheDir string, opts ...Option) *Cache {
+	c := &Cache{
+		cacheDir:            cacheDir,
+		index:               make(map[indexKey]string),
+		refs:                make(map[string]int),
+		derefTimes:          make(map[string]time.Time),
+		evictionGracePeriod: DefaultEvictionGracePeriod,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Dir returns the cache root directory, for callers that still need to compute a blob
+// path via BlobPath.
+func (c *Cache) Dir() string {
+	return c.cacheDir
+}
+
+// snapshot is the on-disk representation of the index, atomically rewritten on every
+// mutation. Reference counts are not part of it: they're purely derived from Entries and
+// are recomputed by Load.
+type snapshot struct {
+	Version int             `json:"version"`
+	Entries []snapshotEntry `json:"entries"`
+}
+
+type snapshotEntry struct {
+	ArtifactType string `json:"artifactType"`
+	Namespace    string `json:"namespace"`
+	Name         string `json:"name"`
+	PlatformKey  string `json:"platformKey,omitempty"`
+	BlobPath     string `json:"blobPath"` // relative to cacheDir
+}
+
+// Load reads cacheDir's snapshot file into memory and recomputes reference counts from
+// the loaded index. A missing snapshot file is not an error: Load starts empty. Load also
+// ensures cacheDir/blobs exists.
+// Not safe to call concurrently with other methods; call once at process startup.
+func (c *Cache) Load() error {
+	if err := os.MkdirAll(filepath.Join(c.cacheDir, BlobsDir), 0o750); err != nil {
+		return fmt.Errorf("create blobs dir: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(c.cacheDir, snapshotFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read snapshot: %w", err)
+	}
+
+	var snap snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("parse snapshot: %w", err)
+	}
+
+	index := make(map[indexKey]string, len(snap.Entries))
+	refs := make(map[string]int, len(snap.Entries))
+	for _, e := range snap.Entries {
+		blobPath := e.BlobPath
+		if !filepath.IsAbs(blobPath) {
+			blobPath = filepath.Join(c.cacheDir, blobPath)
+		}
+		index[indexKey{e.ArtifactType, e.Namespace, e.Name, e.PlatformKey}] = blobPath
+		refs[blobPath]++
+	}
+
+	c.mu.Lock()
+	c.index = index
+	c.refs = refs
+	c.derefTimes = make(map[string]time.Time)
+	c.mu.Unlock()
+	return nil
+}
+
+// Lookup returns the current absolute blob path indexed for (artifactType, namespace, name,
+// platformKey), or ok=false if nothing is cached yet. Pure in-memory read with no filesystem
+// access.
+func (c *Cache) Lookup(artifactType, namespace, name, platformKey string) (blobPath string, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	blobPath, ok = c.index[indexKey{artifactType, namespace, name, platformKey}]
+	return blobPath, ok
+}
+
+// BlobExists reports whether blobPath is still known to the cache: either actively referenced
+// by an index entry, or dereferenced but still within its eviction grace period. A blob written
+// to disk but not yet indexed (e.g. a crash between Store and Set) reports false.
+func (c *Cache) BlobExists(blobPath string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.refs[blobPath] > 0 {
+		return true
+	}
+	_, pending := c.derefTimes[blobPath]
+	return pending
+}
+
+// Set records that (artifactType, namespace, name, platformKey) now resolves to blobPath, which
+// must already exist on disk. If a different blob was previously indexed at this slot, its
+// reference count is decremented and, if it drops to zero, becomes eligible for eviction (see
+// derefLocked). blobPath itself is (re)referenced, canceling any pending eviction for it. The
+// updated index is then persisted to the snapshot file.
+func (c *Cache) Set(artifactType, namespace, name, platformKey, blobPath string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := indexKey{artifactType, namespace, name, platformKey}
+	if old, ok := c.index[key]; ok && old != blobPath {
+		c.derefLocked(old)
+	}
+	c.index[key] = blobPath
+	c.refs[blobPath]++
+	delete(c.derefTimes, blobPath) // referenced again; cancel any pending eviction
+
+	return c.persistLocked()
+}
+
+// RemoveAll removes every index entry for (artifactType, namespace, name), across all
+// platformKey variants (a Plugin CR can have several (os,arch) entries under one name),
+// evicting each now-unreferenced blob the same way Set does. No-op (no error, no persist)
+// if nothing is indexed for this CR.
+func (c *Cache) RemoveAll(artifactType, namespace, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var removedAny bool
+	for key, blobPath := range c.index {
+		if key.ArtifactType != artifactType || key.Namespace != namespace || key.Name != name {
+			continue
+		}
+		delete(c.index, key)
+		c.derefLocked(blobPath)
+		removedAny = true
+	}
+	if !removedAny {
+		return nil
+	}
+	return c.persistLocked()
+}
+
+// derefLocked decrements blobPath's reference count and, if it reaches zero, either defers its
+// removal to Sweep (evictionGracePeriod > 0, the default: records the dereference time and
+// leaves the blob on disk, still reported by BlobExists) or removes it immediately
+// (evictionGracePeriod == 0). An immediate removal failure is logged and swallowed rather than
+// propagated; the file is left for Sweep to clean up later. Caller must hold c.mu.
+func (c *Cache) derefLocked(blobPath string) {
+	c.refs[blobPath]--
+	if c.refs[blobPath] > 0 {
+		return
+	}
+	delete(c.refs, blobPath)
+
+	if c.evictionGracePeriod > 0 {
+		c.derefTimes[blobPath] = time.Now()
+		return
+	}
+
+	if err := os.Remove(blobPath); err != nil && !os.IsNotExist(err) {
+		ctrllog.Log.WithName("artifactcache").V(1).Info(
+			"failed to remove unreferenced blob, will be swept later", "path", blobPath, "err", err)
+		return
+	}
+	_ = os.Remove(blobPath + PermSuffix)
+	// Best-effort: fails with ENOTEMPTY (silently) if other digests/platforms remain in this ref
+	// directory.
+	_ = os.Remove(filepath.Dir(blobPath))
+}
+
+// persistLocked writes the current index to the snapshot file atomically (tmp file, then
+// rename), same pattern as Store's blob writes. Caller must hold c.mu.
+func (c *Cache) persistLocked() error {
+	entries := make([]snapshotEntry, 0, len(c.index))
+	for key, blobPath := range c.index {
+		rel, err := filepath.Rel(c.cacheDir, blobPath)
+		if err != nil {
+			rel = blobPath
+		}
+		entries = append(entries, snapshotEntry{
+			ArtifactType: key.ArtifactType,
+			Namespace:    key.Namespace,
+			Name:         key.Name,
+			PlatformKey:  key.PlatformKey,
+			BlobPath:     rel,
+		})
+	}
+
+	data, err := json.Marshal(snapshot{Version: snapshotVersion, Entries: entries})
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+
+	path := filepath.Join(c.cacheDir, snapshotFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write snapshot: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/pkg/artifactcache/index.go
+++ b/internal/pkg/artifactcache/index.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -185,14 +186,24 @@ func (c *Cache) Set(artifactType, namespace, name, platformKey, blobPath string)
 	defer c.mu.Unlock()
 
 	key := indexKey{artifactType, namespace, name, platformKey}
-	if old, ok := c.index[key]; ok && old != blobPath {
+	old, exists := c.index[key]
+	if exists && old == blobPath {
+		return nil
+	}
+
+	nextIndex := maps.Clone(c.index)
+	nextIndex[key] = blobPath
+	if err := c.persistIndexLocked(nextIndex); err != nil {
+		return err
+	}
+
+	c.index = nextIndex
+	if exists {
 		c.derefLocked(old)
 	}
-	c.index[key] = blobPath
 	c.refs[blobPath]++
 	delete(c.derefTimes, blobPath) // referenced again; cancel any pending eviction
-
-	return c.persistLocked()
+	return nil
 }
 
 // RemoveAll removes every index entry for (artifactType, namespace, name), across all
@@ -203,19 +214,27 @@ func (c *Cache) RemoveAll(artifactType, namespace, name string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var removedAny bool
+	nextIndex := maps.Clone(c.index)
+	var removedBlobs []string
 	for key, blobPath := range c.index {
 		if key.ArtifactType != artifactType || key.Namespace != namespace || key.Name != name {
 			continue
 		}
-		delete(c.index, key)
-		c.derefLocked(blobPath)
-		removedAny = true
+		delete(nextIndex, key)
+		removedBlobs = append(removedBlobs, blobPath)
 	}
-	if !removedAny {
+	if len(removedBlobs) == 0 {
 		return nil
 	}
-	return c.persistLocked()
+	if err := c.persistIndexLocked(nextIndex); err != nil {
+		return err
+	}
+
+	c.index = nextIndex
+	for _, blobPath := range removedBlobs {
+		c.derefLocked(blobPath)
+	}
+	return nil
 }
 
 // derefLocked decrements blobPath's reference count and, if it reaches zero, either defers its
@@ -246,11 +265,11 @@ func (c *Cache) derefLocked(blobPath string) {
 	_ = os.Remove(filepath.Dir(blobPath))
 }
 
-// persistLocked writes the current index to the snapshot file atomically (tmp file, then
-// rename), same pattern as Store's blob writes. Caller must hold c.mu.
-func (c *Cache) persistLocked() error {
-	entries := make([]snapshotEntry, 0, len(c.index))
-	for key, blobPath := range c.index {
+// persistIndexLocked writes index to the snapshot file atomically (tmp file, then rename),
+// same pattern as Store's blob writes. Caller must hold c.mu.
+func (c *Cache) persistIndexLocked(index map[indexKey]string) error {
+	entries := make([]snapshotEntry, 0, len(index))
+	for key, blobPath := range index {
 		rel, err := filepath.Rel(c.cacheDir, blobPath)
 		if err != nil {
 			rel = blobPath

--- a/internal/pkg/artifactcache/index_test.go
+++ b/internal/pkg/artifactcache/index_test.go
@@ -1,0 +1,440 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+)
+
+func TestCache_Load(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(t *testing.T, dir string)
+		wantErrContains string
+		check           func(t *testing.T, dir string, c *artifactcache.Cache)
+	}{
+		{
+			name: "cold start with no snapshot file succeeds with an empty index",
+			check: func(t *testing.T, _ string, c *artifactcache.Cache) {
+				t.Helper()
+				_, ok := c.Lookup("plugin", "ns", "json", "linux-amd64")
+				assert.False(t, ok)
+			},
+		},
+		{
+			name: "creates the blobs directory if missing",
+			check: func(t *testing.T, dir string, _ *artifactcache.Cache) {
+				t.Helper()
+				info, err := os.Stat(filepath.Join(dir, artifactcache.BlobsDir))
+				require.NoError(t, err)
+				assert.True(t, info.IsDir())
+			},
+		},
+		{
+			name: "corrupt snapshot file returns an error",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "index.json"), []byte("not json"), 0o600))
+			},
+			wantErrContains: "parse snapshot",
+		},
+		{
+			name: "snapshot file that is actually a directory fails to read (not a missing-file case)",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "index.json"), 0o755))
+			},
+			wantErrContains: "read snapshot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+			c := artifactcache.NewCache(dir)
+			err := c.Load()
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, dir, c)
+			}
+		})
+	}
+}
+
+func TestCache_Load_BlobsDirCannotBeCreated(t *testing.T) {
+	base := t.TempDir()
+	// cacheDir itself is a regular file, so MkdirAll(cacheDir/blobs) can't create anything
+	// under it.
+	cacheDir := filepath.Join(base, "not-a-dir")
+	require.NoError(t, os.WriteFile(cacheDir, []byte("x"), 0o600))
+
+	c := artifactcache.NewCache(cacheDir)
+	err := c.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create blobs dir")
+}
+
+func TestCache_Dir(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	assert.Equal(t, dir, c.Dir())
+}
+
+func TestCache_Load_RestartResilience(t *testing.T) {
+	dir := t.TempDir()
+
+	first := artifactcache.NewCache(dir)
+	require.NoError(t, first.Load())
+	blobPath := filepath.Join(dir, "blobs", "plugin", "ref", "sha256-abc-linux-amd64")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("content"), 0o755))
+	require.NoError(t, first.Set("plugin", "ns", "json", "linux-amd64", blobPath))
+
+	second := artifactcache.NewCache(dir)
+	require.NoError(t, second.Load())
+
+	got, ok := second.Lookup("plugin", "ns", "json", "linux-amd64")
+	require.True(t, ok)
+	assert.Equal(t, blobPath, got)
+}
+
+func TestCache_Lookup(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobAmd64 := filepath.Join(dir, "blobs", "amd64")
+	blobArm64 := filepath.Join(dir, "blobs", "arm64")
+	require.NoError(t, artifactcache.Store(blobAmd64, []byte("x"), 0o755))
+	require.NoError(t, artifactcache.Store(blobArm64, []byte("x"), 0o755))
+	require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", blobAmd64))
+	require.NoError(t, c.Set("plugin", "ns", "json", "linux-arm64", blobArm64))
+
+	tests := []struct {
+		name        string
+		platformKey string
+		wantBlob    string
+		wantOK      bool
+	}{
+		{name: "amd64 hit", platformKey: "linux-amd64", wantBlob: blobAmd64, wantOK: true},
+		{name: "arm64 hit, does not collide with amd64", platformKey: "linux-arm64", wantBlob: blobArm64, wantOK: true},
+		{name: "miss on unknown platform key", platformKey: "linux-riscv64", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := c.Lookup("plugin", "ns", "json", tt.platformKey)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantBlob, got)
+			}
+		})
+	}
+}
+
+func TestCache_Set(t *testing.T) {
+	t.Run("first write indexes the blob and evicts nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		blobPath := filepath.Join(dir, "blobs", "v1")
+		require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", blobPath))
+
+		got, ok := c.Lookup("rulesfile", "ns", "rules", "")
+		require.True(t, ok)
+		assert.Equal(t, blobPath, got)
+		assert.True(t, c.BlobExists(blobPath))
+	})
+
+	t.Run("overwrite evicts the old blob once nothing else references it (immediate eviction mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		oldBlob := filepath.Join(dir, "blobs", "v1")
+		newBlob := filepath.Join(dir, "blobs", "v2")
+		require.NoError(t, artifactcache.Store(oldBlob, []byte("v1"), 0o755))
+		require.NoError(t, artifactcache.Store(newBlob, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", oldBlob))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", newBlob))
+
+		_, err := os.Stat(oldBlob)
+		assert.True(t, os.IsNotExist(err), "old blob should have been removed")
+		_, err = os.Stat(oldBlob + artifactcache.PermSuffix)
+		assert.True(t, os.IsNotExist(err), "old blob's .perm companion should have been removed")
+		assert.False(t, c.BlobExists(oldBlob))
+
+		got, ok := c.Lookup("rulesfile", "ns", "rules", "")
+		require.True(t, ok)
+		assert.Equal(t, newBlob, got)
+	})
+
+	t.Run("evicting the last blob under a ref also removes the now-empty ref directory (immediate eviction mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		oldBlob := artifactcache.BlobPath(dir, "plugin", "old-ref", "sha256:old", "linux", "amd64")
+		newBlob := artifactcache.BlobPath(dir, "plugin", "new-ref", "sha256:new", "linux", "amd64")
+		require.NoError(t, artifactcache.Store(oldBlob, []byte("v1"), 0o755))
+		require.NoError(t, artifactcache.Store(newBlob, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", oldBlob))
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", newBlob))
+
+		_, err := os.Stat(filepath.Dir(oldBlob))
+		assert.True(t, os.IsNotExist(err), "old-ref's now-empty directory should have been removed")
+		_, err = os.Stat(filepath.Dir(newBlob))
+		assert.NoError(t, err, "new-ref's directory (still holding newBlob) must survive")
+	})
+
+	t.Run("ref directory survives eviction while a sibling blob remains in it", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		// Same ref, different digests: both blobs share one ref directory.
+		blob1 := artifactcache.BlobPath(dir, "plugin", "shared-ref", "sha256:aaa", "linux", "amd64")
+		blob2 := artifactcache.BlobPath(dir, "plugin", "shared-ref", "sha256:bbb", "linux", "amd64")
+		require.NoError(t, artifactcache.Store(blob1, []byte("v1"), 0o755))
+		require.NoError(t, artifactcache.Store(blob2, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", blob1))
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", blob2))
+
+		_, err := os.Stat(filepath.Dir(blob1))
+		assert.NoError(t, err, "shared ref directory must survive: blob2 still lives in it")
+		_, err = os.Stat(blob2)
+		assert.NoError(t, err, "sibling blob must be untouched")
+	})
+
+	t.Run("overwrite keeps the old blob while another CR still references it", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		sharedBlob := filepath.Join(dir, "blobs", "shared")
+		newBlob := filepath.Join(dir, "blobs", "new")
+		require.NoError(t, artifactcache.Store(sharedBlob, []byte("x"), 0o755))
+		require.NoError(t, artifactcache.Store(newBlob, []byte("y"), 0o755))
+
+		require.NoError(t, c.Set("plugin", "ns", "a", "", sharedBlob))
+		require.NoError(t, c.Set("plugin", "ns", "b", "", sharedBlob))
+		require.NoError(t, c.Set("plugin", "ns", "a", "", newBlob))
+
+		_, err := os.Stat(sharedBlob)
+		require.NoError(t, err, "shared blob must survive: CR b still references it")
+		assert.True(t, c.BlobExists(sharedBlob))
+
+		got, ok := c.Lookup("plugin", "ns", "b", "")
+		require.True(t, ok)
+		assert.Equal(t, sharedBlob, got)
+	})
+
+	t.Run("old blob that can't be removed (non-empty directory) is logged and skipped (immediate eviction mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		// A blob path that's actually a non-empty directory: os.Remove fails, exercising
+		// derefLocked's best-effort logged-and-swallowed branch.
+		oldBlob := filepath.Join(dir, "blobs", "old-dir")
+		require.NoError(t, os.MkdirAll(oldBlob, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(oldBlob, "occupied"), []byte("x"), 0o600))
+		newBlob := filepath.Join(dir, "blobs", "v2")
+		require.NoError(t, artifactcache.Store(newBlob, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", oldBlob))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", newBlob))
+
+		_, err := os.Stat(oldBlob)
+		require.NoError(t, err, "removal failure must not be fatal, and the directory stays behind")
+		assert.False(t, c.BlobExists(oldBlob), "refcount is still dropped even though the physical removal failed")
+	})
+
+	t.Run("overwrite dereferences the old blob but leaves it on disk pending eviction (default mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir) // default: deferred eviction
+		require.NoError(t, c.Load())
+
+		oldBlob := filepath.Join(dir, "blobs", "v1")
+		newBlob := filepath.Join(dir, "blobs", "v2")
+		require.NoError(t, artifactcache.Store(oldBlob, []byte("v1"), 0o755))
+		require.NoError(t, artifactcache.Store(newBlob, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", oldBlob))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", newBlob))
+
+		_, err := os.Stat(oldBlob)
+		assert.NoError(t, err, "old blob must still be on disk, pending eviction by Sweep")
+		assert.True(t, c.BlobExists(oldBlob),
+			"a lingering blob must still report as existing so EnsureBlob can reuse it without a registry re-pull")
+
+		got, ok := c.Lookup("rulesfile", "ns", "rules", "")
+		require.True(t, ok)
+		assert.Equal(t, newBlob, got)
+	})
+
+	t.Run("re-Set before eviction cancels the pending eviction (default mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir) // default: deferred eviction
+		require.NoError(t, c.Load())
+
+		blob := filepath.Join(dir, "blobs", "v1")
+		other := filepath.Join(dir, "blobs", "v2")
+		require.NoError(t, artifactcache.Store(blob, []byte("v1"), 0o755))
+		require.NoError(t, artifactcache.Store(other, []byte("v2"), 0o755))
+
+		require.NoError(t, c.Set("rulesfile", "ns", "a", "", blob))
+		require.NoError(t, c.Set("rulesfile", "ns", "a", "", other)) // dereferences blob, pending eviction
+		require.NoError(t, c.Set("rulesfile", "ns", "b", "", blob))  // re-referenced by a different CR
+
+		assert.True(t, c.BlobExists(blob))
+		_, err := os.Stat(blob)
+		assert.NoError(t, err)
+
+		got, ok := c.Lookup("rulesfile", "ns", "b", "")
+		require.True(t, ok)
+		assert.Equal(t, blob, got)
+	})
+
+	t.Run("a blob path that can't be made relative to cacheDir is persisted as-is", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		// A relative blobPath can't be expressed relative to the (absolute) cacheDir via
+		// filepath.Rel, exercising persistLocked's raw-fallback branch.
+		require.NoError(t, c.Set("plugin", "ns", "json", "", "relative/blob"))
+
+		got, ok := c.Lookup("plugin", "ns", "json", "")
+		require.True(t, ok)
+		assert.Equal(t, "relative/blob", got)
+	})
+
+	t.Run("snapshot write failure propagates", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("permission checks are bypassed when running as root")
+		}
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		require.NoError(t, os.Chmod(dir, 0o500)) // read+execute only: no new files allowed
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+		err := c.Set("plugin", "ns", "json", "", "/some/blob")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "write snapshot")
+	})
+
+	t.Run("snapshot rename failure propagates", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		// index.json is occupied by a directory, so the tmp-file rename can't land.
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "index.json"), 0o755))
+
+		err := c.Set("plugin", "ns", "json", "", "/some/blob")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename snapshot")
+	})
+
+	t.Run("-race: concurrent Lookup and Set", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				blobPath := filepath.Join(dir, "blobs", "concurrent")
+				_ = artifactcache.Store(blobPath, []byte("x"), 0o755)
+				_ = c.Set("plugin", "ns", "concurrent", "", blobPath)
+			}()
+			go func() {
+				defer wg.Done()
+				c.Lookup("plugin", "ns", "concurrent", "")
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func TestCache_RemoveAll(t *testing.T) {
+	t.Run("removes every platform variant and evicts unreferenced blobs, leaves other CRs alone (immediate eviction mode)", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		blobAmd64 := filepath.Join(dir, "blobs", "amd64")
+		blobArm64 := filepath.Join(dir, "blobs", "arm64")
+		otherBlob := filepath.Join(dir, "blobs", "other")
+		require.NoError(t, artifactcache.Store(blobAmd64, []byte("x"), 0o755))
+		require.NoError(t, artifactcache.Store(blobArm64, []byte("x"), 0o755))
+		require.NoError(t, artifactcache.Store(otherBlob, []byte("x"), 0o755))
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", blobAmd64))
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-arm64", blobArm64))
+		require.NoError(t, c.Set("plugin", "ns", "other-name", "", otherBlob))
+
+		require.NoError(t, c.RemoveAll("plugin", "ns", "json"))
+
+		_, ok := c.Lookup("plugin", "ns", "json", "linux-amd64")
+		assert.False(t, ok)
+		_, ok = c.Lookup("plugin", "ns", "json", "linux-arm64")
+		assert.False(t, ok)
+		_, err := os.Stat(blobAmd64)
+		assert.True(t, os.IsNotExist(err))
+		_, err = os.Stat(blobArm64)
+		assert.True(t, os.IsNotExist(err))
+
+		got, ok := c.Lookup("plugin", "ns", "other-name", "")
+		require.True(t, ok, "unrelated CR's entry must survive RemoveAll for a different name")
+		assert.Equal(t, otherBlob, got)
+		_, err = os.Stat(otherBlob)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no-op when nothing is indexed for the CR", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir)
+		require.NoError(t, c.Load())
+
+		require.NoError(t, c.RemoveAll("plugin", "ns", "missing"))
+	})
+}

--- a/internal/pkg/artifactcache/index_test.go
+++ b/internal/pkg/artifactcache/index_test.go
@@ -177,6 +177,22 @@ func TestCache_Set(t *testing.T) {
 		assert.True(t, c.BlobExists(blobPath))
 	})
 
+	t.Run("setting the same entry twice does not leak a reference", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		blobPath := filepath.Join(dir, "blobs", "v1")
+		require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", blobPath))
+		require.NoError(t, c.Set("rulesfile", "ns", "rules", "", blobPath))
+		require.NoError(t, c.RemoveAll("rulesfile", "ns", "rules"))
+
+		_, err := os.Stat(blobPath)
+		assert.True(t, os.IsNotExist(err), "the blob must be removed with its only logical reference")
+		assert.False(t, c.BlobExists(blobPath))
+	})
+
 	t.Run("overwrite evicts the old blob once nothing else references it (immediate eviction mode)", func(t *testing.T) {
 		dir := t.TempDir()
 		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
@@ -336,7 +352,7 @@ func TestCache_Set(t *testing.T) {
 		require.NoError(t, c.Load())
 
 		// A relative blobPath can't be expressed relative to the (absolute) cacheDir via
-		// filepath.Rel, exercising persistLocked's raw-fallback branch.
+		// filepath.Rel, exercising persistIndexLocked's raw-fallback branch.
 		require.NoError(t, c.Set("plugin", "ns", "json", "", "relative/blob"))
 
 		got, ok := c.Lookup("plugin", "ns", "json", "")
@@ -358,6 +374,9 @@ func TestCache_Set(t *testing.T) {
 		err := c.Set("plugin", "ns", "json", "", "/some/blob")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "write snapshot")
+		_, ok := c.Lookup("plugin", "ns", "json", "")
+		assert.False(t, ok, "a failed snapshot write must not change the live index")
+		assert.False(t, c.BlobExists("/some/blob"))
 	})
 
 	t.Run("snapshot rename failure propagates", func(t *testing.T) {
@@ -371,6 +390,43 @@ func TestCache_Set(t *testing.T) {
 		err := c.Set("plugin", "ns", "json", "", "/some/blob")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "rename snapshot")
+		_, ok := c.Lookup("plugin", "ns", "json", "")
+		assert.False(t, ok, "a failed snapshot rename must not change the live index")
+		assert.False(t, c.BlobExists("/some/blob"))
+	})
+
+	t.Run("failed overwrite preserves the previous entry and blob", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		oldBlob := filepath.Join(dir, "blobs", "old")
+		newBlob := filepath.Join(dir, "blobs", "new")
+		require.NoError(t, artifactcache.Store(oldBlob, []byte("old"), 0o755))
+		require.NoError(t, artifactcache.Store(newBlob, []byte("new"), 0o755))
+		require.NoError(t, c.Set("plugin", "ns", "json", "", oldBlob))
+
+		snapshotPath := filepath.Join(dir, "index.json")
+		backupPath := snapshotPath + ".backup"
+		require.NoError(t, os.Rename(snapshotPath, backupPath))
+		require.NoError(t, os.Mkdir(snapshotPath, 0o755))
+
+		err := c.Set("plugin", "ns", "json", "", newBlob)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename snapshot")
+
+		got, ok := c.Lookup("plugin", "ns", "json", "")
+		require.True(t, ok)
+		assert.Equal(t, oldBlob, got)
+		assert.FileExists(t, oldBlob, "the old blob must not be evicted before the snapshot commits")
+		assert.True(t, c.BlobExists(oldBlob))
+		assert.False(t, c.BlobExists(newBlob))
+
+		require.NoError(t, os.Remove(snapshotPath))
+		require.NoError(t, os.Rename(backupPath, snapshotPath))
+		require.NoError(t, c.Set("plugin", "ns", "json", "", newBlob))
+		_, err = os.Stat(oldBlob)
+		assert.True(t, os.IsNotExist(err), "a successful retry must evict the old blob")
 	})
 
 	t.Run("-race: concurrent Lookup and Set", func(t *testing.T) {
@@ -436,5 +492,39 @@ func TestCache_RemoveAll(t *testing.T) {
 		require.NoError(t, c.Load())
 
 		require.NoError(t, c.RemoveAll("plugin", "ns", "missing"))
+	})
+
+	t.Run("failed removal changes neither the live index nor the persisted snapshot", func(t *testing.T) {
+		dir := t.TempDir()
+		c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(0))
+		require.NoError(t, c.Load())
+
+		blobPath := filepath.Join(dir, "blobs", "json")
+		require.NoError(t, artifactcache.Store(blobPath, []byte("plugin"), 0o755))
+		require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", blobPath))
+
+		snapshotPath := filepath.Join(dir, "index.json")
+		backupPath := snapshotPath + ".backup"
+		require.NoError(t, os.Rename(snapshotPath, backupPath))
+		require.NoError(t, os.Mkdir(snapshotPath, 0o755))
+
+		err := c.RemoveAll("plugin", "ns", "json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename snapshot")
+		got, ok := c.Lookup("plugin", "ns", "json", "linux-amd64")
+		require.True(t, ok)
+		assert.Equal(t, blobPath, got)
+		assert.FileExists(t, blobPath, "the blob must not be evicted before the snapshot commits")
+
+		require.NoError(t, os.Remove(snapshotPath))
+		require.NoError(t, os.Rename(backupPath, snapshotPath))
+		require.NoError(t, c.RemoveAll("plugin", "ns", "json"))
+
+		restarted := artifactcache.NewCache(dir)
+		require.NoError(t, restarted.Load())
+		_, ok = restarted.Lookup("plugin", "ns", "json", "linux-amd64")
+		assert.False(t, ok, "a successful retry must remain removed after restart")
+		_, err = os.Stat(blobPath)
+		assert.True(t, os.IsNotExist(err))
 	})
 }

--- a/internal/pkg/artifactcache/sweep.go
+++ b/internal/pkg/artifactcache/sweep.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// sweepGraceWindow protects a blob that was just written but not yet indexed (the moment
+// between Store and Set) from being mistaken for an orphan by a sweep that started
+// walking in between. Distinct from Cache.evictionGracePeriod: this one is keyed off the
+// blob file's own mtime (write time), that one off a deref timestamp. See
+// findOrphanCandidates's doc comment for why conflating the two would defeat the latter.
+const sweepGraceWindow = 10 * time.Minute
+
+// DefaultSweepInterval is the polling cadence used by Sweeper when none is specified.
+const DefaultSweepInterval = time.Hour
+
+// Sweep does two things: (1) deletes any blob past its eviction grace period in derefTimes,
+// which for deferred-eviction mode (evictionGracePeriod > 0, the default) is the sole
+// mechanism that actually removes a dereferenced blob from disk, since derefLocked itself
+// only records the timestamp; and (2) scans blobs/ for files unreferenced by any current
+// index entry (and not pending in derefTimes either) and removes them as orphans, a
+// backstop for a best-effort delete failure, or a process crash between Store writing a blob
+// and Set indexing it. Returns the total number of blobs removed across both.
+func (c *Cache) Sweep(ctx context.Context) (removed int, err error) {
+	logger := ctrllog.FromContext(ctx)
+
+	c.mu.RLock()
+	refs := maps.Clone(c.refs)
+	derefTimes := maps.Clone(c.derefTimes)
+	c.mu.RUnlock()
+
+	candidates, err := c.findOrphanCandidates(refs, derefTimes)
+	if err != nil {
+		return 0, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	removed = c.removeExpiredDerefsLocked(logger)
+	removed += c.removeOrphansLocked(logger, candidates)
+	return removed, nil
+}
+
+// findOrphanCandidates walks blobs/ and returns the paths of files that aren't in refs, aren't
+// currently pending eviction in derefTimes (that's removeExpiredDerefsLocked's job, once its
+// own grace period elapses, not this one, which uses sweepGraceWindow against file mtime and
+// would otherwise immediately defeat a blob's eviction grace period on its very next tick),
+// and are older than sweepGraceWindow. Read-only: takes no lock, since it only touches the
+// filesystem and the caller-supplied snapshots.
+func (c *Cache) findOrphanCandidates(refs map[string]int, derefTimes map[string]time.Time) ([]string, error) {
+	blobsDir := filepath.Join(c.cacheDir, BlobsDir)
+	var candidates []string
+	walkErr := filepath.WalkDir(blobsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || strings.HasSuffix(path, PermSuffix) {
+			return nil
+		}
+		if refs[path] > 0 {
+			return nil
+		}
+		if _, pending := derefTimes[path]; pending {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil //nolint:nilerr // stat failed for this one entry; skip it, don't abort the whole walk
+		}
+		if time.Since(info.ModTime()) < sweepGraceWindow {
+			return nil
+		}
+		candidates = append(candidates, path)
+		return nil
+	})
+	if walkErr != nil {
+		if errors.Is(walkErr, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("walk blobs dir: %w", walkErr)
+	}
+	return candidates, nil
+}
+
+// removeOrphansLocked re-checks each candidate against the live refs map, closing the gap
+// against a Set that started referencing it since findOrphanCandidates took its snapshot,
+// and removes it, its .perm companion, and its now-empty ref directory, if still
+// unreferenced. Also skips anything currently in c.derefTimes as a final safety net against a
+// stale pre-walk snapshot (findOrphanCandidates already excludes these, but that's only an
+// optimization; this check is the actual correctness guarantee against double-handling a
+// blob removeExpiredDerefsLocked owns). Caller must hold c.mu.
+func (c *Cache) removeOrphansLocked(logger logr.Logger, candidates []string) int {
+	removed := 0
+	for _, path := range candidates {
+		if c.refs[path] > 0 {
+			continue // referenced again since the snapshot was taken
+		}
+		if _, pending := c.derefTimes[path]; pending {
+			continue // now within its own eviction grace period; removeExpiredDerefsLocked owns it
+		}
+		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+			logger.V(1).Info("sweep: failed to remove orphaned blob", "path", path, "err", removeErr)
+			continue
+		}
+		_ = os.Remove(path + PermSuffix)
+		// Best-effort: fails with ENOTEMPTY (silently) if other blobs remain in this ref dir.
+		_ = os.Remove(filepath.Dir(path))
+		removed++
+	}
+	return removed
+}
+
+// removeExpiredDerefsLocked deletes every blob in c.derefTimes whose eviction grace period
+// has elapsed, along with its .perm companion and now-possibly-empty ref directory. No
+// filesystem walk needed: c.derefTimes already precisely tracks every pending blob, so this
+// runs directly against live state under the lock rather than a pre-walk snapshot. A removal
+// failure is logged and swallowed (mirrors derefLocked's immediate-removal failure handling):
+// the entry is dropped from derefTimes regardless, so a persistently-undeletable blob falls
+// through to the ordinary orphan-sweep path (findOrphanCandidates) on the next cycle instead
+// of being retried here forever. Caller must hold c.mu.
+func (c *Cache) removeExpiredDerefsLocked(logger logr.Logger) int {
+	removed := 0
+	for path, derefAt := range c.derefTimes {
+		if time.Since(derefAt) < c.evictionGracePeriod {
+			continue
+		}
+		delete(c.derefTimes, path)
+		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+			logger.V(1).Info("sweep: failed to remove dereferenced blob, will retry as an orphan", "path", path, "err", removeErr)
+			continue
+		}
+		_ = os.Remove(path + PermSuffix)
+		_ = os.Remove(filepath.Dir(path))
+		removed++
+	}
+	return removed
+}
+
+// Sweeper periodically calls Cache.Sweep as a backstop against orphaned blobs. Mirrors
+// compat.VersionsWatcher's Start(ctx) shape: ticker loop, errors logged and swallowed,
+// returns nil on ctx.Done().
+type Sweeper struct {
+	cache    *Cache
+	interval time.Duration
+}
+
+// NewSweeper creates a Sweeper that calls cache.Sweep every interval.
+func NewSweeper(cache *Cache, interval time.Duration) *Sweeper {
+	return &Sweeper{cache: cache, interval: interval}
+}
+
+// Start implements manager.Runnable. It sweeps until ctx is canceled.
+func (s *Sweeper) Start(ctx context.Context) error {
+	logger := ctrllog.FromContext(ctx)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			removed, err := s.cache.Sweep(ctx)
+			if err != nil {
+				logger.V(4).Info("artifact cache sweep failed, will retry", "err", err)
+				continue
+			}
+			if removed > 0 {
+				logger.V(2).Info("artifact cache sweep removed orphaned blobs", "removed", removed)
+			}
+		}
+	}
+}

--- a/internal/pkg/artifactcache/sweep.go
+++ b/internal/pkg/artifactcache/sweep.go
@@ -112,10 +112,9 @@ func (c *Cache) findOrphanCandidates(refs map[string]int, derefTimes map[string]
 // removeOrphansLocked re-checks each candidate against the live refs map, closing the gap
 // against a Set that started referencing it since findOrphanCandidates took its snapshot,
 // and removes it, its .perm companion, and its now-empty ref directory, if still
-// unreferenced. Also skips anything currently in c.derefTimes as a final safety net against a
-// stale pre-walk snapshot (findOrphanCandidates already excludes these, but that's only an
-// optimization; this check is the actual correctness guarantee against double-handling a
-// blob removeExpiredDerefsLocked owns). Caller must hold c.mu.
+// unreferenced. It also skips anything currently in c.derefTimes and any candidate rewritten
+// within sweepGraceWindow after discovery. Cache.Store shares this mutex, making that final
+// freshness check atomic with production blob replacement. Caller must hold c.mu.
 func (c *Cache) removeOrphansLocked(logger logr.Logger, candidates []string) int {
 	removed := 0
 	for _, path := range candidates {
@@ -124,6 +123,16 @@ func (c *Cache) removeOrphansLocked(logger logr.Logger, candidates []string) int
 		}
 		if _, pending := c.derefTimes[path]; pending {
 			continue // now within its own eviction grace period; removeExpiredDerefsLocked owns it
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			if !os.IsNotExist(statErr) {
+				logger.V(1).Info("sweep: failed to stat orphaned blob", "path", path, "err", statErr)
+			}
+			continue
+		}
+		if time.Since(info.ModTime()) < sweepGraceWindow {
+			continue // rewritten after candidate discovery; protect the new Store-to-Set window
 		}
 		if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
 			logger.V(1).Info("sweep: failed to remove orphaned blob", "path", path, "err", removeErr)

--- a/internal/pkg/artifactcache/sweep_internal_test.go
+++ b/internal/pkg/artifactcache/sweep_internal_test.go
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveOrphansLocked_SkipsReReferenced exercises the TOCTOU re-check inside
+// removeOrphansLocked directly: a candidate that became referenced again after
+// findOrphanCandidates took its snapshot (but before the write lock was acquired) must
+// survive. This race window isn't reproducible deterministically through the public
+// Sweep API, so it's tested white-box instead.
+func TestRemoveOrphansLocked_SkipsReReferenced(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "reref")
+	require.NoError(t, Store(blobPath, []byte("x"), 0o755))
+
+	c.mu.Lock()
+	c.refs[blobPath] = 1
+	c.mu.Unlock()
+
+	removed := c.removeOrphansLocked(logr.Discard(), []string{blobPath})
+
+	assert.Equal(t, 0, removed)
+	_, err := os.Stat(blobPath)
+	assert.NoError(t, err, "re-referenced blob must survive")
+}
+
+// TestRemoveOrphansLocked_RemovalFailureIsLoggedAndSkipped exercises the best-effort
+// os.Remove-failure branch: a candidate that can't actually be unlinked (here, a
+// non-empty directory masquerading as a blob path) is logged and left in place rather
+// than treated as an error.
+func TestRemoveOrphansLocked_RemovalFailureIsLoggedAndSkipped(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "undeletable")
+	require.NoError(t, os.MkdirAll(blobPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blobPath, "occupied"), []byte("x"), 0o600))
+
+	removed := c.removeOrphansLocked(logr.Discard(), []string{blobPath})
+
+	assert.Equal(t, 0, removed)
+	_, err := os.Stat(blobPath)
+	assert.NoError(t, err, "removal failure must not be fatal")
+}
+
+// TestRemoveExpiredDerefsLocked_RemovesExpiredEntry exercises the deferred-eviction deletion
+// path directly, since waiting out a real evictionGracePeriod isn't practical in a test: a
+// blob whose derefTimes entry is older than evictionGracePeriod is deleted, along with its
+// .perm companion and now-empty ref directory.
+func TestRemoveExpiredDerefsLocked_RemovesExpiredEntry(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir) // default evictionGracePeriod (DefaultEvictionGracePeriod)
+	require.NoError(t, c.Load())
+
+	blobPath := BlobPath(dir, "plugin", "expired-ref", "sha256:old", "linux", "amd64")
+	require.NoError(t, Store(blobPath, []byte("x"), 0o755))
+
+	c.mu.Lock()
+	c.derefTimes[blobPath] = time.Now().Add(-time.Hour) // well past DefaultEvictionGracePeriod
+	c.mu.Unlock()
+
+	removed := c.removeExpiredDerefsLocked(logr.Discard())
+
+	assert.Equal(t, 1, removed)
+	_, err := os.Stat(blobPath)
+	assert.True(t, os.IsNotExist(err), "expired blob should have been removed")
+	_, err = os.Stat(blobPath + PermSuffix)
+	assert.True(t, os.IsNotExist(err), ".perm companion should have been removed")
+	_, err = os.Stat(filepath.Dir(blobPath))
+	assert.True(t, os.IsNotExist(err), "now-empty ref directory should have been removed")
+
+	c.mu.Lock()
+	_, stillPending := c.derefTimes[blobPath]
+	c.mu.Unlock()
+	assert.False(t, stillPending)
+}
+
+// TestRemoveExpiredDerefsLocked_SkipsWithinGracePeriod ensures a blob that was only just
+// dereferenced survives, the whole point of deferred eviction.
+func TestRemoveExpiredDerefsLocked_SkipsWithinGracePeriod(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "fresh")
+	require.NoError(t, Store(blobPath, []byte("x"), 0o755))
+
+	c.mu.Lock()
+	c.derefTimes[blobPath] = time.Now()
+	c.mu.Unlock()
+
+	removed := c.removeExpiredDerefsLocked(logr.Discard())
+
+	assert.Equal(t, 0, removed)
+	_, err := os.Stat(blobPath)
+	assert.NoError(t, err, "blob within its grace period must survive")
+}
+
+// TestRemoveExpiredDerefsLocked_RemovalFailureIsLoggedAndSkipped mirrors
+// TestRemoveOrphansLocked_RemovalFailureIsLoggedAndSkipped: an expired entry that can't
+// actually be unlinked (a non-empty directory masquerading as a blob path) is logged and
+// dropped from derefTimes rather than treated as fatal: it falls through to the ordinary
+// orphan-sweep path on the next cycle instead of being retried here forever.
+func TestRemoveExpiredDerefsLocked_RemovalFailureIsLoggedAndSkipped(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "undeletable")
+	require.NoError(t, os.MkdirAll(blobPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blobPath, "occupied"), []byte("x"), 0o600))
+
+	c.mu.Lock()
+	c.derefTimes[blobPath] = time.Now().Add(-time.Hour)
+	c.mu.Unlock()
+
+	removed := c.removeExpiredDerefsLocked(logr.Discard())
+
+	assert.Equal(t, 0, removed)
+	_, err := os.Stat(blobPath)
+	assert.NoError(t, err, "removal failure must not be fatal")
+
+	c.mu.Lock()
+	_, stillPending := c.derefTimes[blobPath]
+	c.mu.Unlock()
+	assert.False(t, stillPending, "entry is dropped from derefTimes regardless, falling through to the orphan sweep")
+}
+
+// TestFindOrphanCandidates_SkipsPendingDeref and TestRemoveOrphansLocked_SkipsPendingDeref
+// together cover the interaction-safety guarantee described in Sweep's doc comment: a blob
+// currently within its own eviction grace period must never be caught by the disk-orphan
+// path, even though its file mtime is almost always already older than sweepGraceWindow by
+// the time it's dereferenced (a long-lived blob was written well before it was ever
+// dereferenced).
+func TestFindOrphanCandidates_SkipsPendingDeref(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "pending")
+	require.NoError(t, Store(blobPath, []byte("x"), 0o755))
+	old := time.Now().Add(-time.Hour) // mtime well past sweepGraceWindow
+	require.NoError(t, os.Chtimes(blobPath, old, old))
+
+	candidates, err := c.findOrphanCandidates(map[string]int{}, map[string]time.Time{blobPath: time.Now()})
+	require.NoError(t, err)
+	assert.NotContains(t, candidates, blobPath)
+}
+
+func TestRemoveOrphansLocked_SkipsPendingDeref(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "pending")
+	require.NoError(t, Store(blobPath, []byte("x"), 0o755))
+
+	c.mu.Lock()
+	c.derefTimes[blobPath] = time.Now() // within its own grace period
+	c.mu.Unlock()
+
+	// Simulate a stale pre-walk snapshot that missed the pending entry and wrongly included
+	// this path as an orphan candidate anyway. removeOrphansLocked's live derefTimes check
+	// must still catch it.
+	removed := c.removeOrphansLocked(logr.Discard(), []string{blobPath})
+
+	assert.Equal(t, 0, removed)
+	_, err := os.Stat(blobPath)
+	assert.NoError(t, err, "a blob pending its own eviction grace period must survive the orphan sweep")
+}

--- a/internal/pkg/artifactcache/sweep_internal_test.go
+++ b/internal/pkg/artifactcache/sweep_internal_test.go
@@ -51,6 +51,33 @@ func TestRemoveOrphansLocked_SkipsReReferenced(t *testing.T) {
 	assert.NoError(t, err, "re-referenced blob must survive")
 }
 
+// TestRemoveOrphansLocked_SkipsFreshlyRewrittenCandidate covers the Store-to-Set window when
+// Sweep discovered an old orphan immediately before a reconciler rewrote the same digest path.
+func TestRemoveOrphansLocked_SkipsFreshlyRewrittenCandidate(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, BlobsDir, "rewritten")
+	require.NoError(t, Store(blobPath, []byte("old orphan"), 0o755))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(blobPath, old, old))
+
+	candidates, err := c.findOrphanCandidates(map[string]int{}, map[string]time.Time{})
+	require.NoError(t, err)
+	require.Contains(t, candidates, blobPath)
+
+	require.NoError(t, c.Store(blobPath, []byte("fresh content"), 0o755))
+	c.mu.Lock()
+	removed := c.removeOrphansLocked(logr.Discard(), candidates)
+	c.mu.Unlock()
+
+	assert.Equal(t, 0, removed)
+	content, err := os.ReadFile(blobPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("fresh content"), content)
+}
+
 // TestRemoveOrphansLocked_RemovalFailureIsLoggedAndSkipped exercises the best-effort
 // os.Remove-failure branch: a candidate that can't actually be unlinked (here, a
 // non-empty directory masquerading as a blob path) is logged and left in place rather

--- a/internal/pkg/artifactcache/sweep_test.go
+++ b/internal/pkg/artifactcache/sweep_test.go
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactcache_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+)
+
+func TestCache_Sweep(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, dir string, c *artifactcache.Cache) (blobPath string)
+		wantRemoved int
+		wantGone    bool
+	}{
+		{
+			name: "orphaned blob past the grace window is removed, .perm companion too",
+			setup: func(t *testing.T, dir string, _ *artifactcache.Cache) string {
+				t.Helper()
+				blobPath := filepath.Join(dir, "blobs", "orphan-old")
+				require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+				old := time.Now().Add(-time.Hour)
+				require.NoError(t, os.Chtimes(blobPath, old, old))
+				return blobPath
+			},
+			wantRemoved: 1,
+			wantGone:    true,
+		},
+		{
+			name: "orphaned blob within the grace window is skipped",
+			setup: func(t *testing.T, dir string, _ *artifactcache.Cache) string {
+				t.Helper()
+				blobPath := filepath.Join(dir, "blobs", "orphan-fresh")
+				require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+				return blobPath
+			},
+			wantRemoved: 0,
+			wantGone:    false,
+		},
+		{
+			name: "referenced blob is never touched regardless of age",
+			setup: func(t *testing.T, dir string, c *artifactcache.Cache) string {
+				t.Helper()
+				blobPath := filepath.Join(dir, "blobs", "referenced")
+				require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+				old := time.Now().Add(-time.Hour)
+				require.NoError(t, os.Chtimes(blobPath, old, old))
+				require.NoError(t, c.Set("plugin", "ns", "json", "", blobPath))
+				return blobPath
+			},
+			wantRemoved: 0,
+			wantGone:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			c := artifactcache.NewCache(dir)
+			require.NoError(t, c.Load())
+			blobPath := tt.setup(t, dir, c)
+
+			removed, err := c.Sweep(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRemoved, removed)
+
+			_, statErr := os.Stat(blobPath)
+			if tt.wantGone {
+				assert.True(t, os.IsNotExist(statErr))
+				_, permErr := os.Stat(blobPath + artifactcache.PermSuffix)
+				assert.True(t, os.IsNotExist(permErr), ".perm companion should be removed alongside its blob")
+			} else {
+				assert.NoError(t, statErr)
+			}
+		})
+	}
+}
+
+func TestCache_Sweep_BlobsDirUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks are bypassed when running as root")
+	}
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobsDir := filepath.Join(dir, artifactcache.BlobsDir)
+	require.NoError(t, os.Chmod(blobsDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blobsDir, 0o755) })
+
+	_, err := c.Sweep(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "walk blobs dir")
+}
+
+func TestCache_Sweep_RemovesNowEmptyRefDirectory(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := artifactcache.BlobPath(dir, "plugin", "orphan-ref", "sha256:old", "linux", "amd64")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(blobPath, old, old))
+
+	removed, err := c.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	_, statErr := os.Stat(filepath.Dir(blobPath))
+	assert.True(t, os.IsNotExist(statErr), "orphan-ref's now-empty directory should have been removed")
+}
+
+func TestCache_Sweep_RefDirectorySurvivesWithSiblingBlob(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	// Same ref, two digests: one orphaned and old, one still referenced.
+	orphan := artifactcache.BlobPath(dir, "plugin", "shared-ref", "sha256:old", "linux", "amd64")
+	kept := artifactcache.BlobPath(dir, "plugin", "shared-ref", "sha256:new", "linux", "amd64")
+	require.NoError(t, artifactcache.Store(orphan, []byte("x"), 0o755))
+	require.NoError(t, artifactcache.Store(kept, []byte("y"), 0o755))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(orphan, old, old))
+	require.NoError(t, c.Set("plugin", "ns", "json", "linux-amd64", kept))
+
+	removed, err := c.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	_, statErr := os.Stat(filepath.Dir(orphan))
+	assert.NoError(t, statErr, "shared ref directory must survive: kept blob still lives in it")
+	_, statErr = os.Stat(kept)
+	assert.NoError(t, statErr, "referenced sibling blob must be untouched")
+}
+
+func TestCache_Sweep_NoBlobsDirYet(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	// Deliberately not calling Load, so blobs/ was never created.
+	removed, err := c.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+}
+
+func TestSweeper_Start_SweepErrorIsLoggedAndRetried(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks are bypassed when running as root")
+	}
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobsDir := filepath.Join(dir, artifactcache.BlobsDir)
+	require.NoError(t, os.Chmod(blobsDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blobsDir, 0o755) })
+
+	sweeper := artifactcache.NewSweeper(c, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- sweeper.Start(ctx) }()
+
+	time.Sleep(100 * time.Millisecond) // let a few failing ticks fire without the loop dying
+
+	cancel()
+	select {
+	case startErr := <-done:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestSweeper_Start(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir)
+	require.NoError(t, c.Load())
+
+	blobPath := filepath.Join(dir, "blobs", "orphan")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(blobPath, old, old))
+
+	sweeper := artifactcache.NewSweeper(c, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- sweeper.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(blobPath)
+		return os.IsNotExist(statErr)
+	}, 2*time.Second, 20*time.Millisecond, "sweeper never removed the orphaned blob")
+
+	cancel()
+	select {
+	case startErr := <-done:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// TestSweeper_Start_DeferredEviction is the end-to-end counterpart to the white-box
+// removeExpiredDerefsLocked tests: a dereferenced blob survives immediately (pending its
+// grace period), then gets removed once both the grace period and a sweep tick have passed.
+func TestSweeper_Start_DeferredEviction(t *testing.T) {
+	dir := t.TempDir()
+	c := artifactcache.NewCache(dir, artifactcache.WithEvictionGracePeriod(50*time.Millisecond))
+	require.NoError(t, c.Load())
+
+	oldBlob := filepath.Join(dir, "blobs", "v1")
+	newBlob := filepath.Join(dir, "blobs", "v2")
+	require.NoError(t, artifactcache.Store(oldBlob, []byte("v1"), 0o755))
+	require.NoError(t, artifactcache.Store(newBlob, []byte("v2"), 0o755))
+	require.NoError(t, c.Set("rulesfile", "ns", "rules", "", oldBlob))
+	require.NoError(t, c.Set("rulesfile", "ns", "rules", "", newBlob)) // dereferences oldBlob
+
+	_, err := os.Stat(oldBlob)
+	require.NoError(t, err, "dereferenced blob must survive immediately, pending its grace period")
+
+	sweeper := artifactcache.NewSweeper(c, 10*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- sweeper.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(oldBlob)
+		return os.IsNotExist(statErr)
+	}, 2*time.Second, 20*time.Millisecond, "sweeper never removed the dereferenced blob after its grace period elapsed")
+
+	cancel()
+	select {
+	case startErr := <-done:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}

--- a/internal/pkg/compat/requirements.go
+++ b/internal/pkg/compat/requirements.go
@@ -19,8 +19,8 @@ package compat
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
+	semver "github.com/blang/semver/v4"
 	"gopkg.in/yaml.v3"
 
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
@@ -30,51 +30,42 @@ import (
 // It uses major-compatibility semantics: the major version must match exactly.
 const CapabilityPluginAPIVersion = "plugin_api_version"
 
-// SemverAtLeast reports whether available >= required, comparing X.Y.Z version tuples
-// part by part. Shorter versions are padded with zeros (e.g. "19" → "19.0.0").
+// SemverAtLeast reports whether available >= required according to semantic-version
+// precedence. Tolerant parsing accepts common forms such as "v1.2.3" and shortened
+// versions such as "19" (interpreted as "19.0.0").
 func SemverAtLeast(available, required string) (bool, error) {
-	ap := strings.SplitN(available, ".", 3)
-	rp := strings.SplitN(required, ".", 3)
-	for len(ap) < 3 {
-		ap = append(ap, "0")
+	availableVersion, err := parseSemver(available, "available")
+	if err != nil {
+		return false, err
 	}
-	for len(rp) < 3 {
-		rp = append(rp, "0")
+	requiredVersion, err := parseSemver(required, "required")
+	if err != nil {
+		return false, err
 	}
-	for i := range 3 {
-		a, err := strconv.Atoi(ap[i])
-		if err != nil {
-			return false, fmt.Errorf("parse available version part %q of %q: %w", ap[i], available, err)
-		}
-		r, err := strconv.Atoi(rp[i])
-		if err != nil {
-			return false, fmt.Errorf("parse required version part %q of %q: %w", rp[i], required, err)
-		}
-		if a != r {
-			return a > r, nil
-		}
-	}
-	return true, nil
+	return availableVersion.GTE(requiredVersion), nil
 }
 
 // SemverMajorCompatible reports whether available and required share the same major version
 // AND available >= required. Used for plugin_api_version, where a higher major version
 // (e.g. framework 3.x) is not compatible with a plugin requiring 2.x.
 func SemverMajorCompatible(available, required string) (bool, error) {
-	aMajor, _, _ := strings.Cut(available, ".")
-	rMajor, _, _ := strings.Cut(required, ".")
-	a, err := strconv.Atoi(aMajor)
+	availableVersion, err := parseSemver(available, "available")
 	if err != nil {
-		return false, fmt.Errorf("parse available major version %q of %q: %w", aMajor, available, err)
+		return false, err
 	}
-	r, err := strconv.Atoi(rMajor)
+	requiredVersion, err := parseSemver(required, "required")
 	if err != nil {
-		return false, fmt.Errorf("parse required major version %q of %q: %w", rMajor, required, err)
+		return false, err
 	}
-	if a != r {
-		return false, nil
+	return availableVersion.Major == requiredVersion.Major && availableVersion.GTE(requiredVersion), nil
+}
+
+func parseSemver(value, role string) (semver.Version, error) {
+	version, err := semver.ParseTolerant(value)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("parse %s version %q: %w", role, value, err)
 	}
-	return SemverAtLeast(available, required)
+	return version, nil
 }
 
 // RulesRequirements holds requirements extracted from a Falco rules YAML document.

--- a/internal/pkg/compat/requirements_test.go
+++ b/internal/pkg/compat/requirements_test.go
@@ -43,6 +43,10 @@ func TestSemverAtLeast(t *testing.T) {
 		{name: "short available padded with zeros", available: "62", required: "15", want: true},
 		{name: "short required padded with zeros", available: "0.62.0", required: "0", want: true},
 		{name: "short versions equal", available: "62", required: "62", want: true},
+		{name: "leading v accepted", available: "v0.62.1", required: "0.62.0", want: true},
+		{name: "prerelease is lower than release", available: "1.0.0-rc.1", required: "1.0.0", want: false},
+		{name: "release is higher than prerelease", available: "1.0.0", required: "1.0.0-rc.1", want: true},
+		{name: "build metadata does not affect precedence", available: "1.0.0+build.2", required: "1.0.0+build.1", want: true},
 		{name: "invalid available part returns error", available: "x.62.0", required: "0.62.0", wantErr: true},
 		{name: "invalid required part returns error", available: "0.62.0", required: "0.x.0", wantErr: true},
 	}
@@ -77,6 +81,8 @@ func TestSemverMajorCompatible(t *testing.T) {
 		{name: "zero major same", available: "0.5.0", required: "0.5.0", want: true},
 		{name: "zero major available higher patch", available: "0.5.1", required: "0.5.0", want: true},
 		{name: "zero major available lower", available: "0.4.9", required: "0.5.0", want: false},
+		{name: "leading v accepted", available: "v2.1.0", required: "2.0.0", want: true},
+		{name: "same major prerelease is lower", available: "2.0.0-rc.1", required: "2.0.0", want: false},
 		{name: "invalid available returns error", available: "x.0.0", required: "2.0.0", wantErr: true},
 		{name: "invalid required returns error", available: "2.0.0", required: "x.0.0", wantErr: true},
 	}

--- a/internal/pkg/oci/puller/mock.go
+++ b/internal/pkg/oci/puller/mock.go
@@ -48,6 +48,12 @@ type MockOCIPuller struct {
 	FetchConfigErr   error
 	FetchConfigCalls []string
 
+	// ResolveDigestResult is the digest string returned by ResolveDigest.
+	ResolveDigestResult string
+	// ResolveDigestErr is returned by ResolveDigest when set.
+	ResolveDigestErr   error
+	ResolveDigestCalls []string
+
 	// ContentResult is returned by FetchContent when FetchContentErr is nil.
 	ContentResult []byte
 	// FetchContentErr is returned by FetchContent when set.
@@ -70,6 +76,15 @@ func (m *MockOCIPuller) FetchConfig(_ context.Context, ref string, _ auth.Creden
 		return nil, "", m.FetchConfigErr
 	}
 	return m.ConfigResult, m.ConfigDigest, nil
+}
+
+// ResolveDigest records the call and returns the preset digest result.
+func (m *MockOCIPuller) ResolveDigest(_ context.Context, ref string, _ auth.CredentialFunc, _ *RegistryOptions) (string, error) {
+	m.ResolveDigestCalls = append(m.ResolveDigestCalls, ref)
+	if m.ResolveDigestErr != nil {
+		return "", m.ResolveDigestErr
+	}
+	return m.ResolveDigestResult, nil
 }
 
 // FetchContent records the call and returns the preset content bytes.

--- a/internal/pkg/oci/puller/puller.go
+++ b/internal/pkg/oci/puller/puller.go
@@ -43,6 +43,9 @@ type Puller interface {
 	// FetchConfig retrieves only the OCI config layer for the given reference without downloading the artifact
 	// binary. It returns the parsed ArtifactConfig and the resolved root digest (suitable as a cache key).
 	FetchConfig(ctx context.Context, ref string, creds auth.CredentialFunc, opts *RegistryOptions) (*ArtifactConfig, string, error)
+	// ResolveDigest resolves the current OCI manifest digest for ref without downloading any content.
+	// It is a cheap HEAD-equivalent call suitable for cache validation.
+	ResolveDigest(ctx context.Context, ref string, creds auth.CredentialFunc, opts *RegistryOptions) (string, error)
 	// FetchContent downloads the content layer for ref and returns the extracted file bytes without writing to disk.
 	// For rulesfile artifacts this is the raw YAML.
 	FetchContent(ctx context.Context, ref string, creds auth.CredentialFunc, opts *RegistryOptions) ([]byte, error)
@@ -265,6 +268,42 @@ func (p *OciPuller) FetchConfig(ctx context.Context, ref string, creds auth.Cred
 	}
 
 	return &config, string(rootDesc.Digest), nil
+}
+
+// ResolveDigest resolves the current OCI manifest digest for ref without downloading any content.
+func (p *OciPuller) ResolveDigest(ctx context.Context, ref string, creds auth.CredentialFunc, opts *RegistryOptions) (string, error) {
+	options := p.defaults
+	if opts != nil {
+		options = opts
+	}
+
+	repo, err := remote.NewRepository(ref)
+	if err != nil {
+		return "", fmt.Errorf("unable to create repository for %q: %w", ref, err)
+	}
+
+	clientOpts := []client.Option{client.WithCredentialFunc(creds)}
+	if options != nil {
+		if options.InsecureSkipVerify {
+			tlsConfig := &tls.Config{InsecureSkipVerify: options.InsecureSkipVerify} //nolint:gosec // user-configured
+			httpTransport := &http.Transport{TLSClientConfig: tlsConfig}
+			retryTransport := retry.NewTransport(httpTransport)
+			clientOpts = append(clientOpts, client.WithTransport(retryTransport))
+		}
+		repo.PlainHTTP = options.PlainHTTP
+	}
+	repo.Client = client.NewClient(clientOpts...)
+
+	if repo.Reference.Reference == "" {
+		repo.Reference.Reference = DefaultTag
+	}
+
+	desc, err := repo.Resolve(ctx, repo.Reference.Reference)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve %q: %w", ref, err)
+	}
+
+	return string(desc.Digest), nil
 }
 
 // FetchContent downloads the artifact content layer for ref and returns the extracted file bytes.

--- a/internal/pkg/oci/puller/puller.go
+++ b/internal/pkg/oci/puller/puller.go
@@ -233,32 +233,12 @@ func (p *OciPuller) FetchConfig(ctx context.Context, ref string, creds auth.Cred
 		return nil, "", fmt.Errorf("unable to resolve %q: %w", ref, err)
 	}
 
-	manifestDesc := rootDesc
-	if rootDesc.MediaType == v1.MediaTypeImageIndex {
-		indexBytes, err := fetchBytes(ctx, repo, &rootDesc)
-		if err != nil {
-			return nil, "", fmt.Errorf("unable to fetch image index for %q: %w", ref, err)
-		}
-		var index v1.Index
-		if err := json.Unmarshal(indexBytes, &index); err != nil {
-			return nil, "", fmt.Errorf("unable to parse image index for %q: %w", ref, err)
-		}
-		if len(index.Manifests) == 0 {
-			return nil, "", fmt.Errorf("image index for %q has no manifests", ref)
-		}
-		manifestDesc = index.Manifests[0]
-	}
-
-	manifestBytes, err := fetchBytes(ctx, repo, &manifestDesc)
+	configDesc, err := resolveConfigDescriptor(ctx, repo, ref, &rootDesc)
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to fetch manifest for %q: %w", ref, err)
-	}
-	var manifest v1.Manifest
-	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return nil, "", fmt.Errorf("unable to parse manifest for %q: %w", ref, err)
+		return nil, "", err
 	}
 
-	configBytes, err := fetchBytes(ctx, repo, &manifest.Config)
+	configBytes, err := fetchBytes(ctx, repo, configDesc)
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to fetch config for %q: %w", ref, err)
 	}
@@ -268,6 +248,60 @@ func (p *OciPuller) FetchConfig(ctx context.Context, ref string, creds auth.Cred
 	}
 
 	return &config, string(rootDesc.Digest), nil
+}
+
+// resolveConfigDescriptor returns the config descriptor of a direct manifest. Falco plugin
+// indexes produced by falcoctl use one shared ArtifactConfig for every platform, so for an
+// index the first concrete platform manifest is sufficient. Descriptors without a platform or
+// with an unknown platform are ignored because OCI indexes may also contain auxiliary entries
+// such as attestations.
+func resolveConfigDescriptor(ctx context.Context, target descriptorFetcher, ref string, rootDesc *v1.Descriptor) (*v1.Descriptor, error) {
+	manifestDesc := rootDesc
+	if rootDesc.MediaType == v1.MediaTypeImageIndex {
+		indexBytes, err := fetchBytes(ctx, target, rootDesc)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch image index for %q: %w", ref, err)
+		}
+		var index v1.Index
+		if err := json.Unmarshal(indexBytes, &index); err != nil {
+			return nil, fmt.Errorf("unable to parse image index for %q: %w", ref, err)
+		}
+		manifestDesc = nil
+		for i := range index.Manifests {
+			if hasConcretePlatform(index.Manifests[i].Platform) {
+				manifestDesc = &index.Manifests[i]
+				break
+			}
+		}
+		if manifestDesc == nil {
+			return nil, fmt.Errorf("image index for %q has no platform manifests", ref)
+		}
+	}
+
+	return fetchManifestConfigDescriptor(ctx, target, ref, manifestDesc)
+}
+
+func hasConcretePlatform(platform *v1.Platform) bool {
+	const unknown = "unknown"
+
+	return platform != nil &&
+		platform.OS != "" && platform.OS != unknown &&
+		platform.Architecture != "" && platform.Architecture != unknown
+}
+
+func fetchManifestConfigDescriptor(ctx context.Context, target descriptorFetcher, ref string, manifestDesc *v1.Descriptor) (*v1.Descriptor, error) {
+	manifestBytes, err := fetchBytes(ctx, target, manifestDesc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch manifest %q for %q: %w", manifestDesc.Digest, ref, err)
+	}
+	var manifest v1.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("unable to parse manifest %q for %q: %w", manifestDesc.Digest, ref, err)
+	}
+	if manifest.Config.Digest == "" {
+		return nil, fmt.Errorf("manifest %q for %q has no config descriptor", manifestDesc.Digest, ref)
+	}
+	return &manifest.Config, nil
 }
 
 // ResolveDigest resolves the current OCI manifest digest for ref without downloading any content.
@@ -320,10 +354,12 @@ func (p *OciPuller) FetchContent(ctx context.Context, ref string, creds auth.Cre
 	return file.Content, nil
 }
 
-// fetchBytes fetches the content of desc from target and returns it as a byte slice.
-func fetchBytes(ctx context.Context, target interface {
+type descriptorFetcher interface {
 	Fetch(context.Context, v1.Descriptor) (io.ReadCloser, error)
-}, desc *v1.Descriptor) ([]byte, error) {
+}
+
+// fetchBytes fetches the content of desc from target and returns it as a byte slice.
+func fetchBytes(ctx context.Context, target descriptorFetcher, desc *v1.Descriptor) ([]byte, error) {
 	r, err := target.Fetch(ctx, *desc)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/oci/puller/puller_internal_test.go
+++ b/internal/pkg/oci/puller/puller_internal_test.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package puller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	orascontent "oras.land/oras-go/v2/content"
+)
+
+type memoryDescriptorFetcher map[string][]byte
+
+//nolint:gocritic // descriptorFetcher mirrors ORAS's Fetcher interface, which passes descriptors by value.
+func (f memoryDescriptorFetcher) Fetch(_ context.Context, desc v1.Descriptor) (io.ReadCloser, error) {
+	content, ok := f[desc.Digest.String()]
+	if !ok {
+		return nil, fmt.Errorf("descriptor %q not found", desc.Digest)
+	}
+	return io.NopCloser(bytes.NewReader(content)), nil
+}
+
+func (f memoryDescriptorFetcher) addJSON(t *testing.T, mediaType string, value any) v1.Descriptor {
+	t.Helper()
+	content, err := json.Marshal(value)
+	require.NoError(t, err)
+	desc := descriptorForContent(mediaType, content)
+	f[desc.Digest.String()] = content
+	return desc
+}
+
+func descriptorForContent(mediaType string, content []byte) v1.Descriptor {
+	return orascontent.NewDescriptorFromBytes(mediaType, content)
+}
+
+func TestResolveConfigDescriptor_DirectManifest(t *testing.T) {
+	fetcher := memoryDescriptorFetcher{}
+	configDesc := descriptorForContent(FalcoPluginConfigMediaType, []byte(`{"name":"plugin"}`))
+	rootDesc := fetcher.addJSON(t, v1.MediaTypeImageManifest, v1.Manifest{Config: configDesc})
+
+	got, err := resolveConfigDescriptor(context.Background(), fetcher, "registry.example/plugin:1", &rootDesc)
+
+	require.NoError(t, err)
+	assert.Equal(t, configDesc, *got)
+}
+
+func TestResolveConfigDescriptor_IndexUsesFirstPlatformManifest(t *testing.T) {
+	fetcher := memoryDescriptorFetcher{}
+	configDesc := descriptorForContent(FalcoPluginConfigMediaType, []byte(`{"name":"plugin"}`))
+	arm64 := fetcher.addJSON(t, v1.MediaTypeImageManifest, v1.Manifest{Config: configDesc})
+	arm64.Platform = &v1.Platform{OS: "linux", Architecture: "arm64"}
+	amd64 := descriptorForContent(v1.MediaTypeImageManifest, []byte("not fetched"))
+	amd64.Platform = &v1.Platform{OS: "linux", Architecture: "amd64"}
+	auxiliary := descriptorForContent(v1.MediaTypeImageManifest, []byte("not fetched"))
+	unknownPlatform := descriptorForContent(v1.MediaTypeImageManifest, []byte("also not fetched"))
+	unknownPlatform.Platform = &v1.Platform{OS: "unknown", Architecture: "unknown"}
+	rootDesc := fetcher.addJSON(t, v1.MediaTypeImageIndex, v1.Index{
+		Manifests: []v1.Descriptor{auxiliary, unknownPlatform, arm64, amd64},
+	})
+
+	got, err := resolveConfigDescriptor(context.Background(), fetcher, "registry.example/plugin:1", &rootDesc)
+
+	require.NoError(t, err)
+	assert.Equal(t, configDesc, *got)
+}
+
+func TestResolveConfigDescriptor_IndexRequiresPlatformManifest(t *testing.T) {
+	fetcher := memoryDescriptorFetcher{}
+	rootDesc := fetcher.addJSON(t, v1.MediaTypeImageIndex, v1.Index{
+		Manifests: []v1.Descriptor{descriptorForContent(v1.MediaTypeImageManifest, []byte("auxiliary"))},
+	})
+
+	_, err := resolveConfigDescriptor(context.Background(), fetcher, "registry.example/plugin:1", &rootDesc)
+
+	require.EqualError(t, err, `image index for "registry.example/plugin:1" has no platform manifests`)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

feat(artifact): add centralized blob cache and EnsureBlob
Adds the shared library pieces the instance operator's Plugin and
Rulesfile aggregator controllers will use to pre-fetch and cache OCI
binary blobs centrally, so per-node artifact operators can read a
warm cache over HTTP instead of each pulling the registry
independently:

- internal/pkg/artifactcache: content-addressed on-disk blob storage
  (Cache, BlobPath, Store), reference-counted eviction with a grace
  period, and a periodic Sweeper as a backstop against orphaned blobs
  from a crash between writing a blob and indexing it.
- Manager.EnsureBlob (internal/pkg/artifact): resolves the digest (or
  reuses a known one), returns immediately on a cache hit, otherwise
  pulls, extracts, and stores the blob. Registering the result in the
  Cache's index is the caller's responsibility, not EnsureBlob's.
- Puller.ResolveDigest, the one new OCI-fetch primitive EnsureBlob
  needed beyond what the previous PR added.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
Depends on #384 