### PR TITLE
feat(instance): wire up the Plugin node-object aggregator controller

### DIFF
--- a/api/common/v1alpha1/types.go
+++ b/api/common/v1alpha1/types.go
@@ -47,6 +47,15 @@ const (
 	// - True: the artifact was programmed successfully.
 	// - False: the artifact could not be programmed.
 	ConditionProgrammed ConditionType = "Programmed"
+	// ConditionDeletionBlocked indicates whether removal of this node's artifact is being
+	// withheld because another artifact on the same node (e.g. a Rulesfile) still structurally
+	// depends on it. Set only by per-node artifact operators on the ArtifactNode they own; the
+	// instance-level aggregator surfaces it onto the parent artifact like any other condition.
+	// The possible status values for this condition type are:
+	// - True: removal is blocked; the message names the blocking dependent(s).
+	// - Absent: not blocked. This condition is only ever set while a removal is actually being
+	//   withheld; there is no corresponding False state to clear.
+	ConditionDeletionBlocked ConditionType = "DeletionBlocked"
 )
 
 // String returns the string representation of the condition type.

--- a/chart/falco-operator/files/ClusterRole.yaml
+++ b/chart/falco-operator/files/ClusterRole.yaml
@@ -105,6 +105,7 @@ rules:
   - artifact.falcosecurity.dev
   resources:
   - configs/finalizers
+  - plugins/finalizers
   verbs:
   - patch
   - update

--- a/cmd/instance/main.go
+++ b/cmd/instance/main.go
@@ -38,6 +38,7 @@ import (
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 	artifactconfigctr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/config"
+	artifactpluginctr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/plugin"
 	"github.com/falcosecurity/falco-operator/controllers/instance/component"
 	"github.com/falcosecurity/falco-operator/controllers/instance/falco"
 	configmapctr "github.com/falcosecurity/falco-operator/controllers/instance/reference/configmap"
@@ -273,6 +274,15 @@ func main() {
 		mgr.GetClient(), mgr.GetScheme(),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", artifactconfigctr.ControllerName)
+		os.Exit(1)
+	}
+
+	// cache is nil until the centralized artifact blob cache is wired up (a later PR); Plugin
+	// pre-fetches are then skipped and per-node artifact operators pull directly.
+	if err := artifactpluginctr.NewPluginAggregatorReconciler(
+		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("instance-artifact-plugin"), nil,
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", artifactpluginctr.ControllerName)
 		os.Exit(1)
 	}
 

--- a/controllers/instance/artifact/config/controller.go
+++ b/controllers/instance/artifact/config/controller.go
@@ -80,11 +80,16 @@ func (r *ConfigAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, r.handleDeletion(ctx, config)
 	}
 
-	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, config.Spec.Selector, config.Namespace)
+	allMatchingNodes, err := controllerhelper.ListMatchingNodes(ctx, r.Client, config.Spec.Selector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	logger.V(1).Info("Listed matching nodes", "count", len(matchingNodes))
+	runningFalcoNodes, err := controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, config.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	matchingNodes := controllerhelper.FilterNodesByName(allMatchingNodes, runningFalcoNodes)
+	logger.V(1).Info("Listed matching nodes", "total", len(allMatchingNodes), "withFalco", len(matchingNodes))
 
 	existingNodes, err := controllerhelper.ListOwnedNodes(ctx, r.Client, config.Namespace, config.Name, controllerhelper.KindConfig)
 	if err != nil {
@@ -97,7 +102,9 @@ func (r *ConfigAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		desired[matchingNodes[i].Name] = struct{}{}
 	}
 
-	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desired); err != nil {
+	if err := controllerhelper.DeleteStaleNodeObjects(
+		ctx, r.Client, existingNodes.Items, desired, runningFalcoNodes,
+	); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -164,7 +171,17 @@ func (r *ConfigAggregatorReconciler) handleDeletion(ctx context.Context, config 
 		return err
 	}
 
-	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	runningFalcoNodes := map[string]struct{}{}
+	if len(existing.Items) > 0 {
+		runningFalcoNodes, err = controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, config.Namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(
+		ctx, r.Client, existing.Items, runningFalcoNodes,
+	)
 	if err != nil {
 		return err
 	}
@@ -192,15 +209,16 @@ func (r *ConfigAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.ConfigList{})
 			}),
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.LabelChangedPredicate{},
+			)),
 		).
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.ConfigList{}, client.InNamespace(pod.GetNamespace()))
 			}),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
-				return ok
-			})),
+			builder.WithPredicates(controllerhelper.FalcoPodChangePredicate()),
 		).
 		Watches(&artifactv1alpha1.ArtifactNode{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Config{}),

--- a/controllers/instance/artifact/config/controller_test.go
+++ b/controllers/instance/artifact/config/controller_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,17 +95,6 @@ func newTestConfigNode(opts ...func(*artifactv1alpha1.ArtifactNode)) *artifactv1
 func newTestReconciler(t *testing.T, objs ...client.Object) (*ConfigAggregatorReconciler, client.Client) {
 	t.Helper()
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithObjects(objs...).
-		WithStatusSubresource(&artifactv1alpha1.Config{}).
-		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
-		Build()
-	return NewConfigAggregatorReconciler(cl, s), cl
-}
-
-func newTestReconcilerWithScheme(t *testing.T, s *runtime.Scheme, objs ...client.Object) (*ConfigAggregatorReconciler, client.Client) {
-	t.Helper()
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(objs...).
@@ -318,7 +306,7 @@ func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) 
 			Message: "old result",
 		}}
 	})
-	r, cl := newTestReconciler(t, config, staleNode, newTestNode())
+	r, cl := newTestReconciler(t, config, staleNode, newTestNode(), newTestFalco(), newRunningFalcoPod())
 
 	result, err := r.Reconcile(context.Background(), testutil.Request(testConfigName))
 	require.NoError(t, err)
@@ -437,7 +425,20 @@ func TestReconcile_EnsureInUseFinalizerError(t *testing.T) {
 func TestHandleDeletion_NoNodeObjects(t *testing.T) {
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	config := newTestConfig()
-	_, cl := newTestReconcilerWithScheme(t, s, config)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(config).
+		WithStatusSubresource(&artifactv1alpha1.Config{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*instancev1alpha1.FalcoList); ok {
+					return fmt.Errorf("Falco list should not be called without node objects")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
 	addInUseFinalizer(t, cl, config)
 
 	r := NewConfigAggregatorReconciler(cl, s)
@@ -472,7 +473,7 @@ func TestHandleDeletion_NodeObjectsBeingDeleted(t *testing.T) {
 		n.DeletionTimestamp = &now
 		n.Finalizers = []string{"some-finalizer"} // keeps the object in the fake client after deletion
 	})
-	r, _ := newTestReconciler(t, config, configNode)
+	r, _ := newTestReconciler(t, config, configNode, newTestNode(), newTestFalco(), newRunningFalcoPod())
 
 	// Should return nil and wait (not remove finalizer).
 	err := r.handleDeletion(context.Background(), config)

--- a/controllers/instance/artifact/plugin/controller.go
+++ b/controllers/instance/artifact/plugin/controller.go
@@ -64,15 +64,6 @@ func NewPluginAggregatorReconciler(
 
 // PluginAggregatorReconciler manages ArtifactNode objects and aggregates their
 // conditions into the parent Plugin status.
-//
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/status,verbs=patch;update
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/finalizers,verbs=patch;update
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
 type PluginAggregatorReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -84,6 +75,15 @@ type PluginAggregatorReconciler struct {
 	// ociPuller overrides the OCI puller used in fetchAndCacheArtifactMeta; nil uses the default.
 	ociPuller puller.Puller
 }
+
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/status,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
 
 // Reconcile reconciles a Plugin: ensures ArtifactNode objects exist for matching nodes,
 // removes stale ones, and writes the aggregate conditions back to the Plugin.
@@ -111,13 +111,13 @@ func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	// matchingNodes: subset of allMatchingNodes where a Running Falco pod exists; only these
-	// nodes get ArtifactNode objects (Deployment mode or tainted DaemonSet nodes have no sidecar
-	// on every cluster node, so creating ArtifactNodes there produces stale Pending objects).
-	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, plugin.Spec.Selector, plugin.Namespace)
+	// matchingNodes: subset of allMatchingNodes where a Running Falco pod exists; these are
+	// the nodes that currently have an artifact operator able to reconcile an ArtifactNode.
+	runningFalcoNodes, err := controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, plugin.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	matchingNodes := controllerhelper.FilterNodesByName(allMatchingNodes, runningFalcoNodes)
 	logger.V(1).Info("Listed matching nodes", "total", len(allMatchingNodes), "withFalco", len(matchingNodes))
 
 	existingNodes, err := controllerhelper.ListOwnedNodes(ctx, r.Client, plugin.Namespace, plugin.Name, controllerhelper.KindPlugin)
@@ -137,16 +137,17 @@ func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// Use allMatchingNodes (not matchingNodes) so that a pod restart, which briefly leaves
-	// matchingNodes empty, does not cause existing ArtifactNodes to be deleted and re-created.
-	// A temporarily absent Running pod does not mean the node has stopped hosting Falco.
-	// ArtifactNodes are only deleted when the node no longer matches the selector at all.
-	desiredForDeletion := make(map[string]struct{}, len(allMatchingNodes))
-	for i := range allMatchingNodes {
-		desiredForDeletion[allMatchingNodes[i].Name] = struct{}{}
+	// ArtifactNode existence is the desired per-node assignment. Use the same set for
+	// creation, stale deletion, and status aggregation. If a Falco pod moves away, its old
+	// ArtifactNode is removed; a later pod on that node causes it to be created again.
+	desired := make(map[string]struct{}, len(matchingNodes))
+	for i := range matchingNodes {
+		desired[matchingNodes[i].Name] = struct{}{}
 	}
 
-	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desiredForDeletion); err != nil {
+	if err := controllerhelper.DeleteStaleNodeObjects(
+		ctx, r.Client, existingNodes.Items, desired, runningFalcoNodes,
+	); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -181,8 +182,8 @@ func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	// Pulls the OCI binary for every platform present in matching nodes before creating ArtifactNode
-	// objects, so the blob cache is warm when the per-node operator requests it over HTTP.
+	// Pulls the OCI binary for every platform present in selector-matching nodes before creating
+	// ArtifactNode objects, so the blob cache is warm when the per-node operator requests it over HTTP.
 	// If the pre-fetch fails, node creation still proceeds: the per-node operator fetches
 	// independently and surfaces any failure in its own conditions.
 	fetchBinErr := r.fetchAndCacheBlobs(ctx, plugin, allMatchingNodes)
@@ -215,10 +216,6 @@ func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// A stale or terminating child no longer represents the desired assignment and must not
 	// keep its last condition in the aggregate while deletion is pending.
-	desired := make(map[string]struct{}, len(matchingNodes))
-	for i := range matchingNodes {
-		desired[matchingNodes[i].Name] = struct{}{}
-	}
 	activeNodes := &artifactv1alpha1.ArtifactNodeList{}
 	for i := range existingNodes.Items {
 		nodeObject := &existingNodes.Items[i]
@@ -314,7 +311,17 @@ func (r *PluginAggregatorReconciler) handleDeletion(ctx context.Context, plugin 
 		return err
 	}
 
-	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	runningFalcoNodes := map[string]struct{}{}
+	if len(existing.Items) > 0 {
+		runningFalcoNodes, err = controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, plugin.Namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(
+		ctx, r.Client, existing.Items, runningFalcoNodes,
+	)
 	if err != nil {
 		return err
 	}
@@ -347,15 +354,16 @@ func (r *PluginAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.PluginList{})
 			}),
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.LabelChangedPredicate{},
+			)),
 		).
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.PluginList{}, client.InNamespace(pod.GetNamespace()))
 			}),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
-				return ok
-			})),
+			builder.WithPredicates(controllerhelper.FalcoPodChangePredicate()),
 		).
 		Watches(&artifactv1alpha1.ArtifactNode{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Plugin{}),

--- a/controllers/instance/artifact/plugin/controller.go
+++ b/controllers/instance/artifact/plugin/controller.go
@@ -1,0 +1,439 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin implements the Plugin node-object aggregator controller.
+// It runs in the instance operator (singleton Deployment) and is responsible for:
+//   - Creating one ArtifactNode per cluster node that matches the Plugin selector.
+//   - Deleting ArtifactNode objects when a node no longer matches.
+//   - Fetching and caching the OCI artifact's requirements/dependencies as
+//     Status.ArtifactMeta, and pre-fetching its binary blob into the shared cache.
+//   - Aggregating per-node conditions into the parent Plugin status (sole writer).
+//   - Managing the NodeObjectsInUseFinalizer on the parent Plugin.
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+// ControllerName identifies this controller in logs and as the SSA field manager.
+const ControllerName = "instance-artifact-plugin"
+
+// NewPluginAggregatorReconciler returns a new PluginAggregatorReconciler.
+// cache is the shared artifact blob cache also used by the artifact HTTP server.
+// Pass nil to disable local caching (direct-pull mode).
+func NewPluginAggregatorReconciler(
+	cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder, cache *artifactcache.Cache,
+) *PluginAggregatorReconciler {
+	return &PluginAggregatorReconciler{Client: cl, Scheme: scheme, recorder: recorder, cache: cache}
+}
+
+// PluginAggregatorReconciler manages ArtifactNode objects and aggregates their
+// conditions into the parent Plugin status.
+//
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/status,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
+type PluginAggregatorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// recorder emits events on the parent Plugin, notably for ArtifactMeta fetch failures in
+	// fetchAndCacheArtifactMeta.
+	recorder events.EventRecorder
+	// cache is the shared artifact blob cache. Nil disables local caching.
+	cache *artifactcache.Cache
+	// ociPuller overrides the OCI puller used in fetchAndCacheArtifactMeta; nil uses the default.
+	ociPuller puller.Puller
+}
+
+// Reconcile reconciles a Plugin: ensures ArtifactNode objects exist for matching nodes,
+// removes stale ones, and writes the aggregate conditions back to the Plugin.
+func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling Plugin")
+
+	plugin := &artifactv1alpha1.Plugin{}
+	if err := r.Get(ctx, req.NamespacedName, plugin); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Deletion is gated by NodeObjectsInUseFinalizer, which stays set while owned ArtifactNode
+	// objects exist. A per-node artifact operator keeps its ArtifactNode's finalizer in place as
+	// long as a Rulesfile on that node still depends on this plugin.
+	if !plugin.DeletionTimestamp.IsZero() {
+		logger.V(1).Info("Plugin marked for deletion, running cleanup")
+		return ctrl.Result{}, r.handleDeletion(ctx, plugin)
+	}
+
+	// allMatchingNodes: all nodes matching the selector, used for blob pre-fetching (all
+	// platforms) and the in-use finalizer (ensures eviction runs even when no Falco pods land
+	// on a node, e.g. a KWOK fake arm64 node in artifact-cache-lifecycle).
+	allMatchingNodes, err := controllerhelper.ListMatchingNodes(ctx, r.Client, plugin.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// matchingNodes: subset of allMatchingNodes where a Running Falco pod exists; only these
+	// nodes get ArtifactNode objects (Deployment mode or tainted DaemonSet nodes have no sidecar
+	// on every cluster node, so creating ArtifactNodes there produces stale Pending objects).
+	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, plugin.Spec.Selector, plugin.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed matching nodes", "total", len(allMatchingNodes), "withFalco", len(matchingNodes))
+
+	existingNodes, err := controllerhelper.ListOwnedNodes(ctx, r.Client, plugin.Namespace, plugin.Name, controllerhelper.KindPlugin)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed existing ArtifactNode objects", "count", len(existingNodes.Items))
+
+	// Keep the parent alive when nodes are desired or until every existing child is
+	// physically gone. The desired-node check also covers a just-created child that the
+	// informer cache may not expose in the immediate re-list yet.
+	if err := controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, plugin,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		len(allMatchingNodes) > 0 || len(existingNodes.Items) > 0,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Use allMatchingNodes (not matchingNodes) so that a pod restart, which briefly leaves
+	// matchingNodes empty, does not cause existing ArtifactNodes to be deleted and re-created.
+	// A temporarily absent Running pod does not mean the node has stopped hosting Falco.
+	// ArtifactNodes are only deleted when the node no longer matches the selector at all.
+	desiredForDeletion := make(map[string]struct{}, len(allMatchingNodes))
+	for i := range allMatchingNodes {
+		desiredForDeletion[allMatchingNodes[i].Name] = struct{}{}
+	}
+
+	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desiredForDeletion); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Snapshot before any status mutation so we can skip the first SSA when nothing changed.
+	oldStatus := plugin.Status.DeepCopy()
+
+	// Fetch OCI config layer once and cache it in parent.Status.ArtifactMeta so that
+	// per-node artifact operators can read requirements without hitting the registry.
+	if err := r.fetchAndCacheArtifactMeta(ctx, plugin); err != nil {
+		// Surfaces the failure directly on the parent Plugin status. ObservedGeneration is not
+		// advanced, so enforce-mode per-node operators stay deferred, and no ArtifactNodes are
+		// created since they cannot be programmed without metadata.
+		apimeta.SetStatusCondition(&plugin.Status.Conditions, metav1.Condition{
+			Type:               commonv1alpha1.ConditionProgrammed.String(),
+			Status:             metav1.ConditionFalse,
+			Reason:             artifact.ReasonOCIArtifactProgramFailed,
+			Message:            fmt.Sprintf("Failed to fetch OCI artifact metadata: %s", err.Error()),
+			ObservedGeneration: plugin.Generation,
+		})
+		if patchErr := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, plugin, ControllerName); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Stamps ObservedGeneration so per-node operators know this spec generation has been processed.
+	// Written in the same SSA patch as ArtifactMeta so ObservedGeneration never advances ahead of it.
+	plugin.Status.ObservedGeneration = plugin.Generation
+	if !apiequality.Semantic.DeepEqual(*oldStatus, plugin.Status) {
+		if err := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, plugin, ControllerName); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Pulls the OCI binary for every platform present in matching nodes before creating ArtifactNode
+	// objects, so the blob cache is warm when the per-node operator requests it over HTTP.
+	// If the pre-fetch fails, node creation still proceeds: the per-node operator fetches
+	// independently and surfaces any failure in its own conditions.
+	fetchBinErr := r.fetchAndCacheBlobs(ctx, plugin, allMatchingNodes)
+
+	// Re-checks deletion status right before creating node objects; see IsBeingDeleted's doc.
+	if deleting, err := controllerhelper.IsBeingDeleted(ctx, r.Client, plugin); err != nil {
+		return ctrl.Result{}, err
+	} else if deleting {
+		logger.Info("Plugin marked for deletion; skipping node object creation")
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure an ArtifactNode exists for each matching node.
+	pluginGVK := artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindPlugin)
+	for i := range matchingNodes {
+		if err := controllerhelper.EnsureNodeObject(
+			ctx, r.Client, plugin, pluginGVK, controllerhelper.ArtifactKindPlugin, matchingNodes[i].Name,
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Re-list node objects: EnsureNodeObject may have just created new ones that are
+	// not in the earlier existingNodes snapshot.
+	existingNodes, err = controllerhelper.ListOwnedNodes(ctx, r.Client, plugin.Namespace, plugin.Name, controllerhelper.KindPlugin)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Re-listed ArtifactNode objects", "count", len(existingNodes.Items))
+
+	// A stale or terminating child no longer represents the desired assignment and must not
+	// keep its last condition in the aggregate while deletion is pending.
+	desired := make(map[string]struct{}, len(matchingNodes))
+	for i := range matchingNodes {
+		desired[matchingNodes[i].Name] = struct{}{}
+	}
+	activeNodes := &artifactv1alpha1.ArtifactNodeList{}
+	for i := range existingNodes.Items {
+		nodeObject := &existingNodes.Items[i]
+		if !nodeObject.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if _, ok := desired[nodeObject.Spec.NodeName]; !ok {
+			continue
+		}
+		activeNodes.Items = append(activeNodes.Items, *nodeObject)
+	}
+
+	condSnap := make([]metav1.Condition, len(plugin.Status.Conditions))
+	copy(condSnap, plugin.Status.Conditions)
+	controllerhelper.ComputeAggregateConditions(ctx, plugin, &plugin.Status.Conditions, activeNodes)
+	if !apiequality.Semantic.DeepEqual(condSnap, plugin.Status.Conditions) {
+		if err := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, plugin, ControllerName); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, fetchBinErr
+}
+
+// fetchAndCacheArtifactMeta fetches the OCI config layer for the Plugin's OCI artifact
+// and stores the parsed requirements and dependencies in parent.Status.ArtifactMeta.
+// The result is included in the SSA patch made by updateAggregateConditions.
+// If the artifact has no OCI source, ArtifactMeta is cleared.
+func (r *PluginAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Context, plugin *artifactv1alpha1.Plugin) error {
+	logger := log.FromContext(ctx)
+
+	if plugin.Spec.OCIArtifact == nil {
+		logger.V(4).Info("No OCI artifact configured, clearing ArtifactMeta")
+		plugin.Status.ArtifactMeta = nil
+		return nil
+	}
+
+	specHash, err := artifact.ComputeOCIArtifactSpecHash(plugin.Spec.OCIArtifact)
+	if err != nil {
+		return fmt.Errorf("compute OCI spec hash: %w", err)
+	}
+
+	var opts []artifact.ManagerOption
+	if r.ociPuller != nil {
+		opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
+	}
+	am := artifact.NewManagerWithOptions(r.Client, plugin.Namespace, opts...)
+
+	if artifact.ArtifactMetaCacheHit(plugin.Status.ArtifactMeta, specHash) {
+		return nil
+	}
+
+	ref := artifact.ResolveReference(plugin.Spec.OCIArtifact)
+	logger.Info("Fetching plugin ArtifactMeta from OCI config layer", "ref", ref)
+	fetched, digest, fetchErr := am.FetchConfig(ctx, plugin.Spec.OCIArtifact)
+	if fetchErr != nil {
+		logger.Error(fetchErr, "Unable to fetch plugin OCI config; ArtifactMeta will remain stale", "ref", ref)
+		artifact.RecordWarning(r.recorder, plugin, artifact.ReasonOCIArtifactProgramFailed,
+			"Failed to fetch OCI config layer: %s", fetchErr.Error())
+		return fetchErr
+	}
+
+	meta := &commonv1alpha1.ArtifactMeta{
+		Digest:   digest,
+		SpecHash: specHash,
+	}
+	artifact.AppendConfigLayerRequirements(meta, fetched)
+	artifact.DeduplicateArtifactMeta(meta)
+	logger.Info("Plugin ArtifactMeta updated from OCI config layer",
+		"ref", ref,
+		"digest", digest,
+		"requirements", len(meta.Requirements),
+		"dependencies", len(meta.Dependencies),
+	)
+	plugin.Status.ArtifactMeta = meta
+	return nil
+}
+
+// handleDeletion deletes all ArtifactNode objects so each per-node artifact operator can clean up and
+// remove its own finalizer (skipping this would deadlock: GC cascade only fires after the owner is
+// deleted, but the in-use finalizer keeps the owner alive).
+func (r *PluginAggregatorReconciler) handleDeletion(ctx context.Context, plugin *artifactv1alpha1.Plugin) error {
+	existing, err := controllerhelper.ListOwnedNodes(ctx, r.Client, plugin.Namespace, plugin.Name, controllerhelper.KindPlugin)
+	if err != nil {
+		return err
+	}
+
+	// Surfaces each node's current conditions onto the parent before triggering deletion below,
+	// notably DeletionBlocked, set by a per-node operator refusing removal while a Rulesfile on
+	// that node still depends on this plugin.
+	if err := controllerhelper.UpdateAggregateConditions(
+		ctx, r.Client, r.Scheme, plugin, &plugin.Status.Conditions, existing, ControllerName,
+	); err != nil {
+		return err
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	if err != nil {
+		return err
+	}
+
+	// Evicts this CR's cache entries here, in the last reconcile before the finalizer is
+	// released and the object is removed from etcd.
+	if !nodesRemaining && r.cache != nil {
+		if err := r.cache.RemoveAll(string(artifact.TypePlugin), plugin.Namespace, plugin.Name); err != nil {
+			return fmt.Errorf("evict plugin cache entries: %w", err)
+		}
+	}
+
+	return controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, plugin,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		nodesRemaining,
+	)
+}
+
+// SetupWithManager registers this controller with the manager.
+func (r *PluginAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&artifactv1alpha1.Plugin{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return !obj.GetDeletionTimestamp().IsZero()
+			}),
+		))).
+		Watches(&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.PluginList{})
+			}),
+		).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.PluginList{}, client.InNamespace(pod.GetNamespace()))
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
+				return ok
+			})),
+		).
+		Watches(&artifactv1alpha1.ArtifactNode{},
+			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Plugin{}),
+		).
+		Named(ControllerName).
+		WithLogConstructor(controllerhelper.LogConstructorFor(mgr.GetLogger(), mgr.GetScheme(), ControllerName, &artifactv1alpha1.Plugin{})).
+		Complete(r)
+}
+
+// fetchAndCacheBlobs pulls the plugin binary for every distinct (os, arch) pair present
+// in nodes and stores each blob in the artifact cache. This runs in the instance operator so
+// that per-node artifact-operator sidecars can fetch the pre-extracted binary over HTTP
+// without touching the OCI registry directly.
+//
+// Fast path: fetchAndCacheArtifactMeta already resolved the current digest and wrote it to
+// plugin.Status.ArtifactMeta.Digest. If r.cache already indexes that exact blob, no
+// filesystem or registry access is needed at all. EnsureBlob (which re-resolves the digest)
+// is only called when the cache doesn't already have the answer: first install or after a
+// digest change.
+func (r *PluginAggregatorReconciler) fetchAndCacheBlobs(ctx context.Context, plugin *artifactv1alpha1.Plugin, nodes []corev1.Node) error {
+	if r.cache == nil || plugin.Spec.OCIArtifact == nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	// Collect distinct (os, arch) pairs from node labels.
+	type platform struct{ goos, goarch string }
+	seen := make(map[platform]struct{})
+	for i := range nodes {
+		goos := nodes[i].Labels["kubernetes.io/os"]
+		goarch := nodes[i].Labels["kubernetes.io/arch"]
+		if goos != "" && goarch != "" {
+			seen[platform{goos, goarch}] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	ref := artifact.ResolveReference(plugin.Spec.OCIArtifact)
+
+	var opts []artifact.ManagerOption
+	if r.ociPuller != nil {
+		opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
+	}
+	am := artifact.NewManagerWithOptions(r.Client, plugin.Namespace, opts...)
+
+	for p := range seen {
+		platformKey := p.goos + "-" + p.goarch
+
+		// Fast path: this CR's index already points at the blob for the known digest.
+		// Pure in-memory comparison, no filesystem or registry access on a warm cache.
+		if meta := plugin.Status.ArtifactMeta; meta != nil && meta.Digest != "" {
+			want := artifactcache.BlobPath(r.cache.Dir(), string(artifact.TypePlugin), ref, meta.Digest, p.goos, p.goarch)
+			if current, ok := r.cache.Lookup(string(artifact.TypePlugin), plugin.Namespace, plugin.Name, platformKey); ok && current == want {
+				logger.V(2).Info("Plugin blob already cached", "os", p.goos, "arch", p.goarch, "digest", meta.Digest)
+				continue
+			}
+		}
+
+		// Slow path: cache doesn't already have the answer.
+		// Pass the digest already resolved by fetchAndCacheArtifactMeta to avoid a
+		// second GET /manifests call. Falls back to resolving if digest is not known.
+		var knownDigest string
+		if meta := plugin.Status.ArtifactMeta; meta != nil {
+			knownDigest = meta.Digest
+		}
+		logger.Info("Pulling plugin blob", "os", p.goos, "arch", p.goarch)
+		blobPath, err := am.EnsureBlob(ctx, plugin.Spec.OCIArtifact, artifact.TypePlugin, p.goos, p.goarch, r.cache, knownDigest)
+		if err != nil {
+			return fmt.Errorf("cache plugin blob (%s/%s): %w", p.goos, p.goarch, err)
+		}
+		if err := r.cache.Set(string(artifact.TypePlugin), plugin.Namespace, plugin.Name, platformKey, blobPath); err != nil {
+			return fmt.Errorf("index plugin blob (%s/%s): %w", p.goos, p.goarch, err)
+		}
+	}
+
+	return nil
+}

--- a/controllers/instance/artifact/plugin/controller_test.go
+++ b/controllers/instance/artifact/plugin/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,7 +47,10 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 )
 
-const testPluginName = "test-plugin"
+const (
+	testPluginName   = "test-plugin"
+	testPluginDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
 
 func testPluginNodeName() string {
 	return controllerhelper.NodeObjectName(controllerhelper.ArtifactKindPlugin, testPluginName, testutil.TestNodeName)
@@ -256,6 +260,47 @@ func TestReconcile_CreatesNodeObject(t *testing.T) {
 	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
 }
 
+func TestReconcile_CreatesIndependentNodeObjectsForNamespaces(t *testing.T) {
+	const (
+		deploymentNamespace = "falco-deployment"
+		daemonSetNamespace  = "falco-daemonset"
+	)
+
+	node := newTestNode(testutil.TestNodeName, nil)
+	objects := make([]client.Object, 0, 7)
+	objects = append(objects, node)
+	for _, namespace := range []string{deploymentNamespace, daemonSetNamespace} {
+		plugin := newTestPlugin()
+		plugin.Namespace = namespace
+		falco := newTestFalco()
+		falco.Namespace = namespace
+		pod := newRunningFalcoPod()
+		pod.Namespace = namespace
+		objects = append(objects, plugin, falco, pod)
+	}
+	r, cl := newTestReconciler(t, objects...)
+
+	for _, namespace := range []string{deploymentNamespace, daemonSetNamespace} {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+			Name:      testPluginName,
+			Namespace: namespace,
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		pluginNode := &artifactv1alpha1.ArtifactNode{}
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{
+			Name:      testPluginNodeName(),
+			Namespace: namespace,
+		}, pluginNode))
+		assert.Equal(t, testutil.TestNodeName, pluginNode.Spec.NodeName)
+	}
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Len(t, nodeList.Items, 2)
+}
+
 func TestReconcile_NodeObjectAlreadyExists(t *testing.T) {
 	plugin := newTestPlugin()
 	node := newTestNode(testutil.TestNodeName, nil)
@@ -317,7 +362,9 @@ func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) 
 			Message: "old result",
 		}}
 	})
-	r, cl := newTestReconciler(t, plugin, staleNode, newTestNode(testutil.TestNodeName, nil))
+	r, cl := newTestReconciler(
+		t, plugin, staleNode, newTestNode(testutil.TestNodeName, nil), newTestFalco(), newRunningFalcoPod(),
+	)
 
 	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
 	require.NoError(t, err)
@@ -336,6 +383,26 @@ func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) 
 	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
 	assert.Equal(t, "NoNodesAssigned", condition.Reason,
 		"the stale child's last successful result must not remain in the aggregate")
+}
+
+func TestReconcile_RemovesNodeObjectWhenFalcoPodGone(t *testing.T) {
+	plugin := newTestPlugin(func(p *artifactv1alpha1.Plugin) {
+		p.Finalizers = []string{controllerhelper.NodeObjectsInUseFinalizer}
+	})
+	staleNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"artifact.example.com/node-cleanup"}
+	})
+	// The Kubernetes Node still matches the Plugin selector, but no Falco pod remains there.
+	r, cl := newTestReconciler(t, plugin, staleNode, newTestNode(testutil.TestNodeName, nil))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	err = cl.Get(context.Background(), client.ObjectKeyFromObject(staleNode), got)
+	assert.True(t, k8serrors.IsNotFound(err),
+		"the instance operator must garbage-collect the ArtifactNode when its artifact operator is gone")
 }
 
 func TestReconcile_ListMatchingNodesError(t *testing.T) {
@@ -389,6 +456,14 @@ func TestHandleDeletion_NoNodeObjects(t *testing.T) {
 		WithScheme(s).
 		WithObjects(plugin).
 		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*instancev1alpha1.FalcoList); ok {
+					return fmt.Errorf("Falco list should not be called without node objects")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
 		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
 		Build()
 	addInUseFinalizer(t, cl, plugin)
@@ -963,7 +1038,7 @@ func TestFetchAndCacheBinaries_FastPath(t *testing.T) {
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
 
 	ref := artifact.ResolveReference(plugin.Spec.OCIArtifact)
-	const digest = "sha256:cached"
+	const digest = testPluginDigest
 	blobPath := artifactcache.BlobPath(cacheDir, string(artifact.TypePlugin), ref, digest, "linux", "amd64")
 	require.NoError(t, artifactcache.Store(blobPath, []byte("fake-plugin"), 0o755))
 	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64", blobPath))
@@ -990,8 +1065,8 @@ func TestFetchAndCacheBinaries_SlowPath(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:pulled",
-		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		ResolveDigestResult: testPluginDigest,
+		Result:              &puller.RegistryResult{RootDigest: testPluginDigest, Type: puller.Plugin},
 		LayerContent:        tarGz,
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
@@ -1011,7 +1086,7 @@ func TestFetchAndCacheBinaries_PullError(t *testing.T) {
 	cacheDir := t.TempDir()
 	plugin := newTestPlugin(withPluginOCI())
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:xyz",
+		ResolveDigestResult: testPluginDigest,
 		PullErr:             fmt.Errorf("registry unreachable"),
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
@@ -1031,8 +1106,8 @@ func TestFetchAndCacheBinaries_DeduplicatesPlatforms(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:dup",
-		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		ResolveDigestResult: testPluginDigest,
+		Result:              &puller.RegistryResult{RootDigest: testPluginDigest, Type: puller.Plugin},
 		LayerContent:        tarGz,
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
@@ -1054,8 +1129,8 @@ func TestFetchAndCacheBinaries_MultiplePlatforms(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:multi",
-		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		ResolveDigestResult: testPluginDigest,
+		Result:              &puller.RegistryResult{RootDigest: testPluginDigest, Type: puller.Plugin},
 		LayerContent:        tarGz,
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
@@ -1069,7 +1144,8 @@ func TestFetchAndCacheBinaries_MultiplePlatforms(t *testing.T) {
 
 func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 	// staleNode is stale: the plugin's env=prod selector excludes plainNode. staleNode carries a
-	// finalizer, so ClearFinalizersIfNodeGone calls Node.Get, which the interceptor fails with a
+	// finalizer and a Falco pod still runs there, so orphan detection calls Node.Get; the
+	// interceptor fails that lookup with a
 	// non-404 error that propagates back to Reconcile.
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	plugin := newTestPlugin(withPluginSelector())
@@ -1079,7 +1155,7 @@ func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 	plainNode := newTestNode(testutil.TestNodeName, nil)
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(plugin, staleNode, plainNode).
+		WithObjects(plugin, staleNode, plainNode, newTestFalco(), newRunningFalcoPod()).
 		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -1098,8 +1174,8 @@ func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 }
 
 func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
-	// pluginNode carries a finalizer, so ClearFinalizersIfNodeGone checks the node via Node.Get,
-	// which the interceptor fails with a non-404 error.
+	// pluginNode carries a finalizer and a Falco pod still runs on its node, so orphan detection
+	// checks the Kubernetes Node via Get, which the interceptor fails with a non-404 error.
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	plugin := newTestPlugin()
 	pluginNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
@@ -1107,7 +1183,7 @@ func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
 	})
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(plugin, pluginNode).
+		WithObjects(plugin, pluginNode, newTestFalco(), newRunningFalcoPod()).
 		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -1135,7 +1211,7 @@ func TestReconcile_FetchAndCacheBinariesError(t *testing.T) {
 
 	mockPuller := &puller.MockOCIPuller{
 		ConfigResult: &puller.ArtifactConfig{},
-		ConfigDigest: "sha256:meta",
+		ConfigDigest: testPluginDigest,
 		PullErr:      fmt.Errorf("registry down"),
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin, node, newTestFalco(), newRunningFalcoPod())

--- a/controllers/instance/artifact/plugin/controller_test.go
+++ b/controllers/instance/artifact/plugin/controller_test.go
@@ -1,0 +1,1145 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+const testPluginName = "test-plugin"
+
+func testPluginNodeName() string {
+	return controllerhelper.NodeObjectName(controllerhelper.ArtifactKindPlugin, testPluginName, testutil.TestNodeName)
+}
+
+func testOCIArtifact() *commonv1alpha1.OCIArtifact {
+	return &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "ghcr.io/test/plugin", Tag: "latest"},
+	}
+}
+
+func newTestNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func newTestPlugin(opts ...func(*artifactv1alpha1.Plugin)) *artifactv1alpha1.Plugin {
+	p := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: testPluginName, Namespace: testutil.TestNamespace},
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func withPluginOCI() func(*artifactv1alpha1.Plugin) {
+	return func(p *artifactv1alpha1.Plugin) {
+		p.Spec.OCIArtifact = testOCIArtifact()
+	}
+}
+
+func withPluginSelector() func(*artifactv1alpha1.Plugin) {
+	return func(p *artifactv1alpha1.Plugin) {
+		p.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}
+	}
+}
+
+func newTestPluginNode(opts ...func(*artifactv1alpha1.ArtifactNode)) *artifactv1alpha1.ArtifactNode {
+	isController := true
+	n := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPluginNodeName(),
+			Namespace: testutil.TestNamespace,
+			Labels:    controllerhelper.NodeObjectLabels(controllerhelper.ArtifactKindPlugin, testPluginName, testutil.TestNodeName),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: artifactv1alpha1.GroupVersion.String(),
+				Kind:       "Plugin",
+				Name:       testPluginName,
+				Controller: &isController,
+			}},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*PluginAggregatorReconciler, client.Client) {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	return NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil), cl
+}
+
+func newTestReconcilerWithPuller(t *testing.T, mockPuller puller.Puller, objs ...client.Object) (*PluginAggregatorReconciler, client.Client) {
+	t.Helper()
+	r, cl := newTestReconciler(t, objs...)
+	r.ociPuller = mockPuller
+	return r, cl
+}
+
+func addInUseFinalizer(t *testing.T, cl client.Client, plugin *artifactv1alpha1.Plugin) {
+	t.Helper()
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), plugin))
+	require.NoError(t, controllerhelper.EnsureInUseFinalizer(
+		context.Background(), cl,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		plugin, true,
+	))
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), plugin))
+}
+
+const testFalcoName = "test-falco"
+
+func newTestFalco() *instancev1alpha1.Falco {
+	return &instancev1alpha1.Falco{
+		ObjectMeta: metav1.ObjectMeta{Name: testFalcoName, Namespace: testutil.TestNamespace},
+	}
+}
+
+func newRunningFalcoPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "falco-pod",
+			Namespace: testutil.TestNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/instance": testFalcoName},
+		},
+		Spec:   corev1.PodSpec{NodeName: testutil.TestNodeName},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestReconcile_NotFound(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	result, err := r.Reconcile(context.Background(), testutil.Request("nonexistent"))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcile_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return fmt.Errorf("api server error")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_DeletionNoNodeObjects(t *testing.T) {
+	// A finalizer makes cl.Delete set DeletionTimestamp on the object rather than removing it.
+	plugin := newTestPlugin(func(p *artifactv1alpha1.Plugin) {
+		p.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	r, cl := newTestReconciler(t, plugin)
+
+	require.NoError(t, cl.Delete(context.Background(), plugin))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// No PluginNodes should exist.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletionWithNodeObjects(t *testing.T) {
+	// A finalizer makes cl.Delete set DeletionTimestamp on the object rather than removing it.
+	plugin := newTestPlugin(func(p *artifactv1alpha1.Plugin) {
+		p.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	pluginNode := newTestPluginNode()
+	r, cl := newTestReconciler(t, plugin, pluginNode)
+
+	require.NoError(t, cl.Delete(context.Background(), plugin))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// PluginNode should be deleted.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_NoMatchingNodes(t *testing.T) {
+	plugin := newTestPlugin()
+	r, cl := newTestReconciler(t, plugin)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+}
+
+func TestReconcile_CreatesNodeObject(t *testing.T) {
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	r, cl := newTestReconciler(t, plugin, node, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	pluginNode := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testPluginNodeName(), Namespace: testutil.TestNamespace}, pluginNode))
+	assert.Equal(t, testutil.TestNodeName, pluginNode.Spec.NodeName)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestReconcile_NodeObjectAlreadyExists(t *testing.T) {
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	existing := newTestPluginNode()
+	r, cl := newTestReconciler(t, plugin, node, existing, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	list := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), list))
+	assert.Len(t, list.Items, 1)
+}
+
+func TestReconcile_NoFalcoPod_NoNodeObject(t *testing.T) {
+	// Node matches the artifact selector but no Falco pod is running on it.
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	r, cl := newTestReconciler(t, plugin, node) // no Falco CR or pod
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletesStaleNodeObject(t *testing.T) {
+	plugin := newTestPlugin(withPluginSelector())
+	staleNode := newTestPluginNode()
+	plainNode := newTestNode(testutil.TestNodeName, nil)
+	r, cl := newTestReconciler(t, plugin, staleNode, plainNode)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) {
+	plugin := newTestPlugin(
+		withPluginSelector(),
+		func(p *artifactv1alpha1.Plugin) {
+			p.Finalizers = []string{controllerhelper.NodeObjectsInUseFinalizer}
+		},
+	)
+	staleNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"artifact.example.com/node-cleanup"}
+		n.Status.Conditions = []metav1.Condition{{
+			Type:    commonv1alpha1.ConditionProgrammed.String(),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Programmed",
+			Message: "old result",
+		}}
+	})
+	r, cl := newTestReconciler(t, plugin, staleNode, newTestNode(testutil.TestNodeName, nil))
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	terminating := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(staleNode), terminating))
+	assert.False(t, terminating.DeletionTimestamp.IsZero(), "the node-side finalizer keeps the stale child terminating")
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer,
+		"the parent must stay alive until the terminating child is physically gone")
+	condition := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+	assert.Equal(t, "NoNodesAssigned", condition.Reason,
+		"the stale child's last successful result must not remain in the aggregate")
+}
+
+func TestReconcile_ListMatchingNodesError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NodeList); ok {
+					return fmt.Errorf("node list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_ListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("plugin node list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestHandleDeletion_NoNodeObjects(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	addInUseFinalizer(t, cl, plugin)
+
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	assert.NotContains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestHandleDeletion_NodeObjectsPresent(t *testing.T) {
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode()
+	r, cl := newTestReconciler(t, plugin, pluginNode)
+
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+
+	node := &artifactv1alpha1.ArtifactNode{}
+	err = cl.Get(context.Background(),
+		types.NamespacedName{Name: testPluginNodeName(), Namespace: testutil.TestNamespace}, node)
+	assert.Error(t, err)
+}
+
+func TestHandleDeletion_EvictsCacheEntries(t *testing.T) {
+	plugin := newTestPlugin()
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, plugin)
+
+	// An exclusively-referenced blob: gone once this CR's last node object disappears.
+	ownBlob := filepath.Join(cacheDir, "blobs", "own")
+	require.NoError(t, artifactcache.Store(ownBlob, []byte("x"), 0o755))
+	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64", ownBlob))
+
+	// A blob shared with another CR: refcount drops but the file survives.
+	sharedBlob := filepath.Join(cacheDir, "blobs", "shared")
+	require.NoError(t, artifactcache.Store(sharedBlob, []byte("y"), 0o755))
+	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-arm64", sharedBlob))
+	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, "other-plugin", "", sharedBlob))
+
+	// No ArtifactNode objects owned by this Plugin exist, so handleDeletion evicts the cache entries now.
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+
+	_, ok := r.cache.Lookup(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64")
+	assert.False(t, ok)
+	_, err = os.Stat(ownBlob)
+	assert.True(t, os.IsNotExist(err), "exclusively-referenced blob must be removed from disk")
+
+	got, ok := r.cache.Lookup(string(artifact.TypePlugin), testutil.TestNamespace, "other-plugin", "")
+	require.True(t, ok, "other CR's entry for the shared blob must survive")
+	assert.Equal(t, sharedBlob, got)
+	_, err = os.Stat(sharedBlob)
+	assert.NoError(t, err, "shared blob must survive: another CR still references it")
+}
+
+func TestHandleDeletion_NodesRemaining_DoesNotEvictCache(t *testing.T) {
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode()
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, plugin, pluginNode)
+
+	blobPath := filepath.Join(cacheDir, "blobs", "own")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o755))
+	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64", blobPath))
+
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+
+	got, ok := r.cache.Lookup(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64")
+	require.True(t, ok, "cache entry must survive while a node object still exists")
+	assert.Equal(t, blobPath, got)
+}
+
+func TestHandleDeletion_SurfacesDeletionBlockedCondition(t *testing.T) {
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Status.Conditions = []metav1.Condition{
+			{
+				Type:    commonv1alpha1.ConditionDeletionBlocked.String(),
+				Status:  metav1.ConditionTrue,
+				Reason:  artifact.ReasonPluginConfigStillRequired,
+				Message: `"container" is still required by [{Rulesfile some-rulesfile}]`,
+			},
+		}
+	})
+	r, cl := newTestReconciler(t, plugin, pluginNode)
+
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionDeletionBlocked.String())
+	require.NotNil(t, cond, "aggregator must surface the per-node DeletionBlocked condition onto the parent Plugin")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, artifact.ReasonPluginConfigStillRequired, cond.Reason)
+}
+
+func TestHandleDeletion_NodeObjectsBeingDeleted(t *testing.T) {
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		now := metav1.Now()
+		n.DeletionTimestamp = &now
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	r, _ := newTestReconciler(t, plugin, pluginNode)
+
+	err := r.handleDeletion(context.Background(), plugin)
+	require.NoError(t, err)
+}
+
+func TestHandleDeletion_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+
+	err := r.handleDeletion(context.Background(), plugin)
+	require.Error(t, err)
+}
+
+func TestEnsureNodeObject_AlreadyExists(t *testing.T) {
+	plugin := newTestPlugin()
+	existing := newTestPluginNode()
+	r, cl := newTestReconciler(t, plugin, existing)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, plugin,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindPlugin), controllerhelper.ArtifactKindPlugin, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	list := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), list))
+	assert.Len(t, list.Items, 1)
+}
+
+func TestEnsureNodeObject_Creates(t *testing.T) {
+	plugin := newTestPlugin()
+	r, cl := newTestReconciler(t, plugin)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, plugin,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindPlugin), controllerhelper.ArtifactKindPlugin, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	created := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testPluginNodeName(), Namespace: testutil.TestNamespace}, created))
+	assert.Equal(t, testutil.TestNodeName, created.Spec.NodeName)
+}
+
+func TestEnsureNodeObject_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("get error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, plugin,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindPlugin), controllerhelper.ArtifactKindPlugin, testutil.TestNodeName)
+	require.Error(t, err)
+}
+
+func TestUpdateAggregateConditions_Empty(t *testing.T) {
+	plugin := newTestPlugin()
+	r, cl := newTestReconciler(t, plugin)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	err := controllerhelper.UpdateAggregateConditions(
+		context.Background(), r.Client, r.Scheme, plugin, &plugin.Status.Conditions, nodeList, ControllerName,
+	)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+	assert.Equal(t, "NoNodesAssigned", cond.Reason)
+}
+
+func TestUpdateAggregateConditions_WithNodeConditions(t *testing.T) {
+	plugin := newTestPlugin()
+	r, cl := newTestReconciler(t, plugin)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{
+		Items: []artifactv1alpha1.ArtifactNode{
+			{
+				Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+				Status: artifactv1alpha1.ArtifactNodeStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    commonv1alpha1.ConditionProgrammed.String(),
+							Status:  metav1.ConditionTrue,
+							Reason:  "Programmed",
+							Message: "ok",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := controllerhelper.UpdateAggregateConditions(
+		context.Background(), r.Client, r.Scheme, plugin, &plugin.Status.Conditions, nodeList, ControllerName,
+	)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Plugin{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(plugin), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+}
+
+func TestFetchAndCacheArtifactMeta_NoOCI(t *testing.T) {
+	plugin := newTestPlugin()
+	r, _ := newTestReconciler(t, plugin)
+
+	plugin.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{Digest: "old"}
+	err := r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.NoError(t, err)
+	assert.Nil(t, plugin.Status.ArtifactMeta)
+}
+
+func TestFetchAndCacheArtifactMeta_CacheHit(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{}
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+
+	specHash, err := artifact.ComputeOCIArtifactSpecHash(plugin.Spec.OCIArtifact)
+	require.NoError(t, err)
+	plugin.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{
+		SpecHash: specHash,
+		Digest:   "sha256:abc123",
+	}
+
+	err = r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.NoError(t, err)
+	assert.Empty(t, mockPuller.FetchConfigCalls)
+	assert.Equal(t, "sha256:abc123", plugin.Status.ArtifactMeta.Digest)
+}
+
+func TestFetchAndCacheArtifactMeta_CacheHitIgnoresDigest(t *testing.T) {
+	// Spec hash matches even though the stored digest is stale, so the cache is still a hit.
+	// Picking up a new image pushed to the same tag requires an explicit spec change.
+	mockPuller := &puller.MockOCIPuller{}
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+
+	specHash, err := artifact.ComputeOCIArtifactSpecHash(plugin.Spec.OCIArtifact)
+	require.NoError(t, err)
+	plugin.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{
+		SpecHash: specHash,
+		Digest:   "sha256:old",
+	}
+
+	err = r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.NoError(t, err)
+	assert.Empty(t, mockPuller.FetchConfigCalls, "spec hash match must skip FetchConfig regardless of digest")
+	assert.Equal(t, "sha256:old", plugin.Status.ArtifactMeta.Digest, "stale digest must not be updated on cache hit")
+}
+
+func TestFetchAndCacheArtifactMeta_NoCacheNoStatus(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{},
+		ConfigDigest: "sha256:fresh",
+	}
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.NoError(t, err)
+	assert.Len(t, mockPuller.FetchConfigCalls, 1)
+	require.NotNil(t, plugin.Status.ArtifactMeta)
+	assert.Equal(t, "sha256:fresh", plugin.Status.ArtifactMeta.Digest)
+}
+
+func TestFetchAndCacheArtifactMeta_FetchConfigError(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		FetchConfigErr: fmt.Errorf("registry unavailable"),
+	}
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry unavailable")
+	// Records a Warning event on the Plugin describing the OCI config fetch failure.
+	testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events,
+		[]string{"Warning OCIArtifactProgramFailed Failed to fetch OCI config layer: registry unavailable"})
+}
+
+func TestFetchAndCacheArtifactMeta_WithDependencies(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Dependencies: []puller.ArtifactDependency{
+				{
+					Name:    "json",
+					Version: ">=0.7.0",
+					Alternatives: []puller.Dependency{
+						{Name: "json-alt", Version: ">=0.6.0"},
+					},
+				},
+			},
+		},
+		ConfigDigest: "sha256:deps",
+	}
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), plugin)
+	require.NoError(t, err)
+	require.NotNil(t, plugin.Status.ArtifactMeta)
+	require.Len(t, plugin.Status.ArtifactMeta.Dependencies, 1)
+	assert.Equal(t, "json", plugin.Status.ArtifactMeta.Dependencies[0].Name)
+	require.Len(t, plugin.Status.ArtifactMeta.Dependencies[0].Alternatives, 1)
+	assert.Equal(t, "json-alt", plugin.Status.ArtifactMeta.Dependencies[0].Alternatives[0].Name)
+}
+
+func TestFindPluginsForNode(t *testing.T) {
+	plugin := newTestPlugin()
+	r, _ := newTestReconciler(t, plugin)
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), r.Client, &artifactv1alpha1.PluginList{})
+	require.Len(t, reqs, 1)
+	assert.Equal(t, testPluginName, reqs[0].Name)
+}
+
+func TestFindPluginsForNode_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.PluginList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.PluginList{})
+	assert.Nil(t, reqs)
+}
+
+func TestFindPluginsForNode_EmptyList(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), r.Client, &artifactv1alpha1.PluginList{})
+	assert.Empty(t, reqs)
+}
+
+// ── Reconcile remaining error paths ─────────────────────────────────────────
+
+func TestReconcile_DeleteStaleNodeError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	// Selector requires env=prod; existing PluginNode is for a node without that label → stale.
+	plugin := newTestPlugin(withPluginSelector())
+	staleNode := newTestPluginNode()
+	plainNode := newTestNode(testutil.TestNodeName, nil)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, staleNode, plainNode).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("delete failed")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_EnsureNodeObjectError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, node, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("create failed")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_EnsureInUseFinalizerError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	pluginNode := newTestPluginNode() // makes ensureNodeObject a no-op
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, node, pluginNode, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("patch failed")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_SecondListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	node := newTestNode(testutil.TestNodeName, nil)
+	pluginNode := newTestPluginNode() // existing PluginNode makes ensureNodeObject a no-op
+	var listCount int
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, node, pluginNode).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					listCount++
+					if listCount == 2 {
+						return fmt.Errorf("second list error")
+					}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+func TestReconcile_FetchAndCacheError(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		FetchConfigErr: fmt.Errorf("registry down"),
+	}
+	plugin := newTestPlugin(withPluginOCI())
+	node := newTestNode(testutil.TestNodeName, nil)
+	pluginNode := newTestPluginNode() // pre-existing
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin, node, pluginNode)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+}
+
+// ── handleDeletion delete error ──────────────────────────────────────────────
+
+func TestHandleDeletion_DeleteError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, pluginNode).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), plugin)
+	require.Error(t, err)
+}
+
+// ── fetchAndCacheBlobs tests ──────────────────────────────────────────────
+
+// newTestReconcilerWithCacheAndPuller creates a PluginAggregatorReconciler with a real,
+// loaded artifact Cache rooted at cacheDir, and an injected mock OCI puller.
+func newTestReconcilerWithCacheAndPuller(
+	t *testing.T, mockPuller puller.Puller, cacheDir string, objs ...client.Object,
+) *PluginAggregatorReconciler {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	// Zero grace period: dereferenced blobs are removed from disk immediately.
+	cache := artifactcache.NewCache(cacheDir, artifactcache.WithEvictionGracePeriod(0))
+	require.NoError(t, cache.Load())
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), cache)
+	r.ociPuller = mockPuller
+	return r
+}
+
+func TestFetchAndCacheBinaries_NoCache(t *testing.T) {
+	// A nil cache disables caching; fetchAndCacheBlobs returns immediately.
+	plugin := newTestPlugin(withPluginOCI())
+	r, _ := newTestReconciler(t, plugin) // cache = nil
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	err := r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node})
+	require.NoError(t, err)
+}
+
+func TestFetchAndCacheBinaries_NoOCIArtifact(t *testing.T) {
+	// No OCI spec → noop regardless of cacheDir.
+	plugin := newTestPlugin() // no OCIArtifact
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, plugin)
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	err := r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node})
+	require.NoError(t, err)
+}
+
+func TestFetchAndCacheBinaries_NoOSArchLabels(t *testing.T) {
+	// Nodes without kubernetes.io/os or kubernetes.io/arch labels → empty platform set → noop.
+	plugin := newTestPlugin(withPluginOCI())
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, plugin)
+	node := newTestNode(testutil.TestNodeName, nil)
+	err := r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node})
+	require.NoError(t, err)
+}
+
+func TestFetchAndCacheBinaries_FastPath(t *testing.T) {
+	// This CR's cache entry already points at the blob for the known digest: no registry
+	// call needed.
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+	mockPuller := &puller.MockOCIPuller{} // must not be called
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
+
+	ref := artifact.ResolveReference(plugin.Spec.OCIArtifact)
+	const digest = "sha256:cached"
+	blobPath := artifactcache.BlobPath(cacheDir, string(artifact.TypePlugin), ref, digest, "linux", "amd64")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("fake-plugin"), 0o755))
+	require.NoError(t, r.cache.Set(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64", blobPath))
+
+	plugin.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{Digest: digest}
+
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	require.NoError(t, r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node}))
+
+	assert.Empty(t, mockPuller.ResolveDigestCalls)
+	assert.Empty(t, mockPuller.PullCalls)
+
+	idx, ok := r.cache.Lookup(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64")
+	require.True(t, ok)
+	assert.Equal(t, blobPath, idx)
+}
+
+func TestFetchAndCacheBinaries_SlowPath(t *testing.T) {
+	// Blob is missing: EnsureBlob pulls from registry and writes the index.
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+
+	tarGz, err := puller.MakeTarGz("plugin.so", []byte("plugin-binary-content"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:pulled",
+		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		LayerContent:        tarGz,
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
+
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	require.NoError(t, r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node}))
+
+	require.Len(t, mockPuller.PullCalls, 1)
+	assert.Equal(t, "linux", mockPuller.PullCalls[0].OS)
+	assert.Equal(t, "amd64", mockPuller.PullCalls[0].Arch)
+
+	_, ok := r.cache.Lookup(string(artifact.TypePlugin), testutil.TestNamespace, testPluginName, "linux-amd64")
+	require.True(t, ok)
+}
+
+func TestFetchAndCacheBinaries_PullError(t *testing.T) {
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:xyz",
+		PullErr:             fmt.Errorf("registry unreachable"),
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
+
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	err := r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry unreachable")
+}
+
+func TestFetchAndCacheBinaries_DeduplicatesPlatforms(t *testing.T) {
+	// Two nodes with the same (os, arch) should trigger only one pull.
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+
+	tarGz, err := puller.MakeTarGz("plugin.so", []byte("data"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:dup",
+		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		LayerContent:        tarGz,
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
+
+	labels := map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"}
+	node1 := newTestNode("node-1", labels)
+	node2 := newTestNode("node-2", labels)
+
+	require.NoError(t, r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node1, *node2}))
+	assert.Len(t, mockPuller.PullCalls, 1)
+}
+
+func TestFetchAndCacheBinaries_MultiplePlatforms(t *testing.T) {
+	// Two nodes with different (os, arch) pairs must each trigger a pull.
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+
+	tarGz, err := puller.MakeTarGz("plugin.so", []byte("data"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:multi",
+		Result:              &puller.RegistryResult{Type: puller.Plugin},
+		LayerContent:        tarGz,
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin)
+
+	node1 := newTestNode("node-1", map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+	node2 := newTestNode("node-2", map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "arm64"})
+
+	require.NoError(t, r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node1, *node2}))
+	assert.Len(t, mockPuller.PullCalls, 2)
+}
+
+func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
+	// staleNode is stale: the plugin's env=prod selector excludes plainNode. staleNode carries a
+	// finalizer, so ClearFinalizersIfNodeGone calls Node.Get, which the interceptor fails with a
+	// non-404 error that propagates back to Reconcile.
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin(withPluginSelector())
+	staleNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	plainNode := newTestNode(testutil.TestNodeName, nil)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, staleNode, plainNode).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					return fmt.Errorf("node lookup error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node lookup error")
+}
+
+func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
+	// pluginNode carries a finalizer, so ClearFinalizersIfNodeGone checks the node via Node.Get,
+	// which the interceptor fails with a non-404 error.
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	plugin := newTestPlugin()
+	pluginNode := newTestPluginNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(plugin, pluginNode).
+		WithStatusSubresource(&artifactv1alpha1.Plugin{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					return fmt.Errorf("node lookup error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewPluginAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), plugin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node lookup error")
+}
+
+func TestReconcile_FetchAndCacheBinariesError(t *testing.T) {
+	// fetchAndCacheArtifactMeta succeeds and sets Status.ArtifactMeta.Digest.
+	// fetchAndCacheBlobs uses that digest as knownDigest → skips ResolveDigest,
+	// goes straight to Pull → Pull fails.
+	cacheDir := t.TempDir()
+	plugin := newTestPlugin(withPluginOCI())
+	node := newTestNode(testutil.TestNodeName, map[string]string{"kubernetes.io/os": "linux", "kubernetes.io/arch": "amd64"})
+
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{},
+		ConfigDigest: "sha256:meta",
+		PullErr:      fmt.Errorf("registry down"),
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, plugin, node, newTestFalco(), newRunningFalcoPod())
+	_, err := r.Reconcile(context.Background(), testutil.Request(testPluginName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry down")
+}

--- a/internal/pkg/artifact/conditions.go
+++ b/internal/pkg/artifact/conditions.go
@@ -28,6 +28,9 @@ const (
 	ReasonReferenceResolutionFailed = "ReferenceResolutionFailed"
 	// ReasonOCIArtifactProgramFailed indicates the OCI-sourced artifact failed to store.
 	ReasonOCIArtifactProgramFailed = "OCIArtifactProgramFailed"
+	// ReasonPluginConfigStillRequired indicates a plugin's on-disk config/binary removal is
+	// being withheld because a Rulesfile on this node still structurally depends on it.
+	ReasonPluginConfigStillRequired = "PluginConfigStillRequired"
 	// ReasonOCIArtifactStored indicates the OCI artifact was stored successfully.
 	ReasonOCIArtifactStored = "OCIArtifactStored"
 	// ReasonOCIArtifactUpdated indicates the OCI artifact was updated successfully.

--- a/internal/pkg/controllerhelper/node.go
+++ b/internal/pkg/controllerhelper/node.go
@@ -132,6 +132,24 @@ func listFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace 
 	return running, nil
 }
 
+// IsBeingDeleted re-fetches obj and reports whether it now has a DeletionTimestamp set, or is
+// gone entirely, which is treated the same way since there is nothing left to create against.
+//
+// Use this as a final check immediately before creating a child object, after any slow,
+// network-bound work (OCI registry calls, blob pulls) that ran since the initial
+// DeletionTimestamp check at the top of Reconcile (that earlier check can go stale if an
+// external delete lands while the reconcile is busy).
+func IsBeingDeleted(ctx context.Context, cl client.Client, obj client.Object) (bool, error) {
+	fresh := obj.DeepCopyObject().(client.Object) //nolint:forcetypeassert // client.Object always satisfies this
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(obj), fresh); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return !fresh.GetDeletionTimestamp().IsZero(), nil
+}
+
 // NodeMatchesSelector checks if a selector matches the node labels.
 func NodeMatchesSelector(ctx context.Context, cl client.Client, nodeName string, labelSelector *metav1.LabelSelector) (bool, error) {
 	logger := log.FromContext(ctx)

--- a/internal/pkg/controllerhelper/node.go
+++ b/internal/pkg/controllerhelper/node.go
@@ -25,34 +25,51 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 )
 
-// ClearFinalizersIfNodeGone checks whether nodeName still exists in the cluster.
-// If the node is gone and obj still has finalizers, it removes all finalizers via
-// a Patch so the API server can complete the pending deletion.
+const falcoInstanceLabel = "app.kubernetes.io/instance"
+
+// ClearFinalizersIfNodeOrPodGone checks whether the per-node artifact operator that
+// owns obj's finalizers can still perform cleanup. When either the Kubernetes Node no
+// longer exists or no Running Falco pod is present on it, all finalizers are removed
+// via a Patch so the API server can complete the pending deletion.
 //
-// This is needed when a Kubernetes node is deleted: the per-node artifact operator
-// (running as a DaemonSet pod on that node) is evicted along with it and can no
-// longer remove its own finalizer from the per-node object (ArtifactNode). Without
-// this call the node objects would remain stuck in Terminating indefinitely,
-// blocking parent artifact cleanup.
-func ClearFinalizersIfNodeGone(ctx context.Context, cl client.Client, nodeName string, obj client.Object) error {
+// This covers both a deleted Kubernetes Node and a Falco pod disappearing from a
+// still-existing node. In either case no per-node artifact operator remains to remove
+// its finalizer, and there is no remaining node-side cleanup to perform. Without this
+// call the ArtifactNode would remain stuck in Terminating indefinitely, blocking its
+// parent artifact cleanup.
+func ClearFinalizersIfNodeOrPodGone(
+	ctx context.Context,
+	cl client.Client,
+	nodeName string,
+	runningFalcoNodes map[string]struct{},
+	obj client.Object,
+) error {
 	if len(obj.GetFinalizers()) == 0 {
 		return nil
 	}
-	node := &corev1.Node{}
-	err := cl.Get(ctx, client.ObjectKey{Name: nodeName}, node)
-	if err == nil {
-		return nil // node still exists, let the per-node operator clean up normally.
+
+	reason := "Falco pod gone"
+	if _, podRunning := runningFalcoNodes[nodeName]; podRunning {
+		node := &corev1.Node{}
+		err := cl.Get(ctx, client.ObjectKey{Name: nodeName}, node)
+		if err == nil {
+			return nil // Node and per-node artifact operator still exist; let it clean up normally.
+		}
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+		reason = "Node gone"
 	}
-	if !k8serrors.IsNotFound(err) {
-		return err
-	}
-	log.FromContext(ctx).Info("Node gone, force-clearing finalizers on orphaned node object",
-		"node", nodeName, "object", obj.GetName())
+
+	log.FromContext(ctx).Info("Force-clearing finalizers on orphaned node object",
+		"node", nodeName, "object", obj.GetName(), "reason", reason)
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object)) //nolint:forcetypeassert // client.Object always satisfies this
 	obj.SetFinalizers(nil)
 	if pErr := cl.Patch(ctx, obj, patch); pErr != nil && !k8serrors.IsNotFound(pErr) {
@@ -90,23 +107,29 @@ func ListMatchingFalcoNodes(ctx context.Context, cl client.Client, sel *metav1.L
 		return nil, err
 	}
 
-	falcoNodes, err := listFalcoRunningNodeNames(ctx, cl, namespace)
+	falcoNodes, err := ListFalcoRunningNodeNames(ctx, cl, namespace)
 	if err != nil {
 		return nil, err
 	}
+	return FilterNodesByName(nodes, falcoNodes), nil
+}
 
-	filtered := nodes[:0]
+// FilterNodesByName returns the nodes whose names are present in desired. The returned
+// slice does not alias nodes, so callers can safely retain the original list for other
+// purposes such as multi-platform cache pre-fetching.
+func FilterNodesByName(nodes []corev1.Node, desired map[string]struct{}) []corev1.Node {
+	filtered := make([]corev1.Node, 0, len(nodes))
 	for i := range nodes {
-		if _, ok := falcoNodes[nodes[i].Name]; ok {
+		if _, ok := desired[nodes[i].Name]; ok {
 			filtered = append(filtered, nodes[i])
 		}
 	}
-	return filtered, nil
+	return filtered
 }
 
-// listFalcoRunningNodeNames lists all Falco CRs in namespace and returns the set of node names
+// ListFalcoRunningNodeNames lists all Falco CRs in namespace and returns the set of node names
 // that currently have a Running pod for any of them.
-func listFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace string) (map[string]struct{}, error) {
+func ListFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace string) (map[string]struct{}, error) {
 	falcoList := &instancev1alpha1.FalcoList{}
 	if err := cl.List(ctx, falcoList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list Falco CRs for node filtering: %w", err)
@@ -118,7 +141,7 @@ func listFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace 
 		podList := &corev1.PodList{}
 		if err := cl.List(ctx, podList,
 			client.InNamespace(namespace),
-			client.MatchingLabels{"app.kubernetes.io/instance": name},
+			client.MatchingLabels{falcoInstanceLabel: name},
 		); err != nil {
 			return nil, fmt.Errorf("list pods for Falco %q: %w", name, err)
 		}
@@ -130,6 +153,47 @@ func listFalcoRunningNodeNames(ctx context.Context, cl client.Client, namespace 
 		}
 	}
 	return running, nil
+}
+
+// FalcoPodChangePredicate accepts exactly the Pod events that can change the result of
+// ListFalcoRunningNodeNames: a labeled Pod appearing or disappearing, or an update to its
+// Falco instance label, node assignment, or phase. In particular, checking both sides of an
+// update ensures that removing the instance label still triggers stale ArtifactNode cleanup.
+func FalcoPodChangePredicate() predicate.Predicate {
+	hasFalcoInstance := func(obj client.Object) bool {
+		_, ok := obj.GetLabels()[falcoInstanceLabel]
+		return ok
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return hasFalcoInstance(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return hasFalcoInstance(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldInstance, oldTracked := e.ObjectOld.GetLabels()[falcoInstanceLabel]
+			newInstance, newTracked := e.ObjectNew.GetLabels()[falcoInstanceLabel]
+			if !oldTracked && !newTracked {
+				return false
+			}
+			if oldTracked != newTracked || oldInstance != newInstance {
+				return true
+			}
+
+			oldPod, oldOK := e.ObjectOld.(*corev1.Pod)
+			newPod, newOK := e.ObjectNew.(*corev1.Pod)
+			if !oldOK || !newOK {
+				return true
+			}
+			return oldPod.Spec.NodeName != newPod.Spec.NodeName ||
+				oldPod.Status.Phase != newPod.Status.Phase
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return hasFalcoInstance(e.Object)
+		},
+	}
 }
 
 // IsBeingDeleted re-fetches obj and reports whether it now has a DeletionTimestamp set, or is

--- a/internal/pkg/controllerhelper/node_test.go
+++ b/internal/pkg/controllerhelper/node_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 )
@@ -51,13 +52,13 @@ func newConfigMapWithFinalizer() *corev1.ConfigMap {
 	}
 }
 
-func TestClearFinalizersIfNodeGone_NoFinalizers(t *testing.T) {
+func TestClearFinalizersIfNodeOrPodGone_NoFinalizers(t *testing.T) {
 	s := newNodeScheme(t)
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: "default"}}
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(node, cm).Build()
 
-	err := controllerhelper.ClearFinalizersIfNodeGone(context.Background(), cl, "worker-1", cm)
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(context.Background(), cl, "worker-1", nil, cm)
 	require.NoError(t, err)
 	// Object had no finalizers, so Patch was never called.
 	got := &corev1.ConfigMap{}
@@ -65,26 +66,44 @@ func TestClearFinalizersIfNodeGone_NoFinalizers(t *testing.T) {
 	assert.Empty(t, got.Finalizers)
 }
 
-func TestClearFinalizersIfNodeGone_NodeExists(t *testing.T) {
+func TestClearFinalizersIfNodeOrPodGone_NodeAndPodExist(t *testing.T) {
 	s := newNodeScheme(t)
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
 	cm := newConfigMapWithFinalizer()
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(node, cm).Build()
 
-	err := controllerhelper.ClearFinalizersIfNodeGone(context.Background(), cl, "worker-1", cm)
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(
+		context.Background(), cl, "worker-1", map[string]struct{}{"worker-1": {}}, cm,
+	)
 	require.NoError(t, err)
-	// Node still exists, so finalizers must be preserved.
+	// Both the node and its artifact operator still exist, so finalizers must be preserved.
 	got := &corev1.ConfigMap{}
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(cm), got))
 	assert.NotEmpty(t, got.Finalizers)
 }
 
-func TestClearFinalizersIfNodeGone_NodeGone(t *testing.T) {
+func TestClearFinalizersIfNodeOrPodGone_PodGone(t *testing.T) {
+	s := newNodeScheme(t)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
+	cm := newConfigMapWithFinalizer()
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(node, cm).Build()
+
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(context.Background(), cl, "worker-1", nil, cm)
+	require.NoError(t, err)
+	// The node still exists, but no artifact operator can release its finalizer.
+	got := &corev1.ConfigMap{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(cm), got))
+	assert.Empty(t, got.Finalizers)
+}
+
+func TestClearFinalizersIfNodeOrPodGone_NodeGone(t *testing.T) {
 	s := newNodeScheme(t)
 	cm := newConfigMapWithFinalizer()
 	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build() // node NOT created
 
-	err := controllerhelper.ClearFinalizersIfNodeGone(context.Background(), cl, "worker-1", cm)
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(
+		context.Background(), cl, "worker-1", map[string]struct{}{"worker-1": {}}, cm,
+	)
 	require.NoError(t, err)
 	// Finalizers are cleared once the node is gone.
 	got := &corev1.ConfigMap{}
@@ -92,7 +111,7 @@ func TestClearFinalizersIfNodeGone_NodeGone(t *testing.T) {
 	assert.Empty(t, got.Finalizers)
 }
 
-func TestClearFinalizersIfNodeGone_GetNodeError(t *testing.T) {
+func TestClearFinalizersIfNodeOrPodGone_GetNodeError(t *testing.T) {
 	s := newNodeScheme(t)
 	cm := newConfigMapWithFinalizer()
 	cl := fake.NewClientBuilder().
@@ -108,11 +127,13 @@ func TestClearFinalizersIfNodeGone_GetNodeError(t *testing.T) {
 		}).
 		Build()
 
-	err := controllerhelper.ClearFinalizersIfNodeGone(context.Background(), cl, "worker-1", cm)
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(
+		context.Background(), cl, "worker-1", map[string]struct{}{"worker-1": {}}, cm,
+	)
 	require.Error(t, err)
 }
 
-func TestClearFinalizersIfNodeGone_PatchError(t *testing.T) {
+func TestClearFinalizersIfNodeOrPodGone_PatchError(t *testing.T) {
 	s := newNodeScheme(t)
 	cm := newConfigMapWithFinalizer()
 	cl := fake.NewClientBuilder().
@@ -125,8 +146,8 @@ func TestClearFinalizersIfNodeGone_PatchError(t *testing.T) {
 		}).
 		Build()
 
-	// Patch is attempted when the node is gone, and its error is returned.
-	err := controllerhelper.ClearFinalizersIfNodeGone(context.Background(), cl, "worker-1", cm)
+	// Patch is attempted when the Falco pod is gone, and its error is returned.
+	err := controllerhelper.ClearFinalizersIfNodeOrPodGone(context.Background(), cl, "worker-1", nil, cm)
 	require.Error(t, err)
 }
 
@@ -181,6 +202,63 @@ func TestListMatchingNodes_ListError(t *testing.T) {
 	_, err := controllerhelper.ListMatchingNodes(context.Background(), cl, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api server unavailable")
+}
+
+func TestFalcoPodChangePredicate(t *testing.T) {
+	pred := controllerhelper.FalcoPodChangePredicate()
+	makePod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app.kubernetes.io/instance": "falco"}},
+			Spec:       corev1.PodSpec{NodeName: "node-1"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+	}
+
+	assert.True(t, pred.Create(event.CreateEvent{Object: makePod()}))
+	assert.True(t, pred.Delete(event.DeleteEvent{Object: makePod()}))
+	assert.False(t, pred.Create(event.CreateEvent{Object: &corev1.Pod{}}))
+	assert.False(t, pred.Delete(event.DeleteEvent{Object: &corev1.Pod{}}))
+
+	t.Run("instance label added", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		oldPod.Labels = nil
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("instance label removed", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		newPod.Labels = nil
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("instance label changed", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		newPod.Labels["app.kubernetes.io/instance"] = "other-falco"
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("node assignment changed", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		oldPod.Spec.NodeName = ""
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("phase changed", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		oldPod.Status.Phase = corev1.PodPending
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("irrelevant status changed", func(t *testing.T) {
+		oldPod, newPod := makePod(), makePod()
+		newPod.Status.PodIP = "10.0.0.1"
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("unrelated pod changed", func(t *testing.T) {
+		oldPod, newPod := &corev1.Pod{}, &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
 }
 
 func TestIsBeingDeleted_NotDeleted(t *testing.T) {

--- a/internal/pkg/controllerhelper/node_test.go
+++ b/internal/pkg/controllerhelper/node_test.go
@@ -183,6 +183,61 @@ func TestListMatchingNodes_ListError(t *testing.T) {
 	assert.Contains(t, err.Error(), "api server unavailable")
 }
 
+func TestIsBeingDeleted_NotDeleted(t *testing.T) {
+	s := newNodeScheme(t)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: "default"}}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+
+	deleting, err := controllerhelper.IsBeingDeleted(context.Background(), cl, cm)
+	require.NoError(t, err)
+	assert.False(t, deleting)
+}
+
+func TestIsBeingDeleted_DeletionTimestampSet(t *testing.T) {
+	s := newNodeScheme(t)
+	now := metav1.Now()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "obj", Namespace: "default",
+			Finalizers:        []string{"test.example.com/finalizer"}, // a DeletionTimestamp requires a finalizer to be set
+			DeletionTimestamp: &now,
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
+
+	deleting, err := controllerhelper.IsBeingDeleted(context.Background(), cl, cm)
+	require.NoError(t, err)
+	assert.True(t, deleting)
+}
+
+func TestIsBeingDeleted_ObjectGone(t *testing.T) {
+	s := newNodeScheme(t)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: "default"}}
+	cl := fake.NewClientBuilder().WithScheme(s).Build() // never created
+
+	deleting, err := controllerhelper.IsBeingDeleted(context.Background(), cl, cm)
+	require.NoError(t, err)
+	assert.True(t, deleting, "a gone object is treated the same as being deleted")
+}
+
+func TestIsBeingDeleted_GetError(t *testing.T) {
+	s := newNodeScheme(t)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "obj", Namespace: "default"}}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cm).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return fmt.Errorf("api server unavailable")
+			},
+		}).
+		Build()
+
+	_, err := controllerhelper.IsBeingDeleted(context.Background(), cl, cm)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api server unavailable")
+}
+
 func TestNodeMatchesSelector(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/pkg/controllerhelper/ownednodes.go
+++ b/internal/pkg/controllerhelper/ownednodes.go
@@ -100,16 +100,21 @@ func deleteNodeObject(ctx context.Context, cl client.Client, node *artifactv1alp
 }
 
 // DeleteStaleNodeObjects deletes every node in existing whose Spec.NodeName is not present in
-// desired (the node no longer matches the parent's selector). ClearFinalizersIfNodeGone runs
-// first for each so a node object orphaned by its underlying Kubernetes Node being removed
-// doesn't block forever waiting for an evicted per-node operator to release its finalizer.
-func DeleteStaleNodeObjects(ctx context.Context, cl client.Client, existing []artifactv1alpha1.ArtifactNode, desired map[string]struct{}) error {
+// desired. Before each deletion, ClearFinalizersIfNodeOrPodGone releases finalizers that cannot
+// be handled because either the Kubernetes Node or its Falco pod is gone.
+func DeleteStaleNodeObjects(
+	ctx context.Context,
+	cl client.Client,
+	existing []artifactv1alpha1.ArtifactNode,
+	desired map[string]struct{},
+	runningFalcoNodes map[string]struct{},
+) error {
 	for i := range existing {
 		node := &existing[i]
 		if _, ok := desired[node.Spec.NodeName]; ok {
 			continue
 		}
-		if err := ClearFinalizersIfNodeGone(ctx, cl, node.Spec.NodeName, node); err != nil {
+		if err := ClearFinalizersIfNodeOrPodGone(ctx, cl, node.Spec.NodeName, runningFalcoNodes, node); err != nil {
 			return err
 		}
 		if err := deleteNodeObject(ctx, cl, node); err != nil {
@@ -125,12 +130,17 @@ func DeleteStaleNodeObjects(ctx context.Context, cl client.Client, existing []ar
 // already taken effect server-side. The caller uses this to decide whether the in-use
 // finalizer can be released yet. A subsequent reconcile (triggered by the ArtifactNode watch
 // once each one is actually removed) re-lists and eventually observes zero remaining.
-func DeleteNodeObjectsForParentDeletion(ctx context.Context, cl client.Client, existing []artifactv1alpha1.ArtifactNode) (nodesRemaining bool, err error) {
+func DeleteNodeObjectsForParentDeletion(
+	ctx context.Context,
+	cl client.Client,
+	existing []artifactv1alpha1.ArtifactNode,
+	runningFalcoNodes map[string]struct{},
+) (nodesRemaining bool, err error) {
 	logger := log.FromContext(ctx)
 
 	for i := range existing {
 		node := &existing[i]
-		if err := ClearFinalizersIfNodeGone(ctx, cl, node.Spec.NodeName, node); err != nil {
+		if err := ClearFinalizersIfNodeOrPodGone(ctx, cl, node.Spec.NodeName, runningFalcoNodes, node); err != nil {
 			return false, err
 		}
 		if node.DeletionTimestamp.IsZero() {

--- a/internal/pkg/controllerhelper/ownednodes_test.go
+++ b/internal/pkg/controllerhelper/ownednodes_test.go
@@ -215,7 +215,7 @@ func TestDeleteStaleNodeObjects_NodeInDesiredIsKept(t *testing.T) {
 	cl := newArtifactNodeClient(t, node)
 
 	err := controllerhelper.DeleteStaleNodeObjects(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"n1": {}})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"n1": {}}, nil)
 	require.NoError(t, err)
 
 	got := &artifactv1alpha1.ArtifactNode{}
@@ -223,12 +223,12 @@ func TestDeleteStaleNodeObjects_NodeInDesiredIsKept(t *testing.T) {
 }
 
 func TestDeleteStaleNodeObjects_NodeNotInDesiredIsDeleted(t *testing.T) {
-	k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}} // node still exists; ClearFinalizersIfNodeGone is a no-op
+	k8sNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
 	node := newArtifactNode("plugin--container--n1", "container")
 	cl := newArtifactNodeClient(t, node, k8sNode)
 
 	err := controllerhelper.DeleteStaleNodeObjects(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"other-node": {}})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"other-node": {}}, nil)
 	require.NoError(t, err)
 
 	got := &artifactv1alpha1.ArtifactNode{}
@@ -251,7 +251,7 @@ func TestDeleteStaleNodeObjects_DeleteAlreadyNotFoundIsNotAnError(t *testing.T) 
 		Build()
 
 	err := controllerhelper.DeleteStaleNodeObjects(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{}, nil)
 	require.NoError(t, err)
 }
 
@@ -261,7 +261,7 @@ func TestDeleteStaleNodeObjects_ClearFinalizersError(t *testing.T) {
 	cl := fake.NewClientBuilder().
 		WithScheme(newArtifactScheme(t)).
 		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
-		WithObjects(node). // no corev1.Node "n1" exists; ClearFinalizersIfNodeGone treats the ArtifactNode as gone and patches it
+		WithObjects(node). // no corev1.Node "n1" exists; orphan cleanup checks it before patching the ArtifactNode
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				if _, ok := obj.(*corev1.Node); ok {
@@ -273,7 +273,7 @@ func TestDeleteStaleNodeObjects_ClearFinalizersError(t *testing.T) {
 		Build()
 
 	err := controllerhelper.DeleteStaleNodeObjects(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{}, map[string]struct{}{"n1": {}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api server unavailable")
 }
@@ -293,7 +293,7 @@ func TestDeleteStaleNodeObjects_DeleteOtherErrorPropagates(t *testing.T) {
 		Build()
 
 	err := controllerhelper.DeleteStaleNodeObjects(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server unavailable")
 }
@@ -303,7 +303,7 @@ func TestDeleteStaleNodeObjects_DeleteOtherErrorPropagates(t *testing.T) {
 func TestDeleteNodeObjectsForParentDeletion_EmptyExisting(t *testing.T) {
 	cl := newArtifactNodeClient(t)
 
-	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl, nil)
+	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl, nil, nil)
 	require.NoError(t, err)
 	assert.False(t, remaining)
 }
@@ -314,7 +314,7 @@ func TestDeleteNodeObjectsForParentDeletion_NodesPresentAreDeletedAndReportedRem
 	cl := newArtifactNodeClient(t, node, k8sNode)
 
 	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node})
+		[]artifactv1alpha1.ArtifactNode{*node}, nil)
 	require.NoError(t, err)
 	// nodesRemaining reflects presence at the start of the call, not whether the Delete
 	// this call issued has already taken effect server-side.
@@ -344,7 +344,7 @@ func TestDeleteNodeObjectsForParentDeletion_AlreadyDeletingNodeIsNotDeletedAgain
 		Build()
 
 	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"n1": {}})
 	require.NoError(t, err)
 	assert.True(t, remaining)
 }
@@ -367,7 +367,7 @@ func TestDeleteNodeObjectsForParentDeletion_ClearFinalizersError(t *testing.T) {
 		Build()
 
 	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node})
+		[]artifactv1alpha1.ArtifactNode{*node}, map[string]struct{}{"n1": {}})
 	require.Error(t, err)
 	assert.False(t, remaining)
 	assert.Contains(t, err.Error(), "api server unavailable")
@@ -388,7 +388,7 @@ func TestDeleteNodeObjectsForParentDeletion_DeleteError(t *testing.T) {
 		Build()
 
 	remaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(context.Background(), cl,
-		[]artifactv1alpha1.ArtifactNode{*node})
+		[]artifactv1alpha1.ArtifactNode{*node}, nil)
 	require.Error(t, err)
 	assert.False(t, remaining)
 	assert.Contains(t, err.Error(), "server unavailable")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

Introduces PluginAggregatorReconciler (controllers/instance/artifact/plugin),
following the same node-object aggregator pattern as Config, plus:

- Fetches and caches the OCI artifact's requirements/dependencies as
  Status.ArtifactMeta.
- Pre-fetches the plugin binary for every platform present among
  matching nodes into the shared blob cache via EnsureBlob,
  best-effort: a failure here doesn't block ArtifactNode creation,
  since the per-node operator can still fetch directly. cmd/instance/
  main.go wires the controller with cache=nil for now, so this
  pre-fetch is currently a no-op.

Follows the same in-use-finalizer and aggregation design as Config:
- The in-use finalizer is reconciled once existingNodes is known,
  keeping the parent alive until every existing child is physically
  gone, not just while nodes are currently desired.
- Aggregation excludes terminating/no-longer-desired ArtifactNodes so
  a departing node's last cached condition can't linger in the
  parent's aggregate status.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #



**Special notes for your reviewer**:
Depends on #385 