### PR TITLE
feat(instance): wire up the Rulesfile node-object aggregator controller

### DIFF
--- a/api/artifact/v1alpha1/rulesfile_types.go
+++ b/api/artifact/v1alpha1/rulesfile_types.go
@@ -56,6 +56,11 @@ type RulesfileStatus struct {
 	// +optional
 	// +nullable
 	ArtifactMeta *commonv1alpha1.ArtifactMeta `json:"artifactMeta,omitempty"`
+	// ArtifactMetaSourcesHash is the SHA-256 hash of every source input used to build
+	// ArtifactMeta: the OCIArtifact spec, referenced ConfigMap rules, and inline rules.
+	// The instance operator reuses ArtifactMeta only while this hash still matches.
+	// +optional
+	ArtifactMetaSourcesHash string `json:"artifactMetaSourcesHash,omitempty"`
 	// ObservedGeneration is the .metadata.generation that the instance operator has fully
 	// processed (ArtifactMeta computed, status patched). Per-node artifact operators defer
 	// reconciliation until this equals metadata.generation.

--- a/chart/falco-operator/crds/artifact.falcosecurity.dev_rulesfiles.yaml
+++ b/chart/falco-operator/crds/artifact.falcosecurity.dev_rulesfiles.yaml
@@ -272,6 +272,12 @@ spec:
                       Digest, Requirements, and Dependencies are invalidated and re-fetched.
                     type: string
                 type: object
+              artifactMetaSourcesHash:
+                description: |-
+                  ArtifactMetaSourcesHash is the SHA-256 hash of every source input used to build
+                  ArtifactMeta: the OCIArtifact spec, referenced ConfigMap rules, and inline rules.
+                  The instance operator reuses ArtifactMeta only while this hash still matches.
+                type: string
               conditions:
                 description: Conditions represent the latest available observations
                   of the Rulesfile's state.

--- a/chart/falco-operator/files/ClusterRole.yaml
+++ b/chart/falco-operator/files/ClusterRole.yaml
@@ -106,6 +106,7 @@ rules:
   resources:
   - configs/finalizers
   - plugins/finalizers
+  - rulesfiles/finalizers
   verbs:
   - patch
   - update

--- a/cmd/instance/main.go
+++ b/cmd/instance/main.go
@@ -39,6 +39,7 @@ import (
 	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
 	artifactconfigctr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/config"
 	artifactpluginctr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/plugin"
+	artifactrulesfilectr "github.com/falcosecurity/falco-operator/controllers/instance/artifact/rulesfile"
 	"github.com/falcosecurity/falco-operator/controllers/instance/component"
 	"github.com/falcosecurity/falco-operator/controllers/instance/falco"
 	configmapctr "github.com/falcosecurity/falco-operator/controllers/instance/reference/configmap"
@@ -278,11 +279,18 @@ func main() {
 	}
 
 	// cache is nil until the centralized artifact blob cache is wired up (a later PR); Plugin
-	// pre-fetches are then skipped and per-node artifact operators pull directly.
+	// and Rulesfile pre-fetches are then skipped and per-node artifact operators pull directly.
 	if err := artifactpluginctr.NewPluginAggregatorReconciler(
 		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("instance-artifact-plugin"), nil,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", artifactpluginctr.ControllerName)
+		os.Exit(1)
+	}
+
+	if err := artifactrulesfilectr.NewRulesfileAggregatorReconciler(
+		mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("instance-artifact-rulesfile"), nil,
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", artifactrulesfilectr.ControllerName)
 		os.Exit(1)
 	}
 

--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -24,6 +24,8 @@ package rulesfile
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -155,17 +157,19 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Snapshot before any status mutation so we can skip the first SSA when nothing changed.
 	oldStatus := rulesfile.Status.DeepCopy()
 
-	// Fetch OCI config layer once and cache it in parent.Status.ArtifactMeta so that
-	// per-node artifact operators can read requirements without hitting the registry.
+	// Build and cache the complete metadata aggregate so per-node artifact operators can
+	// evaluate every configured source without hitting the registry or re-parsing content.
 	if err := r.fetchAndCacheArtifactMeta(ctx, rulesfile); err != nil {
-		// Surfaces the failure directly on the parent Rulesfile status. ObservedGeneration is not
-		// advanced, so enforce-mode per-node operators stay deferred, and no ArtifactNodes are
-		// created since they cannot be programmed without metadata.
+		// A referenced ConfigMap can change without changing Rulesfile.Generation, so merely
+		// retaining the previous ObservedGeneration could make stale metadata look current.
+		// Reset it on every source failure; the last complete ArtifactMeta remains available for
+		// diagnosis, but enforce-mode per-node operators stay deferred until a complete rebuild.
+		rulesfile.Status.ObservedGeneration = 0
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, metav1.Condition{
 			Type:               commonv1alpha1.ConditionProgrammed.String(),
 			Status:             metav1.ConditionFalse,
-			Reason:             artifact.ReasonOCIArtifactProgramFailed,
-			Message:            fmt.Sprintf("Failed to fetch OCI artifact metadata: %s", err.Error()),
+			Reason:             artifact.ReasonProgramFailed,
+			Message:            fmt.Sprintf("Failed to compute artifact metadata: %s", err.Error()),
 			ObservedGeneration: rulesfile.Generation,
 		})
 		if patchErr := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, rulesfile, ControllerName); patchErr != nil {
@@ -239,38 +243,101 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 	return ctrl.Result{}, fetchBinErr
 }
 
-// fetchAndCacheArtifactMeta collects all requirements for the Rulesfile from every source
-// (OCI config layer, OCI content YAML, ConfigMap, or inline rules) and stores the merged
-// result in parent.Status.ArtifactMeta. This single status field is then read by every
-// per-node artifact operator, eliminating per-node registry calls.
-//
-// For OCI sources a digest-based cache avoids redundant registry round-trips: if the
-// spec and current digest match what is already stored, the cached value is kept as-is.
-// ConfigMap and inline sources are always re-parsed on each reconcile (cheap k8s API / in-memory).
+type rulesfileArtifactMetaSources struct {
+	OCIArtifactSpecHash string `json:"ociArtifactSpecHash"`
+	ConfigMapName       string `json:"configMapName"`
+	ConfigMapConfigured bool   `json:"configMapConfigured"`
+	ConfigMapRules      []byte `json:"configMapRules"`
+	InlineConfigured    bool   `json:"inlineConfigured"`
+	InlineRules         []byte `json:"inlineRules"`
+}
+
+func (s *rulesfileArtifactMetaSources) hash() (string, error) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("marshal Rulesfile artifact metadata sources: %w", err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+// collectArtifactMetaSources resolves a stable snapshot of every input from which
+// ArtifactMeta is built. A configured source must be readable and complete: otherwise
+// callers keep the previous status and retry instead of publishing partial metadata.
+func (r *RulesfileAggregatorReconciler) collectArtifactMetaSources(
+	ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile,
+) (*rulesfileArtifactMetaSources, error) {
+	sources := &rulesfileArtifactMetaSources{
+		ConfigMapConfigured: rulesfile.Spec.ConfigMapRef != nil,
+		InlineConfigured:    rulesfile.Spec.InlineRules != nil,
+	}
+
+	if rulesfile.Spec.OCIArtifact != nil {
+		specHash, err := artifact.ComputeOCIArtifactSpecHash(rulesfile.Spec.OCIArtifact)
+		if err != nil {
+			return nil, fmt.Errorf("compute OCI spec hash: %w", err)
+		}
+		sources.OCIArtifactSpecHash = specHash
+	}
+
+	if rulesfile.Spec.ConfigMapRef != nil {
+		sources.ConfigMapName = rulesfile.Spec.ConfigMapRef.Name
+		cm := &corev1.ConfigMap{}
+		key := client.ObjectKey{Name: sources.ConfigMapName, Namespace: rulesfile.Namespace}
+		if err := r.Get(ctx, key, cm); err != nil {
+			return nil, fmt.Errorf("fetch ConfigMap %q for artifact metadata: %w", sources.ConfigMapName, err)
+		}
+		content, ok := cm.Data[commonv1alpha1.ConfigMapRulesKey]
+		if !ok {
+			return nil, fmt.Errorf("ConfigMap %q does not contain required key %q",
+				sources.ConfigMapName, commonv1alpha1.ConfigMapRulesKey)
+		}
+		sources.ConfigMapRules = []byte(content)
+	}
+
+	if rulesfile.Spec.InlineRules != nil {
+		sources.InlineRules = rulesfile.Spec.InlineRules.Raw
+	}
+
+	return sources, nil
+}
+
+// fetchAndCacheArtifactMeta collects requirements for the Rulesfile from every configured
+// source and atomically stores the merged result in parent.Status.ArtifactMeta. The cached
+// aggregate is reused only when ArtifactMetaSourcesHash proves that every source input is
+// unchanged; ArtifactMeta.SpecHash retains its narrower OCI-only meaning for blob lifecycle.
 func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile) error {
 	logger := log.FromContext(ctx)
 
 	if rulesfile.Spec.OCIArtifact == nil && rulesfile.Spec.ConfigMapRef == nil && rulesfile.Spec.InlineRules == nil {
 		logger.V(4).Info("No artifact source configured, clearing ArtifactMeta")
 		rulesfile.Status.ArtifactMeta = nil
+		rulesfile.Status.ArtifactMetaSourcesHash = ""
 		return nil
 	}
 
-	var opts []artifact.ManagerOption
-	if r.ociPuller != nil {
-		opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
+	sources, err := r.collectArtifactMetaSources(ctx, rulesfile)
+	if err != nil {
+		return err
 	}
-	am := artifact.NewManagerWithOptions(r.Client, rulesfile.Namespace, opts...)
+	sourcesHash, err := sources.hash()
+	if err != nil {
+		return err
+	}
+	if rulesfile.Status.ArtifactMeta != nil && rulesfile.Status.ArtifactMetaSourcesHash == sourcesHash {
+		return nil
+	}
+
+	// Build into a fresh value and publish it only after every configured source succeeds.
+	// This prevents both stale entries after a source is removed and partial entries when a
+	// source cannot be read or parsed.
+	meta := &commonv1alpha1.ArtifactMeta{SpecHash: sources.OCIArtifactSpecHash}
 
 	if rulesfile.Spec.OCIArtifact != nil {
-		specHash, err := artifact.ComputeOCIArtifactSpecHash(rulesfile.Spec.OCIArtifact)
-		if err != nil {
-			return fmt.Errorf("compute OCI spec hash: %w", err)
+		var opts []artifact.ManagerOption
+		if r.ociPuller != nil {
+			opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
 		}
-
-		if artifact.ArtifactMetaCacheHit(rulesfile.Status.ArtifactMeta, specHash) {
-			return nil
-		}
+		am := artifact.NewManagerWithOptions(r.Client, rulesfile.Namespace, opts...)
 
 		ref := artifact.ResolveReference(rulesfile.Spec.OCIArtifact)
 		logger.Info("Fetching rulesfile ArtifactMeta from OCI config layer", "ref", ref)
@@ -282,10 +349,7 @@ func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Co
 			return fetchErr
 		}
 
-		meta := &commonv1alpha1.ArtifactMeta{
-			Digest:   digest,
-			SpecHash: specHash,
-		}
+		meta.Digest = digest
 		artifact.AppendConfigLayerRequirements(meta, fetched)
 		logger.Info("Rulesfile ArtifactMeta parsed from OCI config layer",
 			"ref", ref,
@@ -310,55 +374,53 @@ func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Co
 			return contentErr
 		}
 		beforeReqs, beforeDeps := len(meta.Requirements), len(meta.Dependencies)
-		appendYAMLRequirements(meta, content)
+		if err := appendYAMLRequirements(meta, content); err != nil {
+			parseErr := fmt.Errorf("parse OCI content requirements: %w", err)
+			logger.Error(parseErr, "Unable to parse rulesfile OCI content; ArtifactMeta will remain stale", "ref", ref)
+			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactProgramFailed,
+				"Failed to parse OCI content layer: %s", err.Error())
+			return parseErr
+		}
 		logger.Info("Rulesfile ArtifactMeta parsed from OCI content layer",
 			"ref", ref,
 			"newRequirements", len(meta.Requirements)-beforeReqs,
 			"newDependencies", len(meta.Dependencies)-beforeDeps,
 		)
-
-		artifact.DeduplicateArtifactMeta(meta)
-		logger.Info("Rulesfile ArtifactMeta updated from OCI artifact",
-			"ref", ref,
-			"digest", digest,
-			"requirements", len(meta.Requirements),
-			"dependencies", len(meta.Dependencies),
-		)
-		rulesfile.Status.ArtifactMeta = meta
-		return nil
 	}
 
-	// Non-OCI sources: ConfigMap and/or inline. Always re-parse (cheap).
-	meta := &commonv1alpha1.ArtifactMeta{}
-	if rulesfile.Spec.ConfigMapRef != nil {
-		cm := &corev1.ConfigMap{}
-		key := client.ObjectKey{Name: rulesfile.Spec.ConfigMapRef.Name, Namespace: rulesfile.Namespace}
-		if err := r.Get(ctx, key, cm); err != nil {
-			logger.Error(err, "Unable to fetch ConfigMap for requirements", "configMap", rulesfile.Spec.ConfigMapRef.Name)
-		} else {
-			appendYAMLRequirements(meta, []byte(cm.Data[commonv1alpha1.ConfigMapRulesKey]))
+	if sources.ConfigMapConfigured {
+		logger.Info("Parsing rulesfile ArtifactMeta from ConfigMap", "configMap", sources.ConfigMapName)
+		if err := appendYAMLRequirements(meta, sources.ConfigMapRules); err != nil {
+			return fmt.Errorf("parse requirements from ConfigMap %q: %w", sources.ConfigMapName, err)
 		}
-		logger.Info("Parsing rulesfile ArtifactMeta from ConfigMap", "configMap", rulesfile.Spec.ConfigMapRef.Name)
 	}
-	if rulesfile.Spec.InlineRules != nil {
+	if sources.InlineConfigured {
 		logger.Info("Parsing rulesfile ArtifactMeta from inline rules")
-		appendYAMLRequirements(meta, rulesfile.Spec.InlineRules.Raw)
+		if err := appendYAMLRequirements(meta, sources.InlineRules); err != nil {
+			return fmt.Errorf("parse requirements from inline rules: %w", err)
+		}
 	}
+
 	artifact.DeduplicateArtifactMeta(meta)
-	logger.Info("Rulesfile ArtifactMeta updated from YAML content",
+	logger.Info("Rulesfile ArtifactMeta updated from all configured sources",
+		"sourcesHash", sourcesHash,
 		"requirements", len(meta.Requirements),
 		"dependencies", len(meta.Dependencies),
 	)
 	rulesfile.Status.ArtifactMeta = meta
+	rulesfile.Status.ArtifactMetaSourcesHash = sourcesHash
 	return nil
 }
 
 // appendYAMLRequirements parses required_engine_version and required_plugin_versions from
 // a Falco rules YAML document and appends the results to meta.
-func appendYAMLRequirements(meta *commonv1alpha1.ArtifactMeta, content []byte) {
+func appendYAMLRequirements(meta *commonv1alpha1.ArtifactMeta, content []byte) error {
 	rulesReqs, err := compat.ParseRulesRequirements(content)
-	if err != nil || rulesReqs == nil {
-		return
+	if err != nil {
+		return err
+	}
+	if rulesReqs == nil {
+		return nil
 	}
 	if rulesReqs.EngineVersion != "" {
 		capName := "engine_version_semver"
@@ -378,6 +440,7 @@ func appendYAMLRequirements(meta *commonv1alpha1.ArtifactMeta, content []byte) {
 		}
 		meta.Dependencies = append(meta.Dependencies, d)
 	}
+	return nil
 }
 
 // handleDeletion deletes all ArtifactNode objects so each per-node artifact operator can clean up

--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -64,16 +64,6 @@ func NewRulesfileAggregatorReconciler(
 
 // RulesfileAggregatorReconciler manages ArtifactNode objects and aggregates their
 // conditions into the parent Rulesfile status.
-//
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles,verbs=get;list;watch
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/status,verbs=patch;update
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/finalizers,verbs=patch;update
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
-// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
 type RulesfileAggregatorReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -85,6 +75,16 @@ type RulesfileAggregatorReconciler struct {
 	// ociPuller overrides the OCI puller used in fetchAndCacheArtifactMeta; nil uses the default.
 	ociPuller puller.Puller
 }
+
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/status,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
 
 // Reconcile reconciles a Rulesfile: ensures ArtifactNode objects exist for matching nodes,
 // removes stale ones, and writes the aggregate conditions back to the Rulesfile.
@@ -112,10 +112,11 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	// matchingNodes: subset that also has a Running Falco pod; only these nodes get ArtifactNode
 	// objects (avoids stale Pending objects on nodes where no sidecar will ever run).
-	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, rulesfile.Spec.Selector, rulesfile.Namespace)
+	runningFalcoNodes, err := controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, rulesfile.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	matchingNodes := controllerhelper.FilterNodesByName(allMatchingNodes, runningFalcoNodes)
 	logger.V(1).Info("Listed matching nodes", "total", len(allMatchingNodes), "withFalco", len(matchingNodes))
 
 	// List all existing ArtifactNode objects for this Rulesfile.
@@ -137,17 +138,17 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Build a set of node names that should have an ArtifactNode.
-	// Use allMatchingNodes (not matchingNodes) so that a pod restart, which briefly leaves
-	// matchingNodes empty, does not cause existing ArtifactNodes to be deleted and re-created.
-	// A temporarily absent Running pod does not mean the node has stopped hosting Falco.
-	// ArtifactNodes are only deleted when the node no longer matches the selector at all.
-	desiredForDeletion := make(map[string]struct{}, len(allMatchingNodes))
-	for i := range allMatchingNodes {
-		desiredForDeletion[allMatchingNodes[i].Name] = struct{}{}
+	// ArtifactNode existence is the desired per-node assignment. Use the same set for
+	// creation, stale deletion, and status aggregation. If a Falco pod moves away, its old
+	// ArtifactNode is removed; a later pod on that node causes it to be created again.
+	desired := make(map[string]struct{}, len(matchingNodes))
+	for i := range matchingNodes {
+		desired[matchingNodes[i].Name] = struct{}{}
 	}
 
-	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desiredForDeletion); err != nil {
+	if err := controllerhelper.DeleteStaleNodeObjects(
+		ctx, r.Client, existingNodes.Items, desired, runningFalcoNodes,
+	); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -215,10 +216,6 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// A stale or terminating child no longer represents the desired assignment and must not
 	// keep its last condition in the aggregate while deletion is pending.
-	desired := make(map[string]struct{}, len(matchingNodes))
-	for i := range matchingNodes {
-		desired[matchingNodes[i].Name] = struct{}{}
-	}
 	activeNodes := &artifactv1alpha1.ArtifactNodeList{}
 	for i := range existingNodes.Items {
 		nodeObject := &existingNodes.Items[i]
@@ -392,7 +389,17 @@ func (r *RulesfileAggregatorReconciler) handleDeletion(ctx context.Context, rule
 		return err
 	}
 
-	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	runningFalcoNodes := map[string]struct{}{}
+	if len(existing.Items) > 0 {
+		runningFalcoNodes, err = controllerhelper.ListFalcoRunningNodeNames(ctx, r.Client, rulesfile.Namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(
+		ctx, r.Client, existing.Items, runningFalcoNodes,
+	)
 	if err != nil {
 		return err
 	}
@@ -428,15 +435,16 @@ func (r *RulesfileAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.RulesfileList{})
 			}),
+			builder.WithPredicates(predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.LabelChangedPredicate{},
+			)),
 		).
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
 				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.RulesfileList{}, client.InNamespace(pod.GetNamespace()))
 			}),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
-				return ok
-			})),
+			builder.WithPredicates(controllerhelper.FalcoPodChangePredicate()),
 		).
 		Watches(&artifactv1alpha1.ArtifactNode{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Rulesfile{}),

--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -1,0 +1,550 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rulesfile implements the Rulesfile node-object aggregator controller.
+// It runs in the instance operator (singleton Deployment) and is responsible for:
+//   - Creating one ArtifactNode per cluster node that matches the Rulesfile selector.
+//   - Deleting ArtifactNode objects when a node no longer matches.
+//   - Aggregating per-node conditions into the parent Rulesfile status (sole writer).
+//   - Managing the NodeObjectsInUseFinalizer on the parent Rulesfile.
+package rulesfile
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/compat"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+// ControllerName identifies this controller in logs and as the SSA field manager.
+const ControllerName = "instance-artifact-rulesfile"
+
+// NewRulesfileAggregatorReconciler returns a new RulesfileAggregatorReconciler.
+// cache is the shared artifact blob cache also used by the artifact HTTP server.
+// Pass nil to disable local caching (direct-pull mode).
+func NewRulesfileAggregatorReconciler(
+	cl client.Client, scheme *runtime.Scheme, recorder events.EventRecorder, cache *artifactcache.Cache,
+) *RulesfileAggregatorReconciler {
+	return &RulesfileAggregatorReconciler{Client: cl, Scheme: scheme, recorder: recorder, cache: cache}
+}
+
+// RulesfileAggregatorReconciler manages ArtifactNode objects and aggregates their
+// conditions into the parent Rulesfile status.
+//
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/status,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=rulesfiles/finalizers,verbs=patch;update
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=artifactnodes/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=artifact.falcosecurity.dev,resources=plugins,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=instance.falcosecurity.dev,resources=falcos,verbs=get;list;watch
+type RulesfileAggregatorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// recorder emits events on the parent Rulesfile, notably for ArtifactMeta fetch failures in
+	// fetchAndCacheArtifactMeta.
+	recorder events.EventRecorder
+	// cache is the shared artifact blob cache. Nil disables local caching.
+	cache *artifactcache.Cache
+	// ociPuller overrides the OCI puller used in fetchAndCacheArtifactMeta; nil uses the default.
+	ociPuller puller.Puller
+}
+
+// Reconcile reconciles a Rulesfile: ensures ArtifactNode objects exist for matching nodes,
+// removes stale ones, and writes the aggregate conditions back to the Rulesfile.
+func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling Rulesfile")
+
+	rulesfile := &artifactv1alpha1.Rulesfile{}
+	if err := r.Get(ctx, req.NamespacedName, rulesfile); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Handle deletion: remove the in-use finalizer once all node objects are gone.
+	if !rulesfile.DeletionTimestamp.IsZero() {
+		logger.V(1).Info("Rulesfile marked for deletion, running cleanup")
+		return ctrl.Result{}, r.handleDeletion(ctx, rulesfile)
+	}
+
+	// allMatchingNodes: all nodes matching the selector; the blob is pre-fetched unconditionally
+	// (fetchAndCacheBlob is not per-node), but the in-use finalizer is anchored here so that
+	// handleDeletion runs cache eviction even when matchingNodes is empty.
+	allMatchingNodes, err := controllerhelper.ListMatchingNodes(ctx, r.Client, rulesfile.Spec.Selector)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// matchingNodes: subset that also has a Running Falco pod; only these nodes get ArtifactNode
+	// objects (avoids stale Pending objects on nodes where no sidecar will ever run).
+	matchingNodes, err := controllerhelper.ListMatchingFalcoNodes(ctx, r.Client, rulesfile.Spec.Selector, rulesfile.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed matching nodes", "total", len(allMatchingNodes), "withFalco", len(matchingNodes))
+
+	// List all existing ArtifactNode objects for this Rulesfile.
+	existingNodes, err := controllerhelper.ListOwnedNodes(ctx, r.Client, rulesfile.Namespace, rulesfile.Name, controllerhelper.KindRulesfile)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Listed existing ArtifactNode objects", "count", len(existingNodes.Items))
+
+	// Keep the parent alive when nodes are desired or until every existing child is
+	// physically gone. The desired-node check also covers a just-created child that the
+	// informer cache may not expose in the immediate re-list yet.
+	// The SSA variant also strips any legacy per-node finalizers left by old operators.
+	if err := controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, rulesfile,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		len(allMatchingNodes) > 0 || len(existingNodes.Items) > 0,
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Build a set of node names that should have an ArtifactNode.
+	// Use allMatchingNodes (not matchingNodes) so that a pod restart, which briefly leaves
+	// matchingNodes empty, does not cause existing ArtifactNodes to be deleted and re-created.
+	// A temporarily absent Running pod does not mean the node has stopped hosting Falco.
+	// ArtifactNodes are only deleted when the node no longer matches the selector at all.
+	desiredForDeletion := make(map[string]struct{}, len(allMatchingNodes))
+	for i := range allMatchingNodes {
+		desiredForDeletion[allMatchingNodes[i].Name] = struct{}{}
+	}
+
+	if err := controllerhelper.DeleteStaleNodeObjects(ctx, r.Client, existingNodes.Items, desiredForDeletion); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Snapshot before any status mutation so we can skip the first SSA when nothing changed.
+	oldStatus := rulesfile.Status.DeepCopy()
+
+	// Fetch OCI config layer once and cache it in parent.Status.ArtifactMeta so that
+	// per-node artifact operators can read requirements without hitting the registry.
+	if err := r.fetchAndCacheArtifactMeta(ctx, rulesfile); err != nil {
+		// Surfaces the failure directly on the parent Rulesfile status. ObservedGeneration is not
+		// advanced, so enforce-mode per-node operators stay deferred, and no ArtifactNodes are
+		// created since they cannot be programmed without metadata.
+		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, metav1.Condition{
+			Type:               commonv1alpha1.ConditionProgrammed.String(),
+			Status:             metav1.ConditionFalse,
+			Reason:             artifact.ReasonOCIArtifactProgramFailed,
+			Message:            fmt.Sprintf("Failed to fetch OCI artifact metadata: %s", err.Error()),
+			ObservedGeneration: rulesfile.Generation,
+		})
+		if patchErr := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, rulesfile, ControllerName); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Stamps ObservedGeneration so per-node operators know this spec generation has been processed.
+	// Written in the same SSA patch as ArtifactMeta so ObservedGeneration never advances ahead of it.
+	rulesfile.Status.ObservedGeneration = rulesfile.Generation
+	if !apiequality.Semantic.DeepEqual(*oldStatus, rulesfile.Status) {
+		if err := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, rulesfile, ControllerName); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Pulls the OCI binary before creating ArtifactNode objects, so the blob cache is warm
+	// when the per-node operator requests it over HTTP.
+	// If the pre-fetch fails, node creation still proceeds: the per-node operator fetches
+	// independently and surfaces any failure in its own conditions.
+	fetchBinErr := r.fetchAndCacheBlob(ctx, rulesfile)
+
+	// Re-checks deletion status right before creating node objects; see IsBeingDeleted's doc.
+	if deleting, err := controllerhelper.IsBeingDeleted(ctx, r.Client, rulesfile); err != nil {
+		return ctrl.Result{}, err
+	} else if deleting {
+		logger.Info("Rulesfile marked for deletion; skipping node object creation")
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure an ArtifactNode exists for each matching node.
+	rulesfileGVK := artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindRulesfile)
+	for i := range matchingNodes {
+		if err := controllerhelper.EnsureNodeObject(
+			ctx, r.Client, rulesfile, rulesfileGVK, controllerhelper.ArtifactKindRulesfile, matchingNodes[i].Name,
+		); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Re-fetch node objects (some may have just been created) to compute the aggregate.
+	existingNodes, err = controllerhelper.ListOwnedNodes(ctx, r.Client, rulesfile.Namespace, rulesfile.Name, controllerhelper.KindRulesfile)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.V(1).Info("Re-listed ArtifactNode objects after sync", "count", len(existingNodes.Items))
+
+	// A stale or terminating child no longer represents the desired assignment and must not
+	// keep its last condition in the aggregate while deletion is pending.
+	desired := make(map[string]struct{}, len(matchingNodes))
+	for i := range matchingNodes {
+		desired[matchingNodes[i].Name] = struct{}{}
+	}
+	activeNodes := &artifactv1alpha1.ArtifactNodeList{}
+	for i := range existingNodes.Items {
+		nodeObject := &existingNodes.Items[i]
+		if !nodeObject.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if _, ok := desired[nodeObject.Spec.NodeName]; !ok {
+			continue
+		}
+		activeNodes.Items = append(activeNodes.Items, *nodeObject)
+	}
+
+	condSnap := make([]metav1.Condition, len(rulesfile.Status.Conditions))
+	copy(condSnap, rulesfile.Status.Conditions)
+	controllerhelper.ComputeAggregateConditions(ctx, rulesfile, &rulesfile.Status.Conditions, activeNodes)
+	if !apiequality.Semantic.DeepEqual(condSnap, rulesfile.Status.Conditions) {
+		if err := controllerhelper.PatchStatusSSA(ctx, r.Client, r.Scheme, rulesfile, ControllerName); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, fetchBinErr
+}
+
+// fetchAndCacheArtifactMeta collects all requirements for the Rulesfile from every source
+// (OCI config layer, OCI content YAML, ConfigMap, or inline rules) and stores the merged
+// result in parent.Status.ArtifactMeta. This single status field is then read by every
+// per-node artifact operator, eliminating per-node registry calls.
+//
+// For OCI sources a digest-based cache avoids redundant registry round-trips: if the
+// spec and current digest match what is already stored, the cached value is kept as-is.
+// ConfigMap and inline sources are always re-parsed on each reconcile (cheap k8s API / in-memory).
+func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile) error {
+	logger := log.FromContext(ctx)
+
+	if rulesfile.Spec.OCIArtifact == nil && rulesfile.Spec.ConfigMapRef == nil && rulesfile.Spec.InlineRules == nil {
+		logger.V(4).Info("No artifact source configured, clearing ArtifactMeta")
+		rulesfile.Status.ArtifactMeta = nil
+		return nil
+	}
+
+	var opts []artifact.ManagerOption
+	if r.ociPuller != nil {
+		opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
+	}
+	am := artifact.NewManagerWithOptions(r.Client, rulesfile.Namespace, opts...)
+
+	if rulesfile.Spec.OCIArtifact != nil {
+		specHash, err := artifact.ComputeOCIArtifactSpecHash(rulesfile.Spec.OCIArtifact)
+		if err != nil {
+			return fmt.Errorf("compute OCI spec hash: %w", err)
+		}
+
+		if artifact.ArtifactMetaCacheHit(rulesfile.Status.ArtifactMeta, specHash) {
+			return nil
+		}
+
+		ref := artifact.ResolveReference(rulesfile.Spec.OCIArtifact)
+		logger.Info("Fetching rulesfile ArtifactMeta from OCI config layer", "ref", ref)
+		fetched, digest, fetchErr := am.FetchConfig(ctx, rulesfile.Spec.OCIArtifact)
+		if fetchErr != nil {
+			logger.Error(fetchErr, "Unable to fetch rulesfile OCI config; ArtifactMeta will remain stale", "ref", ref)
+			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactProgramFailed,
+				"Failed to fetch OCI config layer: %s", fetchErr.Error())
+			return fetchErr
+		}
+
+		meta := &commonv1alpha1.ArtifactMeta{
+			Digest:   digest,
+			SpecHash: specHash,
+		}
+		artifact.AppendConfigLayerRequirements(meta, fetched)
+		logger.Info("Rulesfile ArtifactMeta parsed from OCI config layer",
+			"ref", ref,
+			"requirements", len(meta.Requirements),
+			"dependencies", len(meta.Dependencies),
+		)
+
+		// Also parses the YAML content layer, since some artifacts declare
+		// required_engine_version/required_plugin_versions there but not in the config layer.
+		// Deduplication below keeps the strictest version when both sources report the same
+		// capability.
+		//
+		// A fetch failure here is fatal: returning leaves ArtifactMeta stale and ObservedGeneration
+		// unadvanced, rather than persisting an incomplete ArtifactMeta that could let a per-node
+		// operator install the rulesfile without its real plugin dependencies enforced.
+		logger.Info("Fetching rulesfile ArtifactMeta from OCI content layer", "ref", ref)
+		content, contentErr := am.FetchContent(ctx, rulesfile.Spec.OCIArtifact)
+		if contentErr != nil {
+			logger.Error(contentErr, "Unable to fetch rulesfile OCI content; ArtifactMeta will remain stale", "ref", ref)
+			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactProgramFailed,
+				"Failed to fetch OCI content layer: %s", contentErr.Error())
+			return contentErr
+		}
+		beforeReqs, beforeDeps := len(meta.Requirements), len(meta.Dependencies)
+		appendYAMLRequirements(meta, content)
+		logger.Info("Rulesfile ArtifactMeta parsed from OCI content layer",
+			"ref", ref,
+			"newRequirements", len(meta.Requirements)-beforeReqs,
+			"newDependencies", len(meta.Dependencies)-beforeDeps,
+		)
+
+		artifact.DeduplicateArtifactMeta(meta)
+		logger.Info("Rulesfile ArtifactMeta updated from OCI artifact",
+			"ref", ref,
+			"digest", digest,
+			"requirements", len(meta.Requirements),
+			"dependencies", len(meta.Dependencies),
+		)
+		rulesfile.Status.ArtifactMeta = meta
+		return nil
+	}
+
+	// Non-OCI sources: ConfigMap and/or inline. Always re-parse (cheap).
+	meta := &commonv1alpha1.ArtifactMeta{}
+	if rulesfile.Spec.ConfigMapRef != nil {
+		cm := &corev1.ConfigMap{}
+		key := client.ObjectKey{Name: rulesfile.Spec.ConfigMapRef.Name, Namespace: rulesfile.Namespace}
+		if err := r.Get(ctx, key, cm); err != nil {
+			logger.Error(err, "Unable to fetch ConfigMap for requirements", "configMap", rulesfile.Spec.ConfigMapRef.Name)
+		} else {
+			appendYAMLRequirements(meta, []byte(cm.Data[commonv1alpha1.ConfigMapRulesKey]))
+		}
+		logger.Info("Parsing rulesfile ArtifactMeta from ConfigMap", "configMap", rulesfile.Spec.ConfigMapRef.Name)
+	}
+	if rulesfile.Spec.InlineRules != nil {
+		logger.Info("Parsing rulesfile ArtifactMeta from inline rules")
+		appendYAMLRequirements(meta, rulesfile.Spec.InlineRules.Raw)
+	}
+	artifact.DeduplicateArtifactMeta(meta)
+	logger.Info("Rulesfile ArtifactMeta updated from YAML content",
+		"requirements", len(meta.Requirements),
+		"dependencies", len(meta.Dependencies),
+	)
+	rulesfile.Status.ArtifactMeta = meta
+	return nil
+}
+
+// appendYAMLRequirements parses required_engine_version and required_plugin_versions from
+// a Falco rules YAML document and appends the results to meta.
+func appendYAMLRequirements(meta *commonv1alpha1.ArtifactMeta, content []byte) {
+	rulesReqs, err := compat.ParseRulesRequirements(content)
+	if err != nil || rulesReqs == nil {
+		return
+	}
+	if rulesReqs.EngineVersion != "" {
+		capName := "engine_version_semver"
+		if rulesReqs.EngineVersionIsInt {
+			capName = "engine_version"
+		}
+		meta.Requirements = append(meta.Requirements, commonv1alpha1.ArtifactMetaRequirement{
+			Name: capName, Version: rulesReqs.EngineVersion,
+		})
+	}
+	for _, pv := range rulesReqs.PluginVersions {
+		d := commonv1alpha1.ArtifactMetaDependency{Name: pv.Name, Version: pv.Version}
+		for _, alt := range pv.Alternatives {
+			d.Alternatives = append(d.Alternatives, commonv1alpha1.ArtifactMetaDependencyVariant{
+				Name: alt.Name, Version: alt.Version,
+			})
+		}
+		meta.Dependencies = append(meta.Dependencies, d)
+	}
+}
+
+// handleDeletion deletes all ArtifactNode objects so each per-node artifact operator can clean up
+// and remove its own finalizer (skipping this would deadlock: GC cascade only fires after the owner
+// is deleted, but the in-use finalizer keeps the owner alive).
+func (r *RulesfileAggregatorReconciler) handleDeletion(ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile) error {
+	existing, err := controllerhelper.ListOwnedNodes(ctx, r.Client, rulesfile.Namespace, rulesfile.Name, controllerhelper.KindRulesfile)
+	if err != nil {
+		return err
+	}
+
+	nodesRemaining, err := controllerhelper.DeleteNodeObjectsForParentDeletion(ctx, r.Client, existing.Items)
+	if err != nil {
+		return err
+	}
+	if nodesRemaining {
+		return nil
+	}
+
+	// Evicts this CR's cache entry here, in the last reconcile before the finalizer is
+	// released and the object is removed from etcd.
+	if r.cache != nil {
+		if err := r.cache.RemoveAll(string(artifact.TypeRulesfile), rulesfile.Namespace, rulesfile.Name); err != nil {
+			return fmt.Errorf("evict rulesfile cache entries: %w", err)
+		}
+	}
+
+	return controllerhelper.ReconcileInUseFinalizer(
+		ctx, r.Client, rulesfile,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		false,
+	)
+}
+
+// SetupWithManager registers this controller with the manager.
+func (r *RulesfileAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&artifactv1alpha1.Rulesfile{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return !obj.GetDeletionTimestamp().IsZero()
+			}),
+		))).
+		Watches(&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.RulesfileList{})
+			}),
+		).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, pod client.Object) []reconcile.Request {
+				return controllerhelper.EnqueueAllOfType(ctx, r.Client, &artifactv1alpha1.RulesfileList{}, client.InNamespace(pod.GetNamespace()))
+			}),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				_, ok := obj.GetLabels()["app.kubernetes.io/instance"]
+				return ok
+			})),
+		).
+		Watches(&artifactv1alpha1.ArtifactNode{},
+			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &artifactv1alpha1.Rulesfile{}),
+		).
+		Watches(&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.findRulesfilesForConfigMap),
+		).
+		Watches(&artifactv1alpha1.Plugin{},
+			handler.EnqueueRequestsFromMapFunc(r.findRulesfilesForPlugin),
+		).
+		Named(ControllerName).
+		WithLogConstructor(controllerhelper.LogConstructorFor(mgr.GetLogger(), mgr.GetScheme(), ControllerName, &artifactv1alpha1.Rulesfile{})).
+		Complete(r)
+}
+
+// fetchAndCacheBlob pulls the rulesfile OCI blob (tar.gz of YAML files) and stores it in the artifact cache.
+// Rulesfiles are platform-agnostic so a single blob is shared across all nodes.
+// This runs in the instance operator so that per-node sidecars can fetch from HTTP
+// without touching the registry.
+//
+// Fast path: fetchAndCacheArtifactMeta already resolved the current digest and wrote it to
+// rulesfile.Status.ArtifactMeta.Digest. If r.cache already indexes that exact blob, no
+// filesystem or registry access is needed at all. EnsureBlob is only called when the cache
+// doesn't already have the answer.
+func (r *RulesfileAggregatorReconciler) fetchAndCacheBlob(ctx context.Context, rulesfile *artifactv1alpha1.Rulesfile) error {
+	if r.cache == nil || rulesfile.Spec.OCIArtifact == nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	ref := artifact.ResolveReference(rulesfile.Spec.OCIArtifact)
+
+	// Fast path: this CR's index already points at the blob for the known digest.
+	// Pure in-memory comparison, no filesystem or registry access on a warm cache.
+	if meta := rulesfile.Status.ArtifactMeta; meta != nil && meta.Digest != "" {
+		want := artifactcache.BlobPath(r.cache.Dir(), string(artifact.TypeRulesfile), ref, meta.Digest, "", "")
+		if current, ok := r.cache.Lookup(string(artifact.TypeRulesfile), rulesfile.Namespace, rulesfile.Name, ""); ok && current == want {
+			logger.V(2).Info("Rulesfile blob already cached", "digest", meta.Digest)
+			return nil
+		}
+	}
+
+	// Slow path: cache doesn't already have the answer.
+	// Pass the digest already resolved by fetchAndCacheArtifactMeta to avoid a
+	// second GET /manifests call. Falls back to resolving if digest is not known.
+	var knownDigest string
+	if meta := rulesfile.Status.ArtifactMeta; meta != nil {
+		knownDigest = meta.Digest
+	}
+	logger.Info("Pulling rulesfile blob")
+	var opts []artifact.ManagerOption
+	if r.ociPuller != nil {
+		opts = append(opts, artifact.WithOCIPuller(r.ociPuller))
+	}
+	am := artifact.NewManagerWithOptions(r.Client, rulesfile.Namespace, opts...)
+
+	blobPath, err := am.EnsureBlob(ctx, rulesfile.Spec.OCIArtifact, artifact.TypeRulesfile, "", "", r.cache, knownDigest)
+	if err != nil {
+		return fmt.Errorf("cache rulesfile blob: %w", err)
+	}
+	if err := r.cache.Set(string(artifact.TypeRulesfile), rulesfile.Namespace, rulesfile.Name, "", blobPath); err != nil {
+		return fmt.Errorf("index rulesfile blob: %w", err)
+	}
+	return nil
+}
+
+// findRulesfilesForConfigMap maps a ConfigMap event to the parent Rulesfiles that reference it,
+// so their ArtifactMeta is refreshed when the ConfigMap content changes.
+func (r *RulesfileAggregatorReconciler) findRulesfilesForConfigMap(ctx context.Context, cm client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	list := &artifactv1alpha1.RulesfileList{}
+	indexKey := cm.GetNamespace() + "/" + cm.GetName()
+	if err := r.List(ctx, list, client.MatchingFields{index.ConfigMapOnRulesfile: indexKey}); err != nil {
+		logger.Error(err, "unable to list Rulesfiles by ConfigMap index")
+		return nil
+	}
+	reqs := make([]reconcile.Request, len(list.Items))
+	for i := range list.Items {
+		reqs[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])}
+	}
+	return reqs
+}
+
+// findRulesfilesForPlugin re-enqueues all Rulesfiles in the same namespace that list this
+// plugin as a dependency (primary or alternative) in their Status.ArtifactMeta. This ensures
+// that when a Plugin is deleted, including force-deleted, its dependent Rulesfiles are
+// reconciled so they can reflect the changed dependency state.
+func (r *RulesfileAggregatorReconciler) findRulesfilesForPlugin(ctx context.Context, obj client.Object) []reconcile.Request {
+	// Resolve the canonical plugin name (spec.config.name if set, else metadata.name).
+	// The PluginOnRulesfile index is keyed by canonical names from the OCI config / rules
+	// YAML, not by Kubernetes CR names, so we must query with the same key.
+	canonicalName := obj.GetName()
+	if plugin, ok := obj.(*artifactv1alpha1.Plugin); ok {
+		if plugin.Spec.Config != nil && plugin.Spec.Config.Name != "" {
+			canonicalName = plugin.Spec.Config.Name
+		}
+	}
+	list := &artifactv1alpha1.RulesfileList{}
+	if err := r.List(ctx, list,
+		client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{index.PluginOnRulesfile: canonicalName},
+	); err != nil {
+		log.FromContext(ctx).Error(err, "unable to list RulesFiles for Plugin change")
+		return nil
+	}
+	reqs := make([]reconcile.Request, len(list.Items))
+	for i := range list.Items {
+		reqs[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])}
+	}
+	return reqs
+}

--- a/controllers/instance/artifact/rulesfile/controller_test.go
+++ b/controllers/instance/artifact/rulesfile/controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +48,10 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 )
 
-const testRulesfileName = "test-rulesfile"
+const (
+	testRulesfileName   = "test-rulesfile"
+	testRulesfileDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
 
 func testRulesfileNodeName() string {
 	return controllerhelper.NodeObjectName(controllerhelper.ArtifactKindRulesfile, testRulesfileName, testutil.TestNodeName)
@@ -295,6 +299,46 @@ func TestReconcile_CreatesNodeObject(t *testing.T) {
 	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
 }
 
+func TestReconcile_CreatesIndependentNodeObjectsForNamespaces(t *testing.T) {
+	const (
+		deploymentNamespace = "falco-deployment"
+		daemonSetNamespace  = "falco-daemonset"
+	)
+
+	objects := make([]client.Object, 0, 7)
+	objects = append(objects, newTestNode())
+	for _, namespace := range []string{deploymentNamespace, daemonSetNamespace} {
+		rf := newTestRulesfile()
+		rf.Namespace = namespace
+		falco := newTestFalco()
+		falco.Namespace = namespace
+		pod := newRunningFalcoPod()
+		pod.Namespace = namespace
+		objects = append(objects, rf, falco, pod)
+	}
+	r, cl := newTestReconciler(t, objects...)
+
+	for _, namespace := range []string{deploymentNamespace, daemonSetNamespace} {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+			Name:      testRulesfileName,
+			Namespace: namespace,
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, result)
+
+		rfNode := &artifactv1alpha1.ArtifactNode{}
+		require.NoError(t, cl.Get(context.Background(), types.NamespacedName{
+			Name:      testRulesfileNodeName(),
+			Namespace: namespace,
+		}, rfNode))
+		assert.Equal(t, testutil.TestNodeName, rfNode.Spec.NodeName)
+	}
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Len(t, nodeList.Items, 2)
+}
+
 func TestReconcile_NodeObjectAlreadyExists(t *testing.T) {
 	rf := newTestRulesfile()
 	node := newTestNode()
@@ -356,7 +400,7 @@ func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) 
 			Message: "old result",
 		}}
 	})
-	r, cl := newTestReconciler(t, rf, staleNode, newTestNode())
+	r, cl := newTestReconciler(t, rf, staleNode, newTestNode(), newTestFalco(), newRunningFalcoPod())
 
 	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
 	require.NoError(t, err)
@@ -375,6 +419,26 @@ func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) 
 	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
 	assert.Equal(t, "NoNodesAssigned", condition.Reason,
 		"the stale child's last successful result must not remain in the aggregate")
+}
+
+func TestReconcile_RemovesNodeObjectWhenFalcoPodGone(t *testing.T) {
+	rf := newTestRulesfile(func(r *artifactv1alpha1.Rulesfile) {
+		r.Finalizers = []string{controllerhelper.NodeObjectsInUseFinalizer}
+	})
+	staleNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"artifact.example.com/node-cleanup"}
+	})
+	// The Kubernetes Node still matches the Rulesfile selector, but no Falco pod remains there.
+	r, cl := newTestReconciler(t, rf, staleNode, newTestNode())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	err = cl.Get(context.Background(), client.ObjectKeyFromObject(staleNode), got)
+	assert.True(t, k8serrors.IsNotFound(err),
+		"the instance operator must garbage-collect the ArtifactNode when its artifact operator is gone")
 }
 
 func TestReconcile_ListMatchingNodesError(t *testing.T) {
@@ -428,6 +492,14 @@ func TestHandleDeletion_NoNodeObjects(t *testing.T) {
 		WithScheme(s).
 		WithObjects(rf).
 		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*instancev1alpha1.FalcoList); ok {
+					return fmt.Errorf("Falco list should not be called without node objects")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
 		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
 		Build()
 	addInUseFinalizer(t, cl, rf)
@@ -524,10 +596,14 @@ func TestHandleDeletion_NodeObjectsBeingDeleted(t *testing.T) {
 		n.DeletionTimestamp = &now
 		n.Finalizers = []string{"some-finalizer"}
 	})
-	r, _ := newTestReconciler(t, rf, rfNode)
+	r, cl := newTestReconciler(t, rf, rfNode, newTestNode(), newTestFalco(), newRunningFalcoPod())
 
 	err := r.handleDeletion(context.Background(), rf)
 	require.NoError(t, err)
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rfNode), got))
+	assert.NotEmpty(t, got.Finalizers, "the running node-side operator must retain responsibility for cleanup")
 }
 
 func TestHandleDeletion_ListError(t *testing.T) {
@@ -1203,7 +1279,7 @@ func TestFetchAndCacheBinary_FastPath(t *testing.T) {
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
 
 	ref := artifact.ResolveReference(rf.Spec.OCIArtifact)
-	const digest = "sha256:cached-rules"
+	const digest = testRulesfileDigest
 	blobPath := artifactcache.BlobPath(cacheDir, string(artifact.TypeRulesfile), ref, digest, "", "")
 	require.NoError(t, artifactcache.Store(blobPath, []byte("rule content"), 0o644))
 	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "", blobPath))
@@ -1229,8 +1305,8 @@ func TestFetchAndCacheBinary_SlowPath(t *testing.T) {
 	require.NoError(t, err)
 
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:pulled-rules",
-		Result:              &puller.RegistryResult{Type: puller.Rulesfile},
+		ResolveDigestResult: testRulesfileDigest,
+		Result:              &puller.RegistryResult{RootDigest: testRulesfileDigest, Type: puller.Rulesfile},
 		LayerContent:        tarGz,
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
@@ -1247,7 +1323,7 @@ func TestFetchAndCacheBinary_PullError(t *testing.T) {
 	cacheDir := t.TempDir()
 	rf := newTestRulesfile(withRulesfileOCI())
 	mockPuller := &puller.MockOCIPuller{
-		ResolveDigestResult: "sha256:xyz",
+		ResolveDigestResult: testRulesfileDigest,
 		PullErr:             fmt.Errorf("registry down"),
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
@@ -1259,8 +1335,8 @@ func TestFetchAndCacheBinary_PullError(t *testing.T) {
 
 func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 	// Selector requires env=prod; plain node doesn't have that label → staleNode is stale.
-	// staleNode has a finalizer so ClearFinalizersIfNodeGone doesn't short-circuit.
-	// The interceptor makes Node.Get return a non-404 error propagated to Reconcile.
+	// staleNode has a finalizer and a Falco pod still runs there, so orphan detection calls
+	// Node.Get. The interceptor returns a non-404 error that propagates to Reconcile.
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	rf := newTestRulesfile(withRulesfileSelector())
 	staleNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
@@ -1269,7 +1345,7 @@ func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 	plainNode := newTestNode()
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(rf, staleNode, plainNode).
+		WithObjects(rf, staleNode, plainNode, newTestFalco(), newRunningFalcoPod()).
 		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -1288,8 +1364,8 @@ func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 }
 
 func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
-	// RulesfileNode has a finalizer so ClearFinalizersIfNodeGone proceeds to check the node.
-	// The Node.Get interceptor returns a non-404 error that is propagated to the caller.
+	// RulesfileNode has a finalizer and a Falco pod still runs on its node, so orphan detection
+	// checks the Kubernetes Node via Get. The interceptor fails it with a non-404 error.
 	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
 	rf := newTestRulesfile()
 	rfNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
@@ -1297,7 +1373,7 @@ func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
 	})
 	cl := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(rf, rfNode).
+		WithObjects(rf, rfNode, newTestFalco(), newRunningFalcoPod()).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 				if _, ok := obj.(*corev1.Node); ok {
@@ -1324,7 +1400,7 @@ func TestReconcile_FetchAndCacheBinaryError(t *testing.T) {
 
 	mockPuller := &puller.MockOCIPuller{
 		ConfigResult: &puller.ArtifactConfig{},
-		ConfigDigest: "sha256:meta",
+		ConfigDigest: testRulesfileDigest,
 		PullErr:      fmt.Errorf("registry down"),
 	}
 	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf, node)

--- a/controllers/instance/artifact/rulesfile/controller_test.go
+++ b/controllers/instance/artifact/rulesfile/controller_test.go
@@ -1,0 +1,1334 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rulesfile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+	"github.com/falcosecurity/falco-operator/controllers/testutil"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
+	"github.com/falcosecurity/falco-operator/internal/pkg/index"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+)
+
+const testRulesfileName = "test-rulesfile"
+
+func testRulesfileNodeName() string {
+	return controllerhelper.NodeObjectName(controllerhelper.ArtifactKindRulesfile, testRulesfileName, testutil.TestNodeName)
+}
+
+func testOCIArtifact() *commonv1alpha1.OCIArtifact {
+	return &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "ghcr.io/test/rulesfile", Tag: "latest"},
+	}
+}
+
+func newTestNode() *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testutil.TestNodeName}}
+}
+
+func newTestRulesfile(opts ...func(*artifactv1alpha1.Rulesfile)) *artifactv1alpha1.Rulesfile {
+	rf := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: testRulesfileName, Namespace: testutil.TestNamespace},
+	}
+	for _, o := range opts {
+		o(rf)
+	}
+	return rf
+}
+
+func withRulesfileOCI() func(*artifactv1alpha1.Rulesfile) {
+	return func(rf *artifactv1alpha1.Rulesfile) {
+		rf.Spec.OCIArtifact = testOCIArtifact()
+	}
+}
+
+func withRulesfileSelector() func(*artifactv1alpha1.Rulesfile) {
+	return func(rf *artifactv1alpha1.Rulesfile) {
+		rf.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}
+	}
+}
+
+func withRulesfileConfigMapRef(name string) func(*artifactv1alpha1.Rulesfile) {
+	return func(rf *artifactv1alpha1.Rulesfile) {
+		rf.Spec.ConfigMapRef = &commonv1alpha1.ConfigMapRef{Name: name}
+	}
+}
+
+func withInlineRules(yamlContent string) func(*artifactv1alpha1.Rulesfile) {
+	return func(rf *artifactv1alpha1.Rulesfile) {
+		rf.Spec.InlineRules = &apiextensionsv1.JSON{Raw: []byte(yamlContent)}
+	}
+}
+
+func newTestRulesfileNode(opts ...func(*artifactv1alpha1.ArtifactNode)) *artifactv1alpha1.ArtifactNode {
+	isController := true
+	n := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRulesfileNodeName(),
+			Namespace: testutil.TestNamespace,
+			Labels:    controllerhelper.NodeObjectLabels(controllerhelper.ArtifactKindRulesfile, testRulesfileName, testutil.TestNodeName),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: artifactv1alpha1.GroupVersion.String(),
+				Kind:       "Rulesfile",
+				Name:       testRulesfileName,
+				Controller: &isController,
+			}},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+	}
+	for _, o := range opts {
+		o(n)
+	}
+	return n
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*RulesfileAggregatorReconciler, client.Client) {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	return NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil), cl
+}
+
+func newTestReconcilerWithIndex(t *testing.T, objs ...client.Object) (*RulesfileAggregatorReconciler, client.Client) {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		WithIndex(&artifactv1alpha1.Rulesfile{}, index.ConfigMapOnRulesfile, index.RulesfileByConfigMapRef).
+		Build()
+	return NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil), cl
+}
+
+func newTestReconcilerWithPluginIndex(t *testing.T, objs ...client.Object) *RulesfileAggregatorReconciler {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		WithIndex(&artifactv1alpha1.Rulesfile{}, index.PluginOnRulesfile, index.RulesfileByPluginDependency).
+		Build()
+	return NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+}
+
+func newTestReconcilerWithPuller(t *testing.T, mockPuller puller.Puller, objs ...client.Object) (*RulesfileAggregatorReconciler, client.Client) {
+	t.Helper()
+	r, cl := newTestReconciler(t, objs...)
+	r.ociPuller = mockPuller
+	return r, cl
+}
+
+func addInUseFinalizer(t *testing.T, cl client.Client, rf *artifactv1alpha1.Rulesfile) {
+	t.Helper()
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), rf))
+	require.NoError(t, controllerhelper.EnsureInUseFinalizer(
+		context.Background(), cl,
+		controllerhelper.NodeObjectsInUseFinalizer,
+		rf, true,
+	))
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), rf))
+}
+
+const testFalcoName = "test-falco"
+
+func newTestFalco() *instancev1alpha1.Falco {
+	return &instancev1alpha1.Falco{
+		ObjectMeta: metav1.ObjectMeta{Name: testFalcoName, Namespace: testutil.TestNamespace},
+	}
+}
+
+func newRunningFalcoPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "falco-pod",
+			Namespace: testutil.TestNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/instance": testFalcoName},
+		},
+		Spec:   corev1.PodSpec{NodeName: testutil.TestNodeName},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestReconcile_NotFound(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	result, err := r.Reconcile(context.Background(), testutil.Request("nonexistent"))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcile_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return fmt.Errorf("api server error")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_DeletionNoNodeObjects(t *testing.T) {
+	// A keep-alive finalizer makes cl.Delete set DeletionTimestamp without removing the object.
+	rf := newTestRulesfile(func(r *artifactv1alpha1.Rulesfile) {
+		r.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	rec, cl := newTestReconciler(t, rf)
+
+	require.NoError(t, cl.Delete(context.Background(), rf))
+
+	result, err := rec.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// No RulesfileNodes should exist.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletionWithNodeObjects(t *testing.T) {
+	// A keep-alive finalizer makes cl.Delete set DeletionTimestamp without removing the object.
+	rf := newTestRulesfile(func(r *artifactv1alpha1.Rulesfile) {
+		r.Finalizers = []string{"test.example.com/keep-alive"}
+	})
+	rfNode := newTestRulesfileNode()
+	rec, cl := newTestReconciler(t, rf, rfNode)
+
+	require.NoError(t, cl.Delete(context.Background(), rf))
+
+	result, err := rec.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// RulesfileNode should be deleted.
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_NoMatchingNodes(t *testing.T) {
+	rf := newTestRulesfile()
+	r, cl := newTestReconciler(t, rf)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+}
+
+func TestReconcile_CreatesNodeObject(t *testing.T) {
+	rf := newTestRulesfile()
+	node := newTestNode()
+	r, cl := newTestReconciler(t, rf, node, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	rfNode := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testRulesfileNodeName(), Namespace: testutil.TestNamespace}, rfNode))
+	assert.Equal(t, testutil.TestNodeName, rfNode.Spec.NodeName)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestReconcile_NodeObjectAlreadyExists(t *testing.T) {
+	rf := newTestRulesfile()
+	node := newTestNode()
+	existing := newTestRulesfileNode()
+	r, cl := newTestReconciler(t, rf, node, existing, newTestFalco(), newRunningFalcoPod())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	list := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), list))
+	assert.Len(t, list.Items, 1)
+}
+
+func TestReconcile_NoFalcoPod_NoNodeObject(t *testing.T) {
+	// Node matches the artifact selector but no Falco pod is running on it.
+	rf := newTestRulesfile()
+	node := newTestNode()
+	r, cl := newTestReconciler(t, rf, node) // no Falco CR or pod
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_DeletesStaleNodeObject(t *testing.T) {
+	rf := newTestRulesfile(withRulesfileSelector())
+	staleNode := newTestRulesfileNode()
+	plainNode := newTestNode()
+	r, cl := newTestReconciler(t, rf, staleNode, plainNode)
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), nodeList))
+	assert.Empty(t, nodeList.Items)
+}
+
+func TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated(t *testing.T) {
+	rf := newTestRulesfile(
+		withRulesfileSelector(),
+		func(r *artifactv1alpha1.Rulesfile) {
+			r.Finalizers = []string{controllerhelper.NodeObjectsInUseFinalizer}
+		},
+	)
+	staleNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"artifact.example.com/node-cleanup"}
+		n.Status.Conditions = []metav1.Condition{{
+			Type:    commonv1alpha1.ConditionProgrammed.String(),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Programmed",
+			Message: "old result",
+		}}
+	})
+	r, cl := newTestReconciler(t, rf, staleNode, newTestNode())
+
+	result, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	terminating := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(staleNode), terminating))
+	assert.False(t, terminating.DeletionTimestamp.IsZero(), "the node-side finalizer keeps the stale child terminating")
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	assert.Contains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer,
+		"the parent must stay alive until the terminating child is physically gone")
+	condition := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionUnknown, condition.Status)
+	assert.Equal(t, "NoNodesAssigned", condition.Reason,
+		"the stale child's last successful result must not remain in the aggregate")
+}
+
+func TestReconcile_ListMatchingNodesError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NodeList); ok {
+					return fmt.Errorf("node list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_ListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("rulesfile node list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestHandleDeletion_NoNodeObjects(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	addInUseFinalizer(t, cl, rf)
+
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	assert.NotContains(t, got.Finalizers, controllerhelper.NodeObjectsInUseFinalizer)
+}
+
+func TestHandleDeletion_NodeObjectsPresent(t *testing.T) {
+	rf := newTestRulesfile()
+	rfNode := newTestRulesfileNode()
+	r, cl := newTestReconciler(t, rf, rfNode)
+
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+
+	node := &artifactv1alpha1.ArtifactNode{}
+	err = cl.Get(context.Background(),
+		types.NamespacedName{Name: testRulesfileNodeName(), Namespace: testutil.TestNamespace}, node)
+	assert.Error(t, err)
+}
+
+func TestHandleDeletion_EvictsCacheEntry(t *testing.T) {
+	rf := newTestRulesfile()
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, rf)
+
+	blobPath := filepath.Join(cacheDir, "blobs", "own")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o644))
+	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "", blobPath))
+
+	// No ArtifactNode objects are owned by this Rulesfile, so handleDeletion evicts the cache entry now.
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+
+	_, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "")
+	assert.False(t, ok)
+	_, statErr := os.Stat(blobPath)
+	assert.True(t, os.IsNotExist(statErr), "exclusively-referenced blob must be removed from disk")
+}
+
+func TestHandleDeletion_SharedBlobSurvivesEviction(t *testing.T) {
+	rf := newTestRulesfile()
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, rf)
+
+	// Two Rulesfile CRs reference the same content-addressed blob; deleting one decrements
+	// the refcount and leaves the file in place.
+	sharedBlob := filepath.Join(cacheDir, "blobs", "shared")
+	require.NoError(t, artifactcache.Store(sharedBlob, []byte("y"), 0o644))
+	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "", sharedBlob))
+	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, "other-rulesfile", "", sharedBlob))
+
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+
+	_, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "")
+	assert.False(t, ok)
+
+	got, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, "other-rulesfile", "")
+	require.True(t, ok, "other CR's entry for the shared blob must survive")
+	assert.Equal(t, sharedBlob, got)
+	_, statErr := os.Stat(sharedBlob)
+	assert.NoError(t, statErr, "shared blob must survive: another CR still references it")
+}
+
+func TestHandleDeletion_NodesRemaining_DoesNotEvictCache(t *testing.T) {
+	rf := newTestRulesfile()
+	rfNode := newTestRulesfileNode()
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, rf, rfNode)
+
+	blobPath := filepath.Join(cacheDir, "blobs", "own")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("x"), 0o644))
+	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "", blobPath))
+
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+
+	got, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "")
+	require.True(t, ok, "cache entry must survive while a node object still exists")
+	assert.Equal(t, blobPath, got)
+}
+
+func TestHandleDeletion_NodeObjectsBeingDeleted(t *testing.T) {
+	rf := newTestRulesfile()
+	rfNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
+		now := metav1.Now()
+		n.DeletionTimestamp = &now
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	r, _ := newTestReconciler(t, rf, rfNode)
+
+	err := r.handleDeletion(context.Background(), rf)
+	require.NoError(t, err)
+}
+
+func TestHandleDeletion_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+
+	err := r.handleDeletion(context.Background(), rf)
+	require.Error(t, err)
+}
+
+func TestEnsureNodeObject_AlreadyExists(t *testing.T) {
+	rf := newTestRulesfile()
+	existing := newTestRulesfileNode()
+	r, cl := newTestReconciler(t, rf, existing)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, rf,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindRulesfile), controllerhelper.ArtifactKindRulesfile, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	list := &artifactv1alpha1.ArtifactNodeList{}
+	require.NoError(t, cl.List(context.Background(), list))
+	assert.Len(t, list.Items, 1)
+}
+
+func TestEnsureNodeObject_Creates(t *testing.T) {
+	rf := newTestRulesfile()
+	r, cl := newTestReconciler(t, rf)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, rf,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindRulesfile), controllerhelper.ArtifactKindRulesfile, testutil.TestNodeName)
+	require.NoError(t, err)
+
+	created := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(),
+		types.NamespacedName{Name: testRulesfileNodeName(), Namespace: testutil.TestNamespace}, created))
+	assert.Equal(t, testutil.TestNodeName, created.Spec.NodeName)
+	assert.Equal(t, testRulesfileName, created.Labels[controllerhelper.LabelArtifactParent])
+}
+
+func TestEnsureNodeObject_GetError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("get error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+
+	err := controllerhelper.EnsureNodeObject(context.Background(), r.Client, rf,
+		artifactv1alpha1.GroupVersion.WithKind(controllerhelper.KindRulesfile), controllerhelper.ArtifactKindRulesfile, testutil.TestNodeName)
+	require.Error(t, err)
+}
+
+func TestUpdateAggregateConditions_Empty(t *testing.T) {
+	rf := newTestRulesfile()
+	r, cl := newTestReconciler(t, rf)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{}
+	err := controllerhelper.UpdateAggregateConditions(context.Background(), r.Client, r.Scheme, rf, &rf.Status.Conditions, nodeList, ControllerName)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+	assert.Equal(t, "NoNodesAssigned", cond.Reason)
+}
+
+func TestUpdateAggregateConditions_WithNodeConditions(t *testing.T) {
+	rf := newTestRulesfile()
+	r, cl := newTestReconciler(t, rf)
+
+	nodeList := &artifactv1alpha1.ArtifactNodeList{
+		Items: []artifactv1alpha1.ArtifactNode{
+			{
+				Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: testutil.TestNodeName},
+				Status: artifactv1alpha1.ArtifactNodeStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    commonv1alpha1.ConditionProgrammed.String(),
+							Status:  metav1.ConditionTrue,
+							Reason:  "Programmed",
+							Message: "ok",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := controllerhelper.UpdateAggregateConditions(context.Background(), r.Client, r.Scheme, rf, &rf.Status.Conditions, nodeList, ControllerName)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+}
+
+func TestFetchAndCacheArtifactMeta_NoSources(t *testing.T) {
+	rf := newTestRulesfile()
+	r, _ := newTestReconciler(t, rf)
+
+	rf.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{Digest: "old"}
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	assert.Nil(t, rf.Status.ArtifactMeta)
+}
+
+func TestFetchAndCacheArtifactMeta_OCICacheHit(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	specHash, err := artifact.ComputeOCIArtifactSpecHash(rf.Spec.OCIArtifact)
+	require.NoError(t, err)
+	rf.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{
+		SpecHash: specHash,
+		Digest:   "sha256:abc",
+	}
+
+	err = r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	assert.Empty(t, mockPuller.FetchConfigCalls)
+}
+
+func TestFetchAndCacheArtifactMeta_OCICacheMiss(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{{Name: "engine_version", Version: "0.36.0"}},
+		},
+		ConfigDigest:  "sha256:new",
+		ContentResult: nil, // no content
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	assert.Len(t, mockPuller.FetchConfigCalls, 1)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	assert.Equal(t, "sha256:new", rf.Status.ArtifactMeta.Digest)
+	require.Len(t, rf.Status.ArtifactMeta.Requirements, 1)
+}
+
+func TestFetchAndCacheArtifactMeta_OCIFetchConfigError(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		FetchConfigErr: fmt.Errorf("registry unavailable"),
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry unavailable")
+	// Records the failure as a Kubernetes event on the Rulesfile.
+	testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events,
+		[]string{"Warning OCIArtifactProgramFailed Failed to fetch OCI config layer: registry unavailable"})
+}
+
+func TestFetchAndCacheArtifactMeta_OCIContentFetchError(t *testing.T) {
+	// The content layer is the only source of required_engine_version and
+	// required_plugin_versions, so a content fetch error is fatal and metadata is not persisted.
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult:    &puller.ArtifactConfig{},
+		ConfigDigest:    "sha256:ok",
+		FetchContentErr: fmt.Errorf("content layer missing"),
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "content layer missing")
+	assert.Nil(t, rf.Status.ArtifactMeta, "must not persist metadata computed from an incomplete fetch")
+	testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events,
+		[]string{"Warning OCIArtifactProgramFailed Failed to fetch OCI content layer: content layer missing"})
+}
+
+func TestFetchAndCacheArtifactMeta_OCIWithContentRequirements(t *testing.T) {
+	// Content YAML declares engine version requirement.
+	yamlContent := []byte(`- required_engine_version: 22`)
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult:  &puller.ArtifactConfig{},
+		ConfigDigest:  "sha256:content",
+		ContentResult: yamlContent,
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	// engine_version from YAML content should appear in requirements.
+	assert.NotEmpty(t, rf.Status.ArtifactMeta.Requirements)
+}
+
+func TestFetchAndCacheArtifactMeta_ConfigMap(t *testing.T) {
+	yamlContent := `- required_engine_version: 15`
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data:       map[string]string{commonv1alpha1.ConfigMapRulesKey: yamlContent},
+	}
+	rf := newTestRulesfile(withRulesfileConfigMapRef("my-rules-cm"))
+	r, _ := newTestReconciler(t, rf, cm)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+}
+
+func TestFetchAndCacheArtifactMeta_ConfigMapMissing(t *testing.T) {
+	rf := newTestRulesfile(withRulesfileConfigMapRef("missing-cm"))
+	r, _ := newTestReconciler(t, rf)
+
+	// ConfigMap not found: error is logged but ArtifactMeta is still set (empty).
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+}
+
+func TestFetchAndCacheArtifactMeta_InlineRules(t *testing.T) {
+	rf := newTestRulesfile(withInlineRules("- required_engine_version: 10"))
+	r, _ := newTestReconciler(t, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+}
+
+func TestFetchAndCacheArtifactMeta_ConfigMapAndInlineRules(t *testing.T) {
+	// ConfigMap has no requirements; InlineRules declares required_engine_version.
+	// Both sources are parsed into ArtifactMeta.Requirements.
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data:       map[string]string{commonv1alpha1.ConfigMapRulesKey: "- rule: plain\n  condition: true\n  output: x\n  desc: d\n  priority: DEBUG"},
+	}
+	rf := newTestRulesfile(
+		withRulesfileConfigMapRef("my-rules-cm"),
+		withInlineRules(`- required_engine_version: "0.30.0"`),
+	)
+	r, _ := newTestReconciler(t, rf, cm)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	require.Len(t, rf.Status.ArtifactMeta.Requirements, 1)
+	assert.Equal(t, "engine_version_semver", rf.Status.ArtifactMeta.Requirements[0].Name)
+	assert.Equal(t, "0.30.0", rf.Status.ArtifactMeta.Requirements[0].Version)
+}
+
+func TestAppendYAMLRequirements_EngineVersionInt(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	content := []byte(`- required_engine_version: 22`)
+	appendYAMLRequirements(meta, content)
+	require.Len(t, meta.Requirements, 1)
+	assert.Equal(t, "engine_version", meta.Requirements[0].Name)
+	assert.Equal(t, "22", meta.Requirements[0].Version)
+}
+
+func TestAppendYAMLRequirements_EngineVersionSemver(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	content := []byte(`- required_engine_version: "0.36.0"`)
+	appendYAMLRequirements(meta, content)
+	require.Len(t, meta.Requirements, 1)
+	assert.Equal(t, "engine_version_semver", meta.Requirements[0].Name)
+}
+
+func TestAppendYAMLRequirements_Empty(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	appendYAMLRequirements(meta, nil)
+	assert.Empty(t, meta.Requirements)
+	assert.Empty(t, meta.Dependencies)
+}
+
+func TestAppendYAMLRequirements_InvalidYAML(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	appendYAMLRequirements(meta, []byte("{invalid"))
+	// Should not panic and should produce no requirements.
+	assert.Empty(t, meta.Requirements)
+}
+
+func TestFindRulesfilesForNode(t *testing.T) {
+	rf := newTestRulesfile()
+	r, _ := newTestReconciler(t, rf)
+
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), r.Client, &artifactv1alpha1.RulesfileList{})
+	require.Len(t, reqs, 1)
+	assert.Equal(t, testRulesfileName, reqs[0].Name)
+}
+
+func TestFindRulesfilesForNode_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	reqs := controllerhelper.EnqueueAllOfType(context.Background(), cl, &artifactv1alpha1.RulesfileList{})
+	assert.Nil(t, reqs)
+}
+
+func TestFindRulesfilesForConfigMap(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+	}
+	rf := newTestRulesfile(withRulesfileConfigMapRef("my-rules-cm"))
+	r, _ := newTestReconcilerWithIndex(t, rf, cm)
+
+	reqs := r.findRulesfilesForConfigMap(context.Background(), cm)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, testRulesfileName, reqs[0].Name)
+}
+
+func TestFindRulesfilesForConfigMap_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: testutil.TestNamespace}}
+	reqs := r.findRulesfilesForConfigMap(context.Background(), cm)
+	assert.Nil(t, reqs)
+}
+
+func TestFindRulesfilesForPlugin(t *testing.T) {
+	const pluginName = "my-plugin"
+	rf := newTestRulesfile(func(r *artifactv1alpha1.Rulesfile) {
+		r.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{
+			Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+				{Name: pluginName, Version: "0.1.0"},
+			},
+		}
+	})
+	plugin := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: pluginName, Namespace: testutil.TestNamespace},
+	}
+	r := newTestReconcilerWithPluginIndex(t, rf, plugin)
+
+	reqs := r.findRulesfilesForPlugin(context.Background(), plugin)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, testRulesfileName, reqs[0].Name)
+}
+
+func TestFindRulesfilesForPlugin_NoMatch(t *testing.T) {
+	rf := newTestRulesfile() // no ArtifactMeta → not indexed
+	plugin := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated-plugin", Namespace: testutil.TestNamespace},
+	}
+	r := newTestReconcilerWithPluginIndex(t, rf, plugin)
+
+	reqs := r.findRulesfilesForPlugin(context.Background(), plugin)
+	assert.Empty(t, reqs)
+}
+
+func TestFindRulesfilesForPlugin_ListError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.RulesfileList); ok {
+					return fmt.Errorf("list error")
+				}
+				return nil
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		WithIndex(&artifactv1alpha1.Rulesfile{}, index.PluginOnRulesfile, index.RulesfileByPluginDependency).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	plugin := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testutil.TestNamespace}}
+	reqs := r.findRulesfilesForPlugin(context.Background(), plugin)
+	assert.Nil(t, reqs)
+}
+
+// ── Reconcile error-path coverage ───────────────────────────────────────────
+
+func TestReconcile_DeleteStaleNodeError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	// Selector requires env=prod; testutil.TestNodeName has no such label → stale.
+	rf := newTestRulesfile(withRulesfileSelector())
+	staleNode := newTestRulesfileNode()
+	plainNode := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, staleNode, plainNode).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("delete failed")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_EnsureNodeObjectError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	node := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, node, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("create failed")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_EnsureInUseFinalizerError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	node := newTestNode()
+	rfNode := newTestRulesfileNode() // pre-existing so ensureNodeObject is a no-op
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, node, rfNode, newTestFalco(), newRunningFalcoPod()).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("patch failed")
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_SecondListNodeObjectsError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	node := newTestNode()
+	rfNode := newTestRulesfileNode() // pre-existing so ensureNodeObject is a no-op
+	var listCount int
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, node, rfNode).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*artifactv1alpha1.ArtifactNodeList); ok {
+					listCount++
+					if listCount == 2 {
+						return fmt.Errorf("second list error")
+					}
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+func TestReconcile_FetchAndCacheError(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		FetchConfigErr: fmt.Errorf("registry down"),
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	node := newTestNode()
+	rfNode := newTestRulesfileNode() // pre-existing
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf, node, rfNode)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+}
+
+// ── fetchAndCacheArtifactMeta additional paths ───────────────────────────────
+
+func TestFetchAndCacheArtifactMeta_OCIWithDependencies(t *testing.T) {
+	// FetchConfig returns a dependency with an alternative.
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Dependencies: []puller.ArtifactDependency{
+				{
+					Name:    "cloudtrail",
+					Version: "0.9.0",
+					Alternatives: []puller.Dependency{
+						{Name: "k8saudit", Version: "0.7.0"},
+					},
+				},
+			},
+		},
+		ConfigDigest:  "sha256:deps",
+		ContentResult: nil,
+	}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	require.Len(t, rf.Status.ArtifactMeta.Dependencies, 1)
+	require.Len(t, rf.Status.ArtifactMeta.Dependencies[0].Alternatives, 1)
+	assert.Equal(t, "k8saudit", rf.Status.ArtifactMeta.Dependencies[0].Alternatives[0].Name)
+}
+
+func TestFetchAndCacheArtifactMeta_OCICacheHitIgnoresDigest(t *testing.T) {
+	// Spec hash matches even though the stored digest is stale, so the cache is still a hit.
+	// Picking up a new image pushed to the same tag requires an explicit spec change.
+	mockPuller := &puller.MockOCIPuller{}
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	specHash, err := artifact.ComputeOCIArtifactSpecHash(rf.Spec.OCIArtifact)
+	require.NoError(t, err)
+	rf.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{
+		SpecHash: specHash,
+		Digest:   "sha256:old",
+	}
+
+	err = r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	assert.Empty(t, mockPuller.FetchConfigCalls, "spec hash match must skip FetchConfig regardless of digest")
+	assert.Equal(t, "sha256:old", rf.Status.ArtifactMeta.Digest, "stale digest must not be updated on cache hit")
+}
+
+// ── appendYAMLRequirements plugin-version paths ──────────────────────────────
+
+func TestAppendYAMLRequirements_PluginVersions(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	content := []byte("- required_plugin_versions:\n  - name: cloudtrail\n    version: \"0.9.0\"")
+	appendYAMLRequirements(meta, content)
+	require.Len(t, meta.Dependencies, 1)
+	assert.Equal(t, "cloudtrail", meta.Dependencies[0].Name)
+	assert.Equal(t, "0.9.0", meta.Dependencies[0].Version)
+	assert.Empty(t, meta.Dependencies[0].Alternatives)
+}
+
+func TestAppendYAMLRequirements_PluginVersionsWithAlternatives(t *testing.T) {
+	meta := &commonv1alpha1.ArtifactMeta{}
+	content := []byte("- required_plugin_versions:\n  - name: cloudtrail\n    version: \"0.9.0\"\n" +
+		"    alternatives:\n      - name: k8saudit\n        version: \"0.7.0\"")
+	appendYAMLRequirements(meta, content)
+	require.Len(t, meta.Dependencies, 1)
+	assert.Equal(t, "cloudtrail", meta.Dependencies[0].Name)
+	require.Len(t, meta.Dependencies[0].Alternatives, 1)
+	assert.Equal(t, "k8saudit", meta.Dependencies[0].Alternatives[0].Name)
+	assert.Equal(t, "0.7.0", meta.Dependencies[0].Alternatives[0].Version)
+}
+
+// ── handleDeletion error path ────────────────────────────────────────────────
+
+func TestHandleDeletion_DeleteError(t *testing.T) {
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	rfNode := newTestRulesfileNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, rfNode).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if _, ok := obj.(*artifactv1alpha1.ArtifactNode); ok {
+					return fmt.Errorf("delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), rf)
+	require.Error(t, err)
+}
+
+// ── fetchAndCacheBlob tests ────────────────────────────────────────────────
+
+// newTestReconcilerWithCacheAndPuller creates a RulesfileAggregatorReconciler with a real,
+// loaded artifact Cache rooted at cacheDir, and an injected mock OCI puller.
+func newTestReconcilerWithCacheAndPuller(
+	t *testing.T, mockPuller puller.Puller, cacheDir string, objs ...client.Object,
+) *RulesfileAggregatorReconciler {
+	t.Helper()
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	// Zero grace period: a dereferenced blob is removed from disk immediately.
+	cache := artifactcache.NewCache(cacheDir, artifactcache.WithEvictionGracePeriod(0))
+	require.NoError(t, cache.Load())
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), cache)
+	r.ociPuller = mockPuller
+	return r
+}
+
+func TestFetchAndCacheBinary_NoCache(t *testing.T) {
+	// A nil cache disables caching; fetchAndCacheBlob returns immediately.
+	rf := newTestRulesfile(withRulesfileOCI())
+	r, _ := newTestReconciler(t, rf) // cache = nil
+	err := r.fetchAndCacheBlob(context.Background(), rf)
+	require.NoError(t, err)
+}
+
+func TestFetchAndCacheBinary_NoOCIArtifact(t *testing.T) {
+	// Non-OCI source (ConfigMap ref) → noop regardless of cacheDir.
+	rf := newTestRulesfile(withRulesfileConfigMapRef("my-cm"))
+	cacheDir := t.TempDir()
+	r := newTestReconcilerWithCacheAndPuller(t, nil, cacheDir, rf)
+	err := r.fetchAndCacheBlob(context.Background(), rf)
+	require.NoError(t, err)
+}
+
+func TestFetchAndCacheBinary_FastPath(t *testing.T) {
+	// This CR's cache entry already points at the blob for the known digest: no registry
+	// call needed.
+	cacheDir := t.TempDir()
+	rf := newTestRulesfile(withRulesfileOCI())
+	mockPuller := &puller.MockOCIPuller{} // must not be called
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
+
+	ref := artifact.ResolveReference(rf.Spec.OCIArtifact)
+	const digest = "sha256:cached-rules"
+	blobPath := artifactcache.BlobPath(cacheDir, string(artifact.TypeRulesfile), ref, digest, "", "")
+	require.NoError(t, artifactcache.Store(blobPath, []byte("rule content"), 0o644))
+	require.NoError(t, r.cache.Set(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "", blobPath))
+
+	rf.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{Digest: digest}
+
+	require.NoError(t, r.fetchAndCacheBlob(context.Background(), rf))
+
+	assert.Empty(t, mockPuller.ResolveDigestCalls)
+	assert.Empty(t, mockPuller.PullCalls)
+
+	idx, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "")
+	require.True(t, ok)
+	assert.Equal(t, blobPath, idx)
+}
+
+func TestFetchAndCacheBinary_SlowPath(t *testing.T) {
+	// Blob is missing: EnsureBlob pulls from registry and writes the index.
+	cacheDir := t.TempDir()
+	rf := newTestRulesfile(withRulesfileOCI())
+
+	tarGz, err := puller.MakeTarGz("rules.yml", []byte("- rule: test"))
+	require.NoError(t, err)
+
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:pulled-rules",
+		Result:              &puller.RegistryResult{Type: puller.Rulesfile},
+		LayerContent:        tarGz,
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
+
+	require.NoError(t, r.fetchAndCacheBlob(context.Background(), rf))
+
+	assert.Len(t, mockPuller.PullCalls, 1)
+
+	_, ok := r.cache.Lookup(string(artifact.TypeRulesfile), testutil.TestNamespace, testRulesfileName, "")
+	require.True(t, ok)
+}
+
+func TestFetchAndCacheBinary_PullError(t *testing.T) {
+	cacheDir := t.TempDir()
+	rf := newTestRulesfile(withRulesfileOCI())
+	mockPuller := &puller.MockOCIPuller{
+		ResolveDigestResult: "sha256:xyz",
+		PullErr:             fmt.Errorf("registry down"),
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf)
+
+	err := r.fetchAndCacheBlob(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry down")
+}
+
+func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
+	// Selector requires env=prod; plain node doesn't have that label → staleNode is stale.
+	// staleNode has a finalizer so ClearFinalizersIfNodeGone doesn't short-circuit.
+	// The interceptor makes Node.Get return a non-404 error propagated to Reconcile.
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile(withRulesfileSelector())
+	staleNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	plainNode := newTestNode()
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, staleNode, plainNode).
+		WithStatusSubresource(&artifactv1alpha1.Rulesfile{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					return fmt.Errorf("node lookup error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node lookup error")
+}
+
+func TestHandleDeletion_ClearFinalizersError(t *testing.T) {
+	// RulesfileNode has a finalizer so ClearFinalizersIfNodeGone proceeds to check the node.
+	// The Node.Get interceptor returns a non-404 error that is propagated to the caller.
+	s := testutil.Scheme(t, artifactv1alpha1.AddToScheme, instancev1alpha1.AddToScheme)
+	rf := newTestRulesfile()
+	rfNode := newTestRulesfileNode(func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{"some-finalizer"}
+	})
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rf, rfNode).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					return fmt.Errorf("node lookup error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeOwnerKind, index.ArtifactNodeOwnerKindIndexer).
+		Build()
+	r := NewRulesfileAggregatorReconciler(cl, s, events.NewFakeRecorder(100), nil)
+	err := r.handleDeletion(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node lookup error")
+}
+
+func TestReconcile_FetchAndCacheBinaryError(t *testing.T) {
+	// fetchAndCacheArtifactMeta succeeds and sets Status.ArtifactMeta.Digest.
+	// fetchAndCacheBlob uses that digest as knownDigest → skips ResolveDigest,
+	// goes straight to Pull → Pull fails.
+	cacheDir := t.TempDir()
+	rf := newTestRulesfile(withRulesfileOCI())
+	node := newTestNode()
+
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{},
+		ConfigDigest: "sha256:meta",
+		PullErr:      fmt.Errorf("registry down"),
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, cacheDir, rf, node)
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry down")
+}

--- a/controllers/instance/artifact/rulesfile/controller_test.go
+++ b/controllers/instance/artifact/rulesfile/controller_test.go
@@ -280,6 +280,32 @@ func TestReconcile_NoMatchingNodes(t *testing.T) {
 	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
 }
 
+func TestReconcile_NoSourcesClearsCachedMetadata(t *testing.T) {
+	rf := newTestRulesfile(withInlineRules(`[{"required_engine_version":15}]`))
+	rf.Generation = 3
+	r, cl := newTestReconciler(t, rf)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+
+	withSource := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), withSource))
+	require.NotNil(t, withSource.Status.ArtifactMeta)
+	require.NotEmpty(t, withSource.Status.ArtifactMetaSourcesHash)
+
+	withSource.Spec.InlineRules = nil
+	withSource.Generation++
+	require.NoError(t, cl.Update(context.Background(), withSource))
+	_, err = r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+
+	withoutSources := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), withoutSources))
+	assert.Nil(t, withoutSources.Status.ArtifactMeta)
+	assert.Empty(t, withoutSources.Status.ArtifactMetaSourcesHash)
+	assert.Equal(t, withSource.Generation, withoutSources.Status.ObservedGeneration)
+}
+
 func TestReconcile_CreatesNodeObject(t *testing.T) {
 	rf := newTestRulesfile()
 	node := newTestNode()
@@ -733,9 +759,11 @@ func TestFetchAndCacheArtifactMeta_NoSources(t *testing.T) {
 	r, _ := newTestReconciler(t, rf)
 
 	rf.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{Digest: "old"}
+	rf.Status.ArtifactMetaSourcesHash = "old"
 	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
 	require.NoError(t, err)
 	assert.Nil(t, rf.Status.ArtifactMeta)
+	assert.Empty(t, rf.Status.ArtifactMetaSourcesHash)
 }
 
 func TestFetchAndCacheArtifactMeta_OCICacheHit(t *testing.T) {
@@ -749,6 +777,10 @@ func TestFetchAndCacheArtifactMeta_OCICacheHit(t *testing.T) {
 		SpecHash: specHash,
 		Digest:   "sha256:abc",
 	}
+	sources, err := r.collectArtifactMetaSources(context.Background(), rf)
+	require.NoError(t, err)
+	rf.Status.ArtifactMetaSourcesHash, err = sources.hash()
+	require.NoError(t, err)
 
 	err = r.fetchAndCacheArtifactMeta(context.Background(), rf)
 	require.NoError(t, err)
@@ -843,11 +875,51 @@ func TestFetchAndCacheArtifactMeta_ConfigMap(t *testing.T) {
 func TestFetchAndCacheArtifactMeta_ConfigMapMissing(t *testing.T) {
 	rf := newTestRulesfile(withRulesfileConfigMapRef("missing-cm"))
 	r, _ := newTestReconciler(t, rf)
+	previousMeta := &commonv1alpha1.ArtifactMeta{
+		Requirements: []commonv1alpha1.ArtifactMetaRequirement{{Name: "engine_version", Version: "15"}},
+	}
+	rf.Status.ArtifactMeta = previousMeta.DeepCopy()
+	rf.Status.ArtifactMetaSourcesHash = "previous-sources"
 
-	// ConfigMap not found: error is logged but ArtifactMeta is still set (empty).
 	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
-	require.NoError(t, err)
-	require.NotNil(t, rf.Status.ArtifactMeta)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `fetch ConfigMap "missing-cm"`)
+	assert.Equal(t, previousMeta, rf.Status.ArtifactMeta,
+		"an unreadable configured source must not replace the last complete aggregate")
+	assert.Equal(t, "previous-sources", rf.Status.ArtifactMetaSourcesHash)
+}
+
+func TestFetchAndCacheArtifactMeta_ConfigMapRequiredKeyMissing(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data:       map[string]string{"other.yaml": "- required_engine_version: 22"},
+	}
+	rf := newTestRulesfile(withRulesfileConfigMapRef(cm.Name))
+	r, _ := newTestReconciler(t, rf, cm)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `does not contain required key "rules.yaml"`)
+	assert.Nil(t, rf.Status.ArtifactMeta)
+	assert.Empty(t, rf.Status.ArtifactMetaSourcesHash)
+}
+
+func TestFetchAndCacheArtifactMeta_InvalidSourceDoesNotPublishPartialAggregate(t *testing.T) {
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{{Name: "plugin_api_version", Version: "3.0.0"}},
+		},
+		ConfigDigest: testRulesfileDigest,
+	}
+	rf := newTestRulesfile(withRulesfileOCI(), withInlineRules("{invalid"))
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse requirements from inline rules")
+	assert.Nil(t, rf.Status.ArtifactMeta,
+		"successful OCI metadata must not be published when another configured source is invalid")
+	assert.Empty(t, rf.Status.ArtifactMetaSourcesHash)
 }
 
 func TestFetchAndCacheArtifactMeta_InlineRules(t *testing.T) {
@@ -880,10 +952,174 @@ func TestFetchAndCacheArtifactMeta_ConfigMapAndInlineRules(t *testing.T) {
 	assert.Equal(t, "0.30.0", rf.Status.ArtifactMeta.Requirements[0].Version)
 }
 
+func TestFetchAndCacheArtifactMeta_AllConfiguredSources(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data: map[string]string{
+			commonv1alpha1.ConfigMapRulesKey: `- required_engine_version: 15`,
+		},
+	}
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{{Name: "plugin_api_version", Version: "3.0.0"}},
+		},
+		ConfigDigest: testRulesfileDigest,
+	}
+	rf := newTestRulesfile(
+		withRulesfileOCI(),
+		withRulesfileConfigMapRef(cm.Name),
+		withInlineRules(`- required_engine_version: "0.30.0"`),
+	)
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf, cm)
+
+	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
+	require.NoError(t, err)
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	assert.ElementsMatch(t, []commonv1alpha1.ArtifactMetaRequirement{
+		{Name: "plugin_api_version", Version: "3.0.0"},
+		{Name: "engine_version", Version: "15"},
+		{Name: "engine_version_semver", Version: "0.30.0"},
+	}, rf.Status.ArtifactMeta.Requirements,
+		"requirements from OCI, ConfigMap, and inline rules must all be aggregated")
+}
+
+func TestFetchAndCacheArtifactMeta_ConfigMapChangeRebuildsCompleteAggregate(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data: map[string]string{
+			commonv1alpha1.ConfigMapRulesKey: `- required_engine_version: 15`,
+		},
+	}
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{{Name: "plugin_api_version", Version: "3.0.0"}},
+		},
+		ConfigDigest: testRulesfileDigest,
+	}
+	rf := newTestRulesfile(withRulesfileOCI(), withRulesfileConfigMapRef(cm.Name))
+	r, cl := newTestReconcilerWithPuller(t, mockPuller, rf, cm)
+
+	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
+	firstSourcesHash := rf.Status.ArtifactMetaSourcesHash
+	ociSpecHash := rf.Status.ArtifactMeta.SpecHash
+	assert.ElementsMatch(t, []commonv1alpha1.ArtifactMetaRequirement{
+		{Name: "plugin_api_version", Version: "3.0.0"},
+		{Name: "engine_version", Version: "15"},
+	}, rf.Status.ArtifactMeta.Requirements)
+
+	updatedCM := &corev1.ConfigMap{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(cm), updatedCM))
+	updatedCM.Data[commonv1alpha1.ConfigMapRulesKey] = `- required_engine_version: 22`
+	require.NoError(t, cl.Update(context.Background(), updatedCM))
+
+	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
+	assert.NotEqual(t, firstSourcesHash, rf.Status.ArtifactMetaSourcesHash)
+	assert.Equal(t, ociSpecHash, rf.Status.ArtifactMeta.SpecHash,
+		"a local source change must not change the OCI-only SpecHash used by blob lifecycle")
+	assert.Len(t, mockPuller.FetchConfigCalls, 2, "a changed source invalidates the complete aggregate")
+	assert.ElementsMatch(t, []commonv1alpha1.ArtifactMetaRequirement{
+		{Name: "plugin_api_version", Version: "3.0.0"},
+		{Name: "engine_version", Version: "22"},
+	}, rf.Status.ArtifactMeta.Requirements, "requirements removed from a source must not remain stale")
+}
+
+func TestFetchAndCacheArtifactMeta_RemovingSourcesDropsTheirMetadata(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data: map[string]string{
+			commonv1alpha1.ConfigMapRulesKey: `- required_engine_version: 15`,
+		},
+	}
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{{Name: "plugin_api_version", Version: "3.0.0"}},
+		},
+		ConfigDigest: testRulesfileDigest,
+	}
+	rf := newTestRulesfile(
+		withRulesfileOCI(),
+		withRulesfileConfigMapRef(cm.Name),
+		withInlineRules(`- required_engine_version: "0.30.0"`),
+	)
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf, cm)
+
+	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
+	rf.Spec.ConfigMapRef = nil
+	rf.Spec.InlineRules = nil
+	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
+
+	assert.Equal(t, []commonv1alpha1.ArtifactMetaRequirement{
+		{Name: "plugin_api_version", Version: "3.0.0"},
+	}, rf.Status.ArtifactMeta.Requirements)
+}
+
+func TestFetchAndCacheArtifactMeta_CombinesConstraintsWithoutMaskingConflicts(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data: map[string]string{commonv1alpha1.ConfigMapRulesKey: `
+- required_engine_version: "0.62.0"
+- required_plugin_versions:
+  - name: container
+    version: "0.5.0"
+    alternatives:
+    - name: cloudtrail
+      version: "0.2.0"
+`},
+	}
+	mockPuller := &puller.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{
+			Requirements: []puller.ArtifactRequirement{
+				{Name: "engine_version_semver", Version: "0.60.0"},
+				{Name: "plugin_api_version", Version: "2.1.0"},
+				{Name: "plugin_api_version", Version: "3.0.0"},
+			},
+			Dependencies: []puller.ArtifactDependency{{
+				Name: "container", Version: "0.4.0",
+				Alternatives: []puller.Dependency{{Name: "k8smeta", Version: "0.1.0"}},
+			}},
+		},
+		ConfigDigest: testRulesfileDigest,
+	}
+	rf := newTestRulesfile(
+		withRulesfileOCI(),
+		withRulesfileConfigMapRef(cm.Name),
+		withInlineRules(`
+- required_engine_version: "0.57.0"
+- required_plugin_versions:
+  - name: container
+    version: "0.4.0"
+    alternatives:
+    - name: k8smeta
+      version: "0.1.0"
+`),
+	)
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf, cm)
+
+	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
+	require.NotNil(t, rf.Status.ArtifactMeta)
+	assert.Equal(t, []commonv1alpha1.ArtifactMetaRequirement{
+		{Name: "engine_version_semver", Version: "0.62.0"},
+		{Name: "plugin_api_version", Version: "2.1.0"},
+		{Name: "plugin_api_version", Version: "3.0.0"},
+	}, rf.Status.ArtifactMeta.Requirements,
+		"the strictest ordered requirement wins, while incompatible plugin API majors remain visible")
+	assert.Equal(t, []commonv1alpha1.ArtifactMetaDependency{
+		{
+			Name: "container", Version: "0.4.0",
+			Alternatives: []commonv1alpha1.ArtifactMetaDependencyVariant{{Name: "k8smeta", Version: "0.1.0"}},
+		},
+		{
+			Name: "container", Version: "0.5.0",
+			Alternatives: []commonv1alpha1.ArtifactMetaDependencyVariant{{Name: "cloudtrail", Version: "0.2.0"}},
+		},
+	}, rf.Status.ArtifactMeta.Dependencies,
+		"identical dependency groups are deduplicated, but distinct AND constraints remain visible")
+}
+
 func TestAppendYAMLRequirements_EngineVersionInt(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
 	content := []byte(`- required_engine_version: 22`)
-	appendYAMLRequirements(meta, content)
+	require.NoError(t, appendYAMLRequirements(meta, content))
 	require.Len(t, meta.Requirements, 1)
 	assert.Equal(t, "engine_version", meta.Requirements[0].Name)
 	assert.Equal(t, "22", meta.Requirements[0].Version)
@@ -892,22 +1128,22 @@ func TestAppendYAMLRequirements_EngineVersionInt(t *testing.T) {
 func TestAppendYAMLRequirements_EngineVersionSemver(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
 	content := []byte(`- required_engine_version: "0.36.0"`)
-	appendYAMLRequirements(meta, content)
+	require.NoError(t, appendYAMLRequirements(meta, content))
 	require.Len(t, meta.Requirements, 1)
 	assert.Equal(t, "engine_version_semver", meta.Requirements[0].Name)
 }
 
 func TestAppendYAMLRequirements_Empty(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
-	appendYAMLRequirements(meta, nil)
+	require.NoError(t, appendYAMLRequirements(meta, nil))
 	assert.Empty(t, meta.Requirements)
 	assert.Empty(t, meta.Dependencies)
 }
 
 func TestAppendYAMLRequirements_InvalidYAML(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
-	appendYAMLRequirements(meta, []byte("{invalid"))
-	// Should not panic and should produce no requirements.
+	err := appendYAMLRequirements(meta, []byte("{invalid"))
+	require.Error(t, err)
 	assert.Empty(t, meta.Requirements)
 }
 
@@ -1120,16 +1356,46 @@ func TestReconcile_SecondListNodeObjectsError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestReconcile_FetchAndCacheError(t *testing.T) {
-	mockPuller := &puller.MockOCIPuller{
-		FetchConfigErr: fmt.Errorf("registry down"),
+func TestReconcile_SourceErrorInvalidatesObservedGeneration(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
+		Data: map[string]string{
+			commonv1alpha1.ConfigMapRulesKey: `- required_engine_version: 15`,
+		},
 	}
-	rf := newTestRulesfile(withRulesfileOCI())
-	node := newTestNode()
-	rfNode := newTestRulesfileNode() // pre-existing
-	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf, node, rfNode)
+	rf := newTestRulesfile(withRulesfileConfigMapRef(cm.Name))
+	rf.Generation = 7
+	r, cl := newTestReconciler(t, rf, cm)
+
 	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
+	require.NoError(t, err)
+	ready := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), ready))
+	require.Equal(t, rf.Generation, ready.Status.ObservedGeneration)
+	require.NotNil(t, ready.Status.ArtifactMeta)
+	previousMeta := ready.Status.ArtifactMeta.DeepCopy()
+	previousSourcesHash := ready.Status.ArtifactMetaSourcesHash
+
+	updatedCM := &corev1.ConfigMap{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(cm), updatedCM))
+	updatedCM.Data[commonv1alpha1.ConfigMapRulesKey] = "{invalid"
+	require.NoError(t, cl.Update(context.Background(), updatedCM))
+
+	_, err = r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
 	require.Error(t, err)
+
+	got := &artifactv1alpha1.Rulesfile{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rf), got))
+	assert.Equal(t, previousMeta, got.Status.ArtifactMeta,
+		"a failed rebuild must retain the last complete aggregate for diagnosis")
+	assert.Equal(t, previousSourcesHash, got.Status.ArtifactMetaSourcesHash)
+	assert.Zero(t, got.Status.ObservedGeneration,
+		"a source failure must invalidate readiness even when the Rulesfile generation did not change")
+	condition := apimeta.FindStatusCondition(got.Status.Conditions, commonv1alpha1.ConditionProgrammed.String())
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, artifact.ReasonProgramFailed, condition.Reason)
+	assert.Contains(t, condition.Message, "Failed to compute artifact metadata")
 }
 
 // ── fetchAndCacheArtifactMeta additional paths ───────────────────────────────
@@ -1175,10 +1441,14 @@ func TestFetchAndCacheArtifactMeta_OCICacheHitIgnoresDigest(t *testing.T) {
 		SpecHash: specHash,
 		Digest:   "sha256:old",
 	}
+	sources, err := r.collectArtifactMetaSources(context.Background(), rf)
+	require.NoError(t, err)
+	rf.Status.ArtifactMetaSourcesHash, err = sources.hash()
+	require.NoError(t, err)
 
 	err = r.fetchAndCacheArtifactMeta(context.Background(), rf)
 	require.NoError(t, err)
-	assert.Empty(t, mockPuller.FetchConfigCalls, "spec hash match must skip FetchConfig regardless of digest")
+	assert.Empty(t, mockPuller.FetchConfigCalls, "unchanged complete source snapshot must skip FetchConfig regardless of digest")
 	assert.Equal(t, "sha256:old", rf.Status.ArtifactMeta.Digest, "stale digest must not be updated on cache hit")
 }
 
@@ -1187,7 +1457,7 @@ func TestFetchAndCacheArtifactMeta_OCICacheHitIgnoresDigest(t *testing.T) {
 func TestAppendYAMLRequirements_PluginVersions(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
 	content := []byte("- required_plugin_versions:\n  - name: cloudtrail\n    version: \"0.9.0\"")
-	appendYAMLRequirements(meta, content)
+	require.NoError(t, appendYAMLRequirements(meta, content))
 	require.Len(t, meta.Dependencies, 1)
 	assert.Equal(t, "cloudtrail", meta.Dependencies[0].Name)
 	assert.Equal(t, "0.9.0", meta.Dependencies[0].Version)
@@ -1198,7 +1468,7 @@ func TestAppendYAMLRequirements_PluginVersionsWithAlternatives(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
 	content := []byte("- required_plugin_versions:\n  - name: cloudtrail\n    version: \"0.9.0\"\n" +
 		"    alternatives:\n      - name: k8saudit\n        version: \"0.7.0\"")
-	appendYAMLRequirements(meta, content)
+	require.NoError(t, appendYAMLRequirements(meta, content))
 	require.Len(t, meta.Dependencies, 1)
 	assert.Equal(t, "cloudtrail", meta.Dependencies[0].Name)
 	require.Len(t, meta.Dependencies[0].Alternatives, 1)

--- a/docs/crds/rulesfile.md
+++ b/docs/crds/rulesfile.md
@@ -39,6 +39,9 @@ The `Rulesfile` Custom Resource manages Falco detection rules. Rules can be sour
 | Field | Type | Description |
 |-------|------|-------------|
 | `conditions` | `[]metav1.Condition` | `Programmed` and `ResolvedRefs` conditions |
+| `artifactMeta` | `ArtifactMeta` | Requirements and dependencies aggregated from every configured source |
+| `artifactMetaSourcesHash` | `string` | Hash of the source snapshot represented by `artifactMeta` |
+| `observedGeneration` | `int64` | Latest resource generation fully processed by the instance operator |
 
 ## Examples
 

--- a/internal/pkg/index/rulesfile.go
+++ b/internal/pkg/index/rulesfile.go
@@ -17,6 +17,8 @@
 package index
 
 import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 )
@@ -26,6 +28,9 @@ const (
 	ConfigMapOnRulesfile = "ConfigMapOnRulesfile"
 	// SecretOnRulesfile is the index field name for Rulesfile resources indexed by their SecretRef.
 	SecretOnRulesfile = "SecretOnRulesfile"
+	// PluginOnRulesfile is the index field name for Rulesfile resources indexed by the plugin names
+	// declared in Status.ArtifactMeta.Dependencies (primary and alternatives).
+	PluginOnRulesfile = "PluginOnRulesfile"
 )
 
 // RulesfileByConfigMapRef indexes Rulesfile resources by their .spec.configMapRef.name.
@@ -46,6 +51,31 @@ var RulesfileBySecretRef = IndexBySecretRef(
 	},
 )
 
+// RulesfileByPluginDependency indexes Rulesfile resources by the plugin names declared in
+// Status.ArtifactMeta.Dependencies, including all alternatives. Returns nil when ArtifactMeta
+// is not yet populated (status not written by the instance operator).
+var RulesfileByPluginDependency client.IndexerFunc = func(obj client.Object) []string {
+	rf, ok := obj.(*artifactv1alpha1.Rulesfile)
+	if !ok || rf.Status.ArtifactMeta == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var names []string
+	addName := func(name string) {
+		if _, exists := seen[name]; !exists {
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	for _, dep := range rf.Status.ArtifactMeta.Dependencies {
+		addName(dep.Name)
+		for _, alt := range dep.Alternatives {
+			addName(alt.Name)
+		}
+	}
+	return names
+}
+
 // RulesfileIndexes holds all field indexes for Rulesfile resources.
 var RulesfileIndexes = []Entry{
 	{
@@ -57,5 +87,10 @@ var RulesfileIndexes = []Entry{
 		Object:         &artifactv1alpha1.Rulesfile{},
 		Field:          SecretOnRulesfile,
 		ExtractValueFn: RulesfileBySecretRef,
+	},
+	{
+		Object:         &artifactv1alpha1.Rulesfile{},
+		Field:          PluginOnRulesfile,
+		ExtractValueFn: RulesfileByPluginDependency,
 	},
 }

--- a/internal/pkg/index/rulesfile_test.go
+++ b/internal/pkg/index/rulesfile_test.go
@@ -146,3 +146,90 @@ func TestRulesfileBySecretRef_WrongType(t *testing.T) {
 	}
 	assert.Nil(t, index.RulesfileBySecretRef(plugin))
 }
+
+func TestRulesfileByPluginDependency(t *testing.T) {
+	tests := []struct {
+		name      string
+		rulesfile *artifactv1alpha1.Rulesfile
+		want      []string
+	}{
+		{
+			name: "nil ArtifactMeta returns nil",
+			rulesfile: &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "rf", Namespace: testNamespace},
+			},
+			want: nil,
+		},
+		{
+			name: "empty dependencies returns nil",
+			rulesfile: &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "rf", Namespace: testNamespace},
+				Status: artifactv1alpha1.RulesfileStatus{
+					ArtifactMeta: &commonv1alpha1.ArtifactMeta{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "single dependency no alternatives",
+			rulesfile: &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "rf", Namespace: testNamespace},
+				Status: artifactv1alpha1.RulesfileStatus{
+					ArtifactMeta: &commonv1alpha1.ArtifactMeta{
+						Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+							{Name: "k8saudit", Version: "0.7.0"},
+						},
+					},
+				},
+			},
+			want: []string{"k8saudit"},
+		},
+		{
+			name: "dependency with alternatives",
+			rulesfile: &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "rf", Namespace: testNamespace},
+				Status: artifactv1alpha1.RulesfileStatus{
+					ArtifactMeta: &commonv1alpha1.ArtifactMeta{
+						Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+							{
+								Name:    "k8saudit",
+								Version: "0.7.0",
+								Alternatives: []commonv1alpha1.ArtifactMetaDependencyVariant{
+									{Name: "k8saudit-eks", Version: "0.5.0"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"k8saudit", "k8saudit-eks"},
+		},
+		{
+			name: "duplicate names across dependencies are deduplicated",
+			rulesfile: &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "rf", Namespace: testNamespace},
+				Status: artifactv1alpha1.RulesfileStatus{
+					ArtifactMeta: &commonv1alpha1.ArtifactMeta{
+						Dependencies: []commonv1alpha1.ArtifactMetaDependency{
+							{Name: "k8saudit", Version: "0.7.0"},
+							{Name: "k8saudit", Version: "0.8.0"},
+						},
+					},
+				},
+			},
+			want: []string{"k8saudit"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, index.RulesfileByPluginDependency(tt.rulesfile))
+		})
+	}
+}
+
+func TestRulesfileByPluginDependency_WrongType(t *testing.T) {
+	assert.Nil(t, index.RulesfileByPluginDependency(&artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: testNamespace},
+	}))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:


Introduces RulesfileAggregatorReconciler (controllers/instance/artifact/rulesfile),
completing the trio of node-object aggregator controllers alongside Config
and Plugin. Beyond the shared pattern, Rulesfile's ArtifactMeta computation
also parses required_engine_version/required_plugin_versions declared in
the rules YAML content itself (via internal/pkg/compat.ParseRulesRequirements
and Manager.FetchContent), not just the OCI config layer that Plugin reads,
since Rulesfile artifacts can declare requirements in either place.

Also adds index.PluginOnRulesfile (internal/pkg/index/rulesfile.go): a
field index keyed by the plugin names in a Rulesfile's
Status.ArtifactMeta.Dependencies, used to re-enqueue dependent Rulesfiles
when a Plugin they depend on changes or is deleted.

Follows the same in-use-finalizer and aggregation design already used
by Config and Plugin: the in-use finalizer is reconciled once
existingNodes is known, and aggregation excludes terminating/
no-longer-desired ArtifactNodes. A matching
TestReconcile_TerminatingStaleNodeIsRetainedButNotAggregated test
confirms both.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Depends on: #386 
