### PR TITLE
Per node operator toolkit

### DIFF
--- a/api/common/v1alpha1/types.go
+++ b/api/common/v1alpha1/types.go
@@ -47,6 +47,37 @@ const (
 	// - True: the artifact was programmed successfully.
 	// - False: the artifact could not be programmed.
 	ConditionProgrammed ConditionType = "Programmed"
+	// ConditionDependenciesSatisfied indicates whether the plugin's declared requirements are met by the
+	// running Falco instance.
+	// The possible status values for this condition type are:
+	// - True: all plugin requirements are satisfied; the plugin may be installed.
+	// - False: one or more requirements are not satisfied; the plugin will not be installed.
+	// - Unknown: the Falco API was unreachable; the check will be retried on the next reconcile.
+	ConditionDependenciesSatisfied ConditionType = "DependenciesSatisfied"
+	// ConditionOCIArtifactProgrammed indicates whether the OCI-sourced artifact has been successfully
+	// stored on the local filesystem. Used by plugin (binary) and rulesfile (OCI rules).
+	// The possible status values for this condition type are:
+	// - True: the artifact was fetched and stored (or verified unchanged on disk).
+	// - False: fetching or storing the artifact failed.
+	ConditionOCIArtifactProgrammed ConditionType = "OCIArtifactProgrammed"
+	// ConditionInlineArtifactProgrammed indicates whether the inline-sourced artifact has been
+	// successfully stored on the local filesystem. Used by rulesfile and config.
+	// The possible status values for this condition type are:
+	// - True: the artifact was stored (or verified unchanged on disk).
+	// - False: storing the artifact failed.
+	ConditionInlineArtifactProgrammed ConditionType = "InlineArtifactProgrammed"
+	// ConditionConfigMapArtifactProgrammed indicates whether the ConfigMap-sourced artifact has been
+	// successfully stored on the local filesystem. Used by rulesfile and config.
+	// The possible status values for this condition type are:
+	// - True: the artifact was stored (or verified unchanged on disk).
+	// - False: storing the artifact failed.
+	ConditionConfigMapArtifactProgrammed ConditionType = "ConfigMapArtifactProgrammed"
+	// ConditionConfigProgrammed indicates whether the shared plugin configuration file
+	// (plugins-config-inline.yaml) has been written for this plugin. Owned exclusively by ensurePluginConfig.
+	// The possible status values for this condition type are:
+	// - True: the config entry was written (or verified unchanged on disk).
+	// - False: writing the config entry failed.
+	ConditionConfigProgrammed ConditionType = "ConfigProgrammed"
 	// ConditionDeletionBlocked indicates whether removal of this node's artifact is being
 	// withheld because another artifact on the same node (e.g. a Rulesfile) still structurally
 	// depends on it. Set only by per-node artifact operators on the ArtifactNode they own; the

--- a/controllers/instance/artifact/plugin/controller.go
+++ b/controllers/instance/artifact/plugin/controller.go
@@ -160,6 +160,27 @@ func (r *PluginAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Surfaces the failure directly on the parent Plugin status. ObservedGeneration is not
 		// advanced, so enforce-mode per-node operators stay deferred, and no ArtifactNodes are
 		// created since they cannot be programmed without metadata.
+
+		// Still aggregate per-node conditions from existing ArtifactNodes: a broken reference
+		// (e.g. a missing auth Secret) fails fetchAndCacheArtifactMeta too, and the usual
+		// aggregation pass below never runs in this branch, since node creation depends on
+		// metadata having been fetched. Without this, a per-node operator's ResolvedRefs=False
+		// would never reach the Plugin's own status.
+		activeNodes := &artifactv1alpha1.ArtifactNodeList{}
+		for i := range existingNodes.Items {
+			nodeObject := &existingNodes.Items[i]
+			if !nodeObject.DeletionTimestamp.IsZero() {
+				continue
+			}
+			if _, ok := desired[nodeObject.Spec.NodeName]; !ok {
+				continue
+			}
+			activeNodes.Items = append(activeNodes.Items, *nodeObject)
+		}
+		controllerhelper.ComputeAggregateConditions(ctx, plugin, &plugin.Status.Conditions, activeNodes)
+
+		// The instance-level metadata failure is the more specific, authoritative cause of
+		// Programmed=False; it must win over whatever the per-node aggregate computed above.
 		apimeta.SetStatusCondition(&plugin.Status.Conditions, metav1.Condition{
 			Type:               commonv1alpha1.ConditionProgrammed.String(),
 			Status:             metav1.ConditionFalse,

--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -165,6 +165,27 @@ func (r *RulesfileAggregatorReconciler) Reconcile(ctx context.Context, req ctrl.
 		// Reset it on every source failure; the last complete ArtifactMeta remains available for
 		// diagnosis, but enforce-mode per-node operators stay deferred until a complete rebuild.
 		rulesfile.Status.ObservedGeneration = 0
+
+		// Still aggregate per-node conditions from existing ArtifactNodes: a broken reference
+		// (e.g. a missing ConfigMap) fails fetchAndCacheArtifactMeta too, and the usual
+		// aggregation pass below never runs in this branch, since node creation depends on
+		// metadata having been fetched. Without this, a per-node operator's ResolvedRefs=False
+		// would never reach the Rulesfile's own status.
+		activeNodes := &artifactv1alpha1.ArtifactNodeList{}
+		for i := range existingNodes.Items {
+			nodeObject := &existingNodes.Items[i]
+			if !nodeObject.DeletionTimestamp.IsZero() {
+				continue
+			}
+			if _, ok := desired[nodeObject.Spec.NodeName]; !ok {
+				continue
+			}
+			activeNodes.Items = append(activeNodes.Items, *nodeObject)
+		}
+		controllerhelper.ComputeAggregateConditions(ctx, rulesfile, &rulesfile.Status.Conditions, activeNodes)
+
+		// The instance-level metadata failure is the more specific, authoritative cause of
+		// Programmed=False; it must win over whatever the per-node aggregate computed above.
 		apimeta.SetStatusCondition(&rulesfile.Status.Conditions, metav1.Condition{
 			Type:               commonv1alpha1.ConditionProgrammed.String(),
 			Status:             metav1.ConditionFalse,

--- a/internal/pkg/common/conditions.go
+++ b/internal/pkg/common/conditions.go
@@ -17,10 +17,16 @@
 package common
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 )
+
+// msgNoConditionsToGateOn is the Programmed message used when there are no
+// non-Programmed conditions to gate on.
+const msgNoConditionsToGateOn = "no conditions to gate on"
 
 // NewCondition creates a new metav1.Condition with the given parameters.
 func NewCondition(
@@ -56,4 +62,73 @@ func NewAvailableCondition(status metav1.ConditionStatus, reason, message string
 // NewProgrammedCondition creates a ConditionProgrammed condition.
 func NewProgrammedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
 	return NewCondition(commonv1alpha1.ConditionProgrammed, status, reason, message, generation)
+}
+
+// ComputeProgrammedCondition derives the gateway Programmed condition from every other
+// condition currently in conditions: True only when all of them (except any skip excludes)
+// are also True. skip is consulted per condition type — pass nil to gate on everything — and
+// lets callers make a specific condition (e.g. DependenciesSatisfied in advise mode)
+// advisory-only rather than blocking.
+//
+// On failure the message names the specific blocking condition and its own message (e.g.
+// "blocked by ConfigProgrammed (False): unable to fetch ConfigMap").
+//
+// Shared by every per-node reconciler (Plugin, Rulesfile, Config): each writes conditions for
+// its own sources, then converges on this single Programmed gate the same way.
+func ComputeProgrammedCondition(
+	conditions []metav1.Condition,
+	skip func(condType string) bool,
+	trueReason, trueMessage, falseReason string,
+	generation int64,
+) metav1.Condition {
+	n := 0
+	var blocking *metav1.Condition
+	for i := range conditions {
+		cond := &conditions[i]
+		if cond.Type == commonv1alpha1.ConditionProgrammed.String() || (skip != nil && skip(cond.Type)) {
+			continue
+		}
+		n++
+		if cond.Status != metav1.ConditionTrue && blocking == nil {
+			blocking = cond
+		}
+	}
+	if n > 0 && blocking == nil {
+		return NewProgrammedCondition(metav1.ConditionTrue, trueReason, trueMessage, generation)
+	}
+	msg := msgNoConditionsToGateOn
+	if blocking != nil {
+		msg = fmt.Sprintf("blocked by %s (%s): %s", blocking.Type, blocking.Status, blocking.Message)
+	}
+	return NewProgrammedCondition(metav1.ConditionFalse, falseReason, msg, generation)
+}
+
+// NewDependenciesSatisfiedCondition creates a ConditionDependenciesSatisfied condition.
+func NewDependenciesSatisfiedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionDependenciesSatisfied, status, reason, message, generation)
+}
+
+// NewOCIArtifactProgrammedCondition creates a ConditionOCIArtifactProgrammed condition.
+func NewOCIArtifactProgrammedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionOCIArtifactProgrammed, status, reason, message, generation)
+}
+
+// NewInlineArtifactProgrammedCondition creates a ConditionInlineArtifactProgrammed condition.
+func NewInlineArtifactProgrammedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionInlineArtifactProgrammed, status, reason, message, generation)
+}
+
+// NewConfigMapArtifactProgrammedCondition creates a ConditionConfigMapArtifactProgrammed condition.
+func NewConfigMapArtifactProgrammedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionConfigMapArtifactProgrammed, status, reason, message, generation)
+}
+
+// NewConfigProgrammedCondition creates a ConditionConfigProgrammed condition.
+func NewConfigProgrammedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionConfigProgrammed, status, reason, message, generation)
+}
+
+// NewDeletionBlockedCondition creates a ConditionDeletionBlocked condition.
+func NewDeletionBlockedCondition(status metav1.ConditionStatus, reason, message string, generation int64) metav1.Condition {
+	return NewCondition(commonv1alpha1.ConditionDeletionBlocked, status, reason, message, generation)
 }

--- a/internal/pkg/common/conditions_test.go
+++ b/internal/pkg/common/conditions_test.go
@@ -113,3 +113,134 @@ func TestNewProgrammedCondition(t *testing.T) {
 			condition.Reason, "ProgramFailed")
 	}
 }
+
+func TestNewDependenciesSatisfiedCondition(t *testing.T) {
+	condition := NewDependenciesSatisfiedCondition(metav1.ConditionTrue, "DependenciesSatisfied", "ok", 1)
+	if condition.Type != string(commonv1alpha1.ConditionDependenciesSatisfied) {
+		t.Errorf("NewDependenciesSatisfiedCondition().Type = %v, want %v",
+			condition.Type, string(commonv1alpha1.ConditionDependenciesSatisfied))
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("NewDependenciesSatisfiedCondition().Status = %v, want %v", condition.Status, metav1.ConditionTrue)
+	}
+}
+
+func TestNewOCIArtifactProgrammedCondition(t *testing.T) {
+	condition := NewOCIArtifactProgrammedCondition(metav1.ConditionTrue, "OCIArtifactProgrammed", "ok", 1)
+	if condition.Type != string(commonv1alpha1.ConditionOCIArtifactProgrammed) {
+		t.Errorf("NewOCIArtifactProgrammedCondition().Type = %v, want %v",
+			condition.Type, string(commonv1alpha1.ConditionOCIArtifactProgrammed))
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("NewOCIArtifactProgrammedCondition().Status = %v, want %v", condition.Status, metav1.ConditionTrue)
+	}
+}
+
+func TestNewInlineArtifactProgrammedCondition(t *testing.T) {
+	condition := NewInlineArtifactProgrammedCondition(metav1.ConditionFalse, "InlineArtifactProgramFailed", "bad yaml", 1)
+	if condition.Type != string(commonv1alpha1.ConditionInlineArtifactProgrammed) {
+		t.Errorf("NewInlineArtifactProgrammedCondition().Type = %v, want %v",
+			condition.Type, string(commonv1alpha1.ConditionInlineArtifactProgrammed))
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Errorf("NewInlineArtifactProgrammedCondition().Status = %v, want %v", condition.Status, metav1.ConditionFalse)
+	}
+}
+
+func TestNewConfigMapArtifactProgrammedCondition(t *testing.T) {
+	condition := NewConfigMapArtifactProgrammedCondition(metav1.ConditionTrue, "ConfigMapArtifactProgrammed", "ok", 1)
+	if condition.Type != string(commonv1alpha1.ConditionConfigMapArtifactProgrammed) {
+		t.Errorf("NewConfigMapArtifactProgrammedCondition().Type = %v, want %v",
+			condition.Type, string(commonv1alpha1.ConditionConfigMapArtifactProgrammed))
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("NewConfigMapArtifactProgrammedCondition().Status = %v, want %v", condition.Status, metav1.ConditionTrue)
+	}
+}
+
+func TestNewConfigProgrammedCondition(t *testing.T) {
+	condition := NewConfigProgrammedCondition(metav1.ConditionTrue, "ConfigProgrammed", "ok", 1)
+	if condition.Type != string(commonv1alpha1.ConditionConfigProgrammed) {
+		t.Errorf("NewConfigProgrammedCondition().Type = %v, want %v",
+			condition.Type, string(commonv1alpha1.ConditionConfigProgrammed))
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("NewConfigProgrammedCondition().Status = %v, want %v", condition.Status, metav1.ConditionTrue)
+	}
+}
+
+func TestComputeProgrammedCondition(t *testing.T) {
+	gen := int64(7)
+
+	t.Run("all true -> Programmed True", func(t *testing.T) {
+		conditions := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionTrue},
+			{Type: "B", Status: metav1.ConditionTrue},
+		}
+		got := ComputeProgrammedCondition(conditions, nil, "TrueReason", "TrueMsg", "FalseReason", gen)
+		if got.Status != metav1.ConditionTrue || got.Reason != "TrueReason" || got.Message != "TrueMsg" {
+			t.Errorf("got %+v, want Status=True Reason=TrueReason Message=TrueMsg", got)
+		}
+		if got.ObservedGeneration != gen {
+			t.Errorf("got ObservedGeneration=%d, want %d", got.ObservedGeneration, gen)
+		}
+	})
+
+	t.Run("one condition false -> Programmed False naming the blocker", func(t *testing.T) {
+		conditions := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionTrue},
+			{Type: "B", Status: metav1.ConditionFalse, Message: "disk full"},
+		}
+		got := ComputeProgrammedCondition(conditions, nil, "TrueReason", "TrueMsg", "FalseReason", gen)
+		if got.Status != metav1.ConditionFalse || got.Reason != "FalseReason" {
+			t.Errorf("got %+v, want Status=False Reason=FalseReason", got)
+		}
+		want := "blocked by B (False): disk full"
+		if got.Message != want {
+			t.Errorf("got Message=%q, want %q", got.Message, want)
+		}
+	})
+
+	t.Run("first blocking condition wins when several are not True", func(t *testing.T) {
+		conditions := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionFalse, Message: "first failure"},
+			{Type: "B", Status: metav1.ConditionUnknown, Message: "second failure"},
+		}
+		got := ComputeProgrammedCondition(conditions, nil, "TrueReason", "TrueMsg", "FalseReason", gen)
+		want := "blocked by A (False): first failure"
+		if got.Message != want {
+			t.Errorf("got Message=%q, want %q", got.Message, want)
+		}
+	})
+
+	t.Run("skip excludes a condition type from the gate even when False", func(t *testing.T) {
+		conditions := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionTrue},
+			{Type: "DependenciesSatisfied", Status: metav1.ConditionFalse, Message: "advisory only"},
+		}
+		skip := func(condType string) bool { return condType == "DependenciesSatisfied" }
+		got := ComputeProgrammedCondition(conditions, skip, "TrueReason", "TrueMsg", "FalseReason", gen)
+		if got.Status != metav1.ConditionTrue {
+			t.Errorf("got Status=%v, want True (DependenciesSatisfied should be skipped)", got.Status)
+		}
+	})
+
+	t.Run("existing Programmed condition in the input is always excluded from the gate", func(t *testing.T) {
+		conditions := []metav1.Condition{
+			{Type: string(commonv1alpha1.ConditionProgrammed), Status: metav1.ConditionFalse},
+		}
+		got := ComputeProgrammedCondition(conditions, nil, "TrueReason", "TrueMsg", "FalseReason", gen)
+		// The only input condition is Programmed and it's excluded, so n stays 0 and the
+		// result is False with the msgNoConditionsToGateOn message.
+		if got.Status != metav1.ConditionFalse || got.Message != msgNoConditionsToGateOn {
+			t.Errorf("got %+v, want Status=False Message=%q", got, msgNoConditionsToGateOn)
+		}
+	})
+
+	t.Run("empty conditions -> False, no conditions to gate on", func(t *testing.T) {
+		got := ComputeProgrammedCondition(nil, nil, "TrueReason", "TrueMsg", "FalseReason", gen)
+		if got.Status != metav1.ConditionFalse || got.Message != msgNoConditionsToGateOn {
+			t.Errorf("got %+v, want Status=False Message=%q", got, msgNoConditionsToGateOn)
+		}
+	})
+}

--- a/internal/pkg/compat/versions.go
+++ b/internal/pkg/compat/versions.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the default base URL for the Falco REST API.
+	DefaultBaseURL = "http://localhost:8765"
+
+	versionsPath   = "/versions"
+	defaultTimeout = 5 * time.Second
+)
+
+// defaultInterval is the wait between retries in WaitAndFetch.
+// It is a package-level var so tests can override it.
+var defaultInterval = 2 * time.Second
+
+// VersionsFetcher fetches version capabilities from the Falco REST API.
+type VersionsFetcher interface {
+	Fetch(ctx context.Context) (*Versions, error)
+}
+
+// Versions holds the capability versions returned by the Falco REST API at /versions.
+// Values are stored as strings; numeric JSON values are converted automatically.
+type Versions struct {
+	capabilities   map[string]string
+	pluginVersions map[string]string // keys that came from the nested plugin_versions object
+}
+
+// Capability returns the version string for a named capability, and whether it was present.
+func (v *Versions) Capability(name string) (string, bool) {
+	val, ok := v.capabilities[name]
+	return val, ok
+}
+
+// All returns a copy of every capability name to its version string, including both top-level
+// capabilities (e.g. engine_version_semver, plugin_api_version) and the flattened plugin_versions
+// entries (e.g. "container"). Callers must not assume any particular set of keys — it reflects
+// whatever Falco reported.
+func (v *Versions) All() map[string]string {
+	out := make(map[string]string, len(v.capabilities))
+	maps.Copy(out, v.capabilities)
+	return out
+}
+
+// PluginVersions returns a copy of just the plugin_versions subset — the set of plugin names
+// Falco currently reports as loaded, each with its version. Unlike All(), this never mixes in
+// unrelated top-level capabilities (e.g. engine_version_semver), so it's safe to treat as "the
+// set of currently loaded plugin names.".
+func (v *Versions) PluginVersions() map[string]string {
+	out := make(map[string]string, len(v.pluginVersions))
+	maps.Copy(out, v.pluginVersions)
+	return out
+}
+
+// HTTPVersionsFetcher queries the Falco REST API at /versions over HTTP.
+type HTTPVersionsFetcher struct {
+	url    string
+	client *http.Client
+}
+
+// NewHTTPVersionsFetcher creates a fetcher that queries baseURL + "/versions".
+// Pass falco.DefaultBaseURL to use the default Falco API endpoint.
+func NewHTTPVersionsFetcher(baseURL string) *HTTPVersionsFetcher {
+	return &HTTPVersionsFetcher{
+		url:    baseURL + versionsPath,
+		client: &http.Client{Timeout: defaultTimeout},
+	}
+}
+
+// Fetch calls the Falco /versions endpoint and returns the parsed capability map.
+func (f *HTTPVersionsFetcher) Fetch(ctx context.Context) (*Versions, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request for %s: %w", f.url, err)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", f.url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned %d", f.url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response from %s: %w", f.url, err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parse response from %s: %w", f.url, err)
+	}
+
+	caps := make(map[string]string, len(raw))
+	pluginCaps := make(map[string]string)
+	for k, v := range raw {
+		switch t := v.(type) {
+		case string:
+			caps[k] = t
+		case float64:
+			caps[k] = strconv.FormatFloat(t, 'f', -1, 64)
+		case map[string]any:
+			// Falco reports loaded plugin versions as a nested object:
+			//   "plugin_versions": {"container": "0.7.1"}
+			// Flatten into the top-level capability map and also record them separately in pluginCaps.
+			for nk, nv := range t {
+				if s, ok := nv.(string); ok {
+					caps[nk] = s
+					pluginCaps[nk] = s
+				}
+			}
+		}
+	}
+
+	return &Versions{capabilities: caps, pluginVersions: pluginCaps}, nil
+}
+
+// WaitAndFetch blocks until the Falco /versions endpoint at baseURL responds successfully,
+// retrying every defaultInterval. It returns immediately on context cancellation.
+func WaitAndFetch(ctx context.Context, baseURL string) (*Versions, error) {
+	f := NewHTTPVersionsFetcher(baseURL)
+	for {
+		v, err := f.Fetch(ctx)
+		if err == nil {
+			return v, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(defaultInterval):
+		}
+	}
+}
+
+// MockVersionsFetcher is a test double for VersionsFetcher.
+type MockVersionsFetcher struct {
+	Result   *Versions
+	FetchErr error
+}
+
+// NewMockVersionsFetcher creates a MockVersionsFetcher that returns the given capabilities on Fetch.
+func NewMockVersionsFetcher(caps map[string]string) *MockVersionsFetcher {
+	return &MockVersionsFetcher{Result: &Versions{capabilities: caps}}
+}
+
+// NewMockVersionsFetcherWithPlugins creates a MockVersionsFetcher whose result reports pluginVersions
+// as loaded plugins — flattened into capabilities too, matching HTTPVersionsFetcher's real behavior —
+// for tests that need PluginVersions() populated, not just Capability()/All().
+func NewMockVersionsFetcherWithPlugins(pluginVersions map[string]string) *MockVersionsFetcher {
+	caps := make(map[string]string, len(pluginVersions))
+	maps.Copy(caps, pluginVersions)
+	return &MockVersionsFetcher{Result: &Versions{capabilities: caps, pluginVersions: pluginVersions}}
+}
+
+// Fetch returns the preset result or error.
+func (m *MockVersionsFetcher) Fetch(_ context.Context) (*Versions, error) {
+	if m.FetchErr != nil {
+		return nil, m.FetchErr
+	}
+	return m.Result, nil
+}

--- a/internal/pkg/compat/versions_test.go
+++ b/internal/pkg/compat/versions_test.go
@@ -1,0 +1,318 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errBodyTransport returns a 200 response whose body always errors on read,
+// exercising the io.ReadAll failure path in Fetch.
+type errBodyTransport struct{}
+
+func (e *errBodyTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(iotest.ErrReader(errors.New("body read error"))),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestHTTPVersionsFetcher_Fetch(t *testing.T) {
+	tests := []struct {
+		name               string
+		body               string
+		statusCode         int
+		wantErr            bool
+		wantCaps           map[string]string
+		notWantKeys        []string
+		wantPluginVersions map[string]string
+	}{
+		{
+			name: "flat scalar values only",
+			body: `{
+				"engine_version_semver": "0.62.0",
+				"falco_version": "0.44.1",
+				"engine_version": "62"
+			}`,
+			wantCaps: map[string]string{
+				"engine_version_semver": "0.62.0",
+				"falco_version":         "0.44.1",
+				"engine_version":        "62",
+			},
+			wantPluginVersions: map[string]string{},
+		},
+		{
+			// JSON numbers unmarshal as float64; the fetcher must convert them to strings.
+			name: "numeric JSON field is converted to string",
+			body: `{"engine_version": 62, "falco_version": "0.44.1"}`,
+			wantCaps: map[string]string{
+				"engine_version": "62",
+				"falco_version":  "0.44.1",
+			},
+			wantPluginVersions: map[string]string{},
+		},
+		{
+			name: "plugin_versions nested object is flattened",
+			body: `{
+				"engine_version_semver": "0.62.0",
+				"plugin_versions": {
+					"container": "0.7.1",
+					"k8smeta": "0.2.0"
+				}
+			}`,
+			wantCaps: map[string]string{
+				"engine_version_semver": "0.62.0",
+				"container":             "0.7.1",
+				"k8smeta":               "0.2.0",
+			},
+			notWantKeys: []string{"plugin_versions"},
+			wantPluginVersions: map[string]string{
+				"container": "0.7.1",
+				"k8smeta":   "0.2.0",
+			},
+		},
+		{
+			name: "full real-world response",
+			body: `{
+				"default_driver_version": "10.2.0+driver",
+				"driver_api_version": "10.0.0",
+				"driver_schema_version": "4.3.0",
+				"engine_version": "62",
+				"engine_version_semver": "0.62.0",
+				"falco_version": "0.44.1",
+				"libs_version": "0.25.4",
+				"plugin_api_version": "3.12.0",
+				"plugin_versions": {
+					"container": "0.7.1"
+				}
+			}`,
+			wantCaps: map[string]string{
+				"engine_version_semver": "0.62.0",
+				"falco_version":         "0.44.1",
+				"container":             "0.7.1",
+			},
+			notWantKeys:        []string{"plugin_versions"},
+			wantPluginVersions: map[string]string{"container": "0.7.1"},
+		},
+		{
+			name: "idle mode: empty plugin_versions is harmless",
+			body: `{
+				"engine_version_semver": "0.62.0",
+				"plugin_versions": {}
+			}`,
+			wantCaps: map[string]string{
+				"engine_version_semver": "0.62.0",
+			},
+			wantPluginVersions: map[string]string{},
+		},
+		{
+			name:       "non-200 status returns error",
+			body:       `{}`,
+			statusCode: http.StatusServiceUnavailable,
+			wantErr:    true,
+		},
+		{
+			name:    "invalid JSON returns error",
+			body:    `not-json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code := http.StatusOK
+			if tt.statusCode != 0 {
+				code = tt.statusCode
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			f := NewHTTPVersionsFetcher(srv.URL)
+			versions, err := f.Fetch(context.Background())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			for k, wantV := range tt.wantCaps {
+				got, found := versions.Capability(k)
+				assert.True(t, found, "expected capability %q to be present", k)
+				assert.Equal(t, wantV, got, "capability %q value mismatch", k)
+			}
+			for _, k := range tt.notWantKeys {
+				_, found := versions.Capability(k)
+				assert.False(t, found, "capability key %q should not be present (it is a container key, not a capability)", k)
+			}
+			if tt.wantPluginVersions != nil {
+				assert.Equal(t, tt.wantPluginVersions, versions.pluginVersions)
+			}
+		})
+	}
+}
+
+func TestHTTPVersionsFetcher_Fetch_Errors(t *testing.T) {
+	t.Run("invalid URL triggers request build error", func(t *testing.T) {
+		// A null byte makes url.Parse fail inside http.NewRequestWithContext.
+		f := &HTTPVersionsFetcher{url: "\x00", client: http.DefaultClient}
+		_, err := f.Fetch(context.Background())
+		require.Error(t, err)
+	})
+
+	t.Run("body read error is propagated", func(t *testing.T) {
+		f := &HTTPVersionsFetcher{
+			url:    "http://example.com/versions",
+			client: &http.Client{Transport: &errBodyTransport{}},
+		}
+		_, err := f.Fetch(context.Background())
+		require.Error(t, err)
+	})
+}
+
+func TestVersions_Capability(t *testing.T) {
+	v := &Versions{capabilities: map[string]string{
+		"engine_version_semver": "0.62.0",
+		"container":             "0.7.1",
+	}}
+
+	val, ok := v.Capability("engine_version_semver")
+	assert.True(t, ok)
+	assert.Equal(t, "0.62.0", val)
+
+	val, ok = v.Capability("container")
+	assert.True(t, ok)
+	assert.Equal(t, "0.7.1", val)
+
+	_, ok = v.Capability("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestVersions_PluginVersions(t *testing.T) {
+	v := &Versions{
+		capabilities: map[string]string{
+			"engine_version_semver": "0.62.0",
+			"container":             "0.7.1",
+		},
+		pluginVersions: map[string]string{
+			"container": "0.7.1",
+		},
+	}
+
+	got := v.PluginVersions()
+	assert.Equal(t, map[string]string{"container": "0.7.1"}, got)
+
+	// Returned map must be a copy: mutating it must not affect the Versions' own state.
+	got["container"] = "mutated"
+	got2 := v.PluginVersions()
+	assert.Equal(t, "0.7.1", got2["container"])
+}
+
+func TestVersions_PluginVersions_Empty(t *testing.T) {
+	v := &Versions{capabilities: map[string]string{"engine_version_semver": "0.62.0"}}
+	assert.Empty(t, v.PluginVersions())
+}
+
+func TestWaitAndFetch(t *testing.T) {
+	orig := defaultInterval
+	defaultInterval = time.Millisecond
+	t.Cleanup(func() { defaultInterval = orig })
+
+	t.Run("server immediately available", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"falco_version": "0.44.1"}`))
+		}))
+		defer srv.Close()
+
+		v, err := WaitAndFetch(context.Background(), srv.URL)
+		require.NoError(t, err)
+		val, found := v.Capability("falco_version")
+		assert.True(t, found)
+		assert.Equal(t, "0.44.1", val)
+	})
+
+	t.Run("canceled context returns context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := WaitAndFetch(ctx, "http://127.0.0.1:0")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("retries on transient failure then succeeds", func(t *testing.T) {
+		var calls atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if calls.Add(1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"falco_version": "0.44.1"}`))
+		}))
+		defer srv.Close()
+
+		v, err := WaitAndFetch(context.Background(), srv.URL)
+		require.NoError(t, err)
+		val, found := v.Capability("falco_version")
+		assert.True(t, found)
+		assert.Equal(t, "0.44.1", val)
+	})
+}
+
+func TestMockVersionsFetcher(t *testing.T) {
+	t.Run("returns configured capabilities", func(t *testing.T) {
+		m := NewMockVersionsFetcher(map[string]string{"falco_version": "0.44.1"})
+		v, err := m.Fetch(context.Background())
+		require.NoError(t, err)
+		val, found := v.Capability("falco_version")
+		assert.True(t, found)
+		assert.Equal(t, "0.44.1", val)
+	})
+
+	t.Run("returns configured error", func(t *testing.T) {
+		m := &MockVersionsFetcher{FetchErr: errors.New("fetch failed")}
+		_, err := m.Fetch(context.Background())
+		require.EqualError(t, err, "fetch failed")
+	})
+}
+
+func TestNewMockVersionsFetcherWithPlugins(t *testing.T) {
+	m := NewMockVersionsFetcherWithPlugins(map[string]string{"container": "0.7.1"})
+	v, err := m.Fetch(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"container": "0.7.1"}, v.PluginVersions())
+	val, found := v.Capability("container")
+	assert.True(t, found, "plugin entries must also be flattened into capabilities, matching real Fetch behavior")
+	assert.Equal(t, "0.7.1", val)
+}

--- a/internal/pkg/compat/watcher.go
+++ b/internal/pkg/compat/watcher.go
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat
+
+import (
+	"context"
+	"maps"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// DefaultWatchInterval is the polling cadence used by VersionsWatcher when none is specified.
+const DefaultWatchInterval = 5 * time.Second
+
+// VersionsWatcher polls the Falco /versions endpoint and publishes one GenericEvent whenever the
+// capability set changes (plugin loaded/unloaded, version bump, Falco restart). Register it with
+// the manager as a Runnable. Call Events() once per controller that needs to react to changes —
+// each call returns an independent channel, so every subscriber gets its own copy of each event.
+type VersionsWatcher struct {
+	fetcher            VersionsFetcher
+	interval           time.Duration
+	mu                 sync.Mutex
+	lastCapabilities   map[string]string
+	lastPluginVersions map[string]string
+	subscribers        []chan event.GenericEvent
+	sink               func(*Versions)
+}
+
+// NewVersionsWatcher creates a watcher that polls using fetcher every interval.
+func NewVersionsWatcher(fetcher VersionsFetcher, interval time.Duration) *VersionsWatcher {
+	return &VersionsWatcher{
+		fetcher:  fetcher,
+		interval: interval,
+	}
+}
+
+// SetSink registers a callback invoked with the freshly-fetched *Versions on every successful
+// poll, regardless of whether the capability set changed (unlike the subscriber/GenericEvent
+// mechanism, which only fires on an actual change). Intended for a consumer that wants to keep
+// its own cache of Falco's latest reported state fresh (e.g. nodeartifacts.Manager). Not safe
+// to call concurrently with Start; call it once during setup, before the watcher is registered
+// with the manager.
+func (w *VersionsWatcher) SetSink(sink func(*Versions)) {
+	w.sink = sink
+}
+
+// Events returns a new channel that receives one GenericEvent each time Falco's capability set
+// changes. Call this once per controller that needs to watch for changes — each call registers
+// and returns a fresh, independent channel, so every subscriber sees every change event.
+func (w *VersionsWatcher) Events() <-chan event.GenericEvent {
+	ch := make(chan event.GenericEvent, 100)
+	w.mu.Lock()
+	w.subscribers = append(w.subscribers, ch)
+	w.mu.Unlock()
+	return ch
+}
+
+// Start implements manager.Runnable. It polls until ctx is canceled.
+func (w *VersionsWatcher) Start(ctx context.Context) error {
+	logger := ctrllog.FromContext(ctx)
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := w.poll(ctx); err != nil {
+				logger.V(4).Info("Falco versions poll failed, will retry", "err", err)
+			}
+		}
+	}
+}
+
+// poll fetches /versions once and sends a GenericEvent if the capability set changed. It diffs
+// the full capability map, not just plugin_versions, so a change to any top-level capability
+// (e.g. plugin_api_version in a mocked test endpoint) is also detected. On fetch error it resets
+// cached state so the next successful fetch is treated as a change.
+func (w *VersionsWatcher) poll(ctx context.Context) error {
+	versions, err := w.fetcher.Fetch(ctx)
+	if err != nil {
+		w.mu.Lock()
+		w.lastCapabilities = nil
+		w.lastPluginVersions = nil
+		w.mu.Unlock()
+		return err
+	}
+
+	if w.sink != nil {
+		w.sink(versions)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if maps.Equal(w.lastCapabilities, versions.capabilities) && maps.Equal(w.lastPluginVersions, versions.pluginVersions) {
+		return nil
+	}
+	w.lastCapabilities = maps.Clone(versions.capabilities)
+	w.lastPluginVersions = maps.Clone(versions.pluginVersions)
+
+	// Non-blocking send to every subscriber: if a subscriber already has a pending event, the
+	// controller will pick it up on its next work cycle, making the duplicate a no-op.
+	for _, ch := range w.subscribers {
+		select {
+		case ch <- event.GenericEvent{}:
+		default:
+		}
+	}
+	return nil
+}

--- a/internal/pkg/compat/watcher_test.go
+++ b/internal/pkg/compat/watcher_test.go
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compat
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// versionsWithPlugins builds a Versions value with the given plugin_versions map.
+func versionsWithPlugins(plugins map[string]string) *Versions {
+	return &Versions{pluginVersions: plugins}
+}
+
+func TestVersionsWatcher_poll(t *testing.T) {
+	t.Run("plugin loaded sends event", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected event when plugin set changes from nil to non-empty")
+		}
+	})
+
+	t.Run("same plugin set sends no event", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background()))
+		<-ch // drain first event
+
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+			t.Fatal("unexpected event when plugin set is unchanged")
+		default:
+		}
+	})
+
+	t.Run("plugin version bump sends event", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background()))
+		<-ch // drain initial event
+
+		m.Result = versionsWithPlugins(map[string]string{"container": "0.7.2"})
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected event when plugin version changes")
+		}
+	})
+
+	t.Run("unchanged capabilities send no event", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: &Versions{
+			capabilities:   map[string]string{"engine_version_semver": "0.62.0"},
+			pluginVersions: map[string]string{},
+		}}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background()))
+		<-ch // drain first event (nil -> non-empty capabilities is a change)
+
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+			t.Fatal("unexpected event: capabilities unchanged")
+		default:
+		}
+	})
+
+	t.Run("capability change alone sends event", func(t *testing.T) {
+		// In practice engine/Falco version are fixed for a running binary, but a mocked
+		// /versions endpoint (used in e2e tests) can change a top-level capability like
+		// plugin_api_version without touching plugin_versions — this must still be detected.
+		m := &MockVersionsFetcher{Result: &Versions{
+			capabilities:   map[string]string{"plugin_api_version": "2.99.0"},
+			pluginVersions: map[string]string{},
+		}}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background()))
+		<-ch // drain initial event
+
+		m.Result = &Versions{
+			capabilities:   map[string]string{"plugin_api_version": "3.10.0"},
+			pluginVersions: map[string]string{},
+		}
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected event when a capability value changes")
+		}
+	})
+
+	t.Run("fetch error resets cached state and returns error", func(t *testing.T) {
+		m := &MockVersionsFetcher{FetchErr: errors.New("unreachable")}
+		w := NewVersionsWatcher(m, time.Hour)
+		w.lastPluginVersions = map[string]string{"container": "0.7.1"}
+		w.lastCapabilities = map[string]string{"plugin_api_version": "3.10.0"}
+
+		err := w.poll(context.Background())
+		require.Error(t, err)
+		w.mu.Lock()
+		assert.Nil(t, w.lastPluginVersions, "cached plugin versions must be reset on fetch error")
+		assert.Nil(t, w.lastCapabilities, "cached capabilities must be reset on fetch error")
+		w.mu.Unlock()
+	})
+
+	t.Run("successful fetch after error triggers event", func(t *testing.T) {
+		m := &MockVersionsFetcher{FetchErr: errors.New("unreachable")}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		w.lastPluginVersions = map[string]string{"container": "0.7.1"}
+		_ = w.poll(context.Background()) // error → lastPluginVersions reset to nil
+
+		m.FetchErr = nil
+		m.Result = versionsWithPlugins(map[string]string{"container": "0.7.1"})
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected event: nil lastPluginVersions != recovered state")
+		}
+	})
+
+	t.Run("full channel does not block", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		ch := w.Events()
+		require.NoError(t, w.poll(context.Background())) // fills channel (cap=1)
+
+		// Force a second state change without draining.
+		w.mu.Lock()
+		w.lastPluginVersions = nil
+		w.mu.Unlock()
+
+		require.NoError(t, w.poll(context.Background())) // channel full → default branch
+		// Channel still has the original event.
+		select {
+		case <-ch:
+		default:
+			t.Fatal("expected buffered event to still be present")
+		}
+	})
+
+	t.Run("sink fires on every successful poll, including unchanged values", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		var sinkCalls int
+		var lastSeen *Versions
+		w.SetSink(func(v *Versions) {
+			sinkCalls++
+			lastSeen = v
+		})
+
+		require.NoError(t, w.poll(context.Background()))
+		assert.Equal(t, 1, sinkCalls)
+		assert.Same(t, m.Result, lastSeen)
+
+		// Unlike the subscriber/GenericEvent path, the sink must fire again even though
+		// nothing changed — it's a "keep my cache fresh" callback, not a change notification.
+		require.NoError(t, w.poll(context.Background()))
+		assert.Equal(t, 2, sinkCalls)
+	})
+
+	t.Run("sink is not called on fetch error", func(t *testing.T) {
+		m := &MockVersionsFetcher{FetchErr: errors.New("unreachable")}
+		w := NewVersionsWatcher(m, time.Hour)
+		var sinkCalls int
+		w.SetSink(func(*Versions) { sinkCalls++ })
+
+		err := w.poll(context.Background())
+
+		require.Error(t, err)
+		assert.Equal(t, 0, sinkCalls)
+	})
+
+	t.Run("multiple subscribers each receive every event", func(t *testing.T) {
+		// Regression test: Events() used to return a single shared channel, so two
+		// controllers each calling it would race as competing consumers — only one would
+		// ever see a given event. Each call must now return an independent channel.
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Hour)
+		chA := w.Events()
+		chB := w.Events()
+
+		require.NoError(t, w.poll(context.Background()))
+		select {
+		case <-chA:
+		default:
+			t.Fatal("subscriber A did not receive the event")
+		}
+		select {
+		case <-chB:
+		default:
+			t.Fatal("subscriber B did not receive the event")
+		}
+	})
+}
+
+func TestVersionsWatcher_Start(t *testing.T) {
+	t.Run("logs fetch errors and keeps running", func(t *testing.T) {
+		// Run Start synchronously until the context deadline so the ticker fires several
+		// times through the error branch (line with logger.V(4).Info), confirming it does
+		// not block or panic when every fetch fails.
+		w := NewVersionsWatcher(&MockVersionsFetcher{FetchErr: errors.New("unreachable")}, time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		defer cancel()
+		require.NoError(t, w.Start(ctx))
+	})
+
+	t.Run("stops cleanly on context cancellation", func(t *testing.T) {
+		w := NewVersionsWatcher(&MockVersionsFetcher{FetchErr: errors.New("not ready")}, time.Millisecond)
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() { done <- w.Start(ctx) }()
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("Start did not return after context cancellation")
+		}
+	})
+
+	t.Run("publishes event when plugin set changes", func(t *testing.T) {
+		m := &MockVersionsFetcher{Result: versionsWithPlugins(map[string]string{"container": "0.7.1"})}
+		w := NewVersionsWatcher(m, time.Millisecond)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() { _ = w.Start(ctx) }()
+
+		select {
+		case <-w.Events():
+		case <-time.After(time.Second):
+			t.Fatal("no event received within timeout")
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

- Adds five new per-source condition types (`DependenciesSatisfied`, `OCIArtifactProgrammed`, `InlineArtifactProgrammed`, `ConfigMapArtifactProgrammed`, `ConfigProgrammed`) and their
  constructors, plus `ComputeProgrammedCondition`, a shared gateway-condition helper for per-node reconcilers.
- Adds `internal/pkg/compat`: an `HTTPVersionsFetcher`/`VersionsWatcher` pair that polls Falco's `/versions` API and emits a controller-runtime event on change.
- Fixes a real bug in the Plugin/Rulesfile instance controllers: on a `fetchAndCacheArtifactMeta` failure (e.g. a missing referenced ConfigMap), `Reconcile` returned before ever calling
  `ComputeAggregateConditions`, so a per-node operator's `ResolvedRefs=False` could never reach the parent's status. Now aggregates on the failure path too, with the instance-level failure
  reason still winning for `Programmed`.


> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
The condition types/constructors and the `compat` package are foundational pieces for the upcoming per-node artifact-operator work; nothing in this repo calls them yet, so they're inert
  until that lands. The `Programmed`-aggregation fix is live code (already-merged Plugin/Rulesfile controllers) but is also currently unobservable, since nothing on `main` today writes
  per-node conditions onto an `ArtifactNode` for it to aggregate from.
