### PR TITLE
feat: add mTLS artifact HTTP cache server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.26.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.4
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.4
@@ -90,7 +92,6 @@ require (
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.6 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
@@ -195,7 +196,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/pkg/artifactserver/metrics.go
+++ b/internal/pkg/artifactserver/metrics.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactserver
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metrics are registered against controller-runtime's shared metrics registry and exposed on
+// the operator's existing metrics HTTP endpoint.
+var (
+	requestsTotal = promauto.With(ctrlmetrics.Registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "artifactserver_requests_total",
+			Help: "Total artifact server HTTP requests, by artifact type and response status code.",
+		},
+		[]string{"type", "status"},
+	)
+
+	requestDuration = promauto.With(ctrlmetrics.Registry).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "artifactserver_request_duration_seconds",
+			Help:    "Artifact server request handling latency, by artifact type.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"type"},
+	)
+
+	cacheLookupsTotal = promauto.With(ctrlmetrics.Registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "artifactserver_cache_lookups_total",
+			Help: "Artifact cache lookups performed by the artifact server, by artifact type and result (hit|miss).",
+		},
+		[]string{"type", "result"},
+	)
+)

--- a/internal/pkg/artifactserver/server.go
+++ b/internal/pkg/artifactserver/server.go
@@ -1,0 +1,366 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package artifactserver provides the HTTP artifact cache server embedded in the
+// falco-operator. It serves pre-extracted OCI artifact binaries that have been pulled
+// and cached by the instance-level aggregator controllers.
+//
+// The server itself never contacts the OCI registry — it only reads from the local
+// blob cache written by the Plugin and Rulesfile aggregator controllers.
+package artifactserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/tlsutil"
+)
+
+// NodeNameHeader is the HTTP request header the artifact-operator client sets to its node's
+// name, identifying the caller for logging. Mirrors internal/pkg/artifact.NodeNameHeader.
+const NodeNameHeader = "X-Node-Name"
+
+// Default timeouts and limits applied unconditionally to the underlying http.Server.
+const (
+	// DefaultReadHeaderTimeout bounds how long a client may take sending request headers.
+	DefaultReadHeaderTimeout = 5 * time.Second
+	// DefaultReadTimeout bounds how long reading the entire request may take. Requests here
+	// are small GETs with no body.
+	DefaultReadTimeout = 15 * time.Second
+	// DefaultWriteTimeout bounds how long writing the response may take, covering streaming
+	// of artifact blobs up to tens of MB.
+	DefaultWriteTimeout = 5 * time.Minute
+	// DefaultIdleTimeout bounds how long an idle keep-alive connection is kept open.
+	DefaultIdleTimeout = 2 * time.Minute
+	// DefaultMaxHeaderBytes caps the total size of request headers, below Go's 1MiB default.
+	DefaultMaxHeaderBytes = 32 * 1024
+)
+
+// Server is the artifact HTTP cache server embedded in the falco-operator.
+// It serves binaries that the aggregator controllers have already pulled and cached,
+// looked up through the same in-memory Cache the aggregator controllers write to.
+type Server struct {
+	cache       *artifactcache.Cache
+	certWatcher *certwatcher.CertWatcher // nil = plain HTTP, the default; no behavior change
+	clientCAs   *tlsutil.CAWatcher       // nil = no client-cert requirement
+	authorizer  *Authorizer              // nil = no additional check beyond CA chain verification
+	maxInflight int                      // 0 = unlimited
+}
+
+// Option configures optional Server behavior.
+type Option func(*Server)
+
+// WithTLS configures the server's own TLS identity via a hot-reloadable cert+key watcher.
+// The caller is responsible for also registering cw with the manager (mgr.Add) so its
+// reload loop actually runs.
+func WithTLS(cw *certwatcher.CertWatcher) Option {
+	return func(s *Server) { s.certWatcher = cw }
+}
+
+// WithClientCAs enables mTLS: the server requires and verifies a client certificate against
+// caw's current trust pool, re-read on every new connection. Only takes effect together with
+// WithTLS; Start returns a configuration error if client CAs are set without a cert watcher.
+// The caller is responsible for also registering caw with the manager (mgr.Add).
+func WithClientCAs(caw *tlsutil.CAWatcher) Option {
+	return func(s *Server) { s.clientCAs = caw }
+}
+
+// WithAuthorizer adds an application-level check after standard mTLS chain verification: a's
+// VerifyConnection runs for every connection, including resumed ones, rejecting a client
+// certificate that is CA-signed but does not correspond to a known Falco instance. Only takes
+// effect together with WithClientCAs.
+func WithAuthorizer(a *Authorizer) Option {
+	return func(s *Server) { s.authorizer = a }
+}
+
+// WithMaxConcurrentRequests limits how many blob transfers may be in flight simultaneously.
+// When the limit is reached the server returns 503 with a jittered Retry-After header so
+// clients spread their retries. Zero (the default) disables the limit.
+func WithMaxConcurrentRequests(n int) Option {
+	return func(s *Server) { s.maxInflight = n }
+}
+
+// New creates a Server that serves cached binaries indexed by cache. cache.Load must
+// already have been called.
+func New(cache *artifactcache.Cache, opts ...Option) *Server {
+	s := &Server{cache: cache}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// httpServer builds the http.Server used by Start, with baseline timeout hardening applied
+// unconditionally.
+func (s *Server) httpServer(addr string, baseCtx func(net.Listener) context.Context) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		BaseContext:       baseCtx,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
+		ReadTimeout:       DefaultReadTimeout,
+		WriteTimeout:      DefaultWriteTimeout,
+		IdleTimeout:       DefaultIdleTimeout,
+		MaxHeaderBytes:    DefaultMaxHeaderBytes,
+	}
+}
+
+// Start binds to addr and serves requests until ctx is canceled.
+func (s *Server) Start(ctx context.Context, addr string) error {
+	if s.clientCAs != nil && s.certWatcher == nil {
+		return fmt.Errorf("artifact server: client CAs configured without a TLS certificate watcher")
+	}
+
+	logger := log.FromContext(ctx).WithName("artifact-server")
+	// BaseContext returns a context carrying the named logger. Request handlers obtain their
+	// logger from r.Context(), which descends from BaseContext's return value, not from
+	// Start's own ctx variable.
+	baseCtx := log.IntoContext(ctx, logger)
+
+	srv := s.httpServer(addr, func(net.Listener) context.Context { return baseCtx })
+
+	var tlsConfig *tls.Config
+	if s.certWatcher != nil {
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+				cfg := &tls.Config{MinVersion: tls.VersionTLS12, GetCertificate: s.certWatcher.GetCertificate}
+				if s.clientCAs != nil {
+					cfg.ClientCAs = s.clientCAs.CertPool()
+					cfg.ClientAuth = tls.RequireAndVerifyClientCert
+					if s.authorizer != nil {
+						cfg.VerifyConnection = s.authorizer.VerifyConnection
+					}
+				}
+				return cfg, nil
+			},
+		}
+		srv.TLSConfig = tlsConfig
+	}
+
+	go func() { //nolint:gosec // shutdown watcher outlives ctx by design; it must wait for ctx.Done() before acting
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background()) //nolint:contextcheck // ctx is Done; Shutdown needs a live context to drain requests
+	}()
+
+	logger.Info("Artifact server listening", "addr", addr, "tls", tlsConfig != nil, "mtls", s.clientCAs != nil,
+		"spiffeAuthz", s.authorizer != nil)
+	var err error
+	if tlsConfig != nil {
+		err = srv.ListenAndServeTLS("", "")
+	} else {
+		err = srv.ListenAndServe()
+	}
+	if err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("artifact server: %w", err)
+	}
+	return nil
+}
+
+// limitConcurrency wraps next with a semaphore-based concurrency limit when maxInflight > 0.
+// Excess requests receive a 503 with a jittered Retry-After so simultaneous retries spread out.
+func (s *Server) limitConcurrency(next http.Handler) http.Handler {
+	if s.maxInflight <= 0 {
+		return next
+	}
+	sem := make(chan struct{}, s.maxInflight)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case sem <- struct{}{}:
+			defer func() { <-sem }()
+			next.ServeHTTP(w, r)
+		default:
+			delay := int(wait.Jitter(10*time.Second, 0.5).Seconds())
+			w.Header().Set("Retry-After", strconv.Itoa(delay))
+			http.Error(w, "server busy, retry shortly", http.StatusServiceUnavailable)
+		}
+	})
+}
+
+// Handler returns the HTTP request multiplexer. Exported for testing.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/artifacts/plugins/", s.servePlugin)
+	mux.HandleFunc("/v1/artifacts/rulesfiles/", s.serveRulesfile)
+	return s.limitConcurrency(mux)
+}
+
+// servePlugin handles GET /v1/artifacts/plugins/{namespace}/{name}?os=linux&arch=amd64
+// The binary must already be cached by the Plugin aggregator controller.
+func (s *Server) servePlugin(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		requestsTotal.WithLabelValues("plugin", strconv.Itoa(http.StatusMethodNotAllowed)).Inc()
+		return
+	}
+
+	ns, name, ok := parsePath(r.URL.Path, "/v1/artifacts/plugins/")
+	if !ok {
+		http.Error(w, "path must be /v1/artifacts/plugins/{namespace}/{name}", http.StatusBadRequest)
+		requestsTotal.WithLabelValues("plugin", strconv.Itoa(http.StatusBadRequest)).Inc()
+		return
+	}
+
+	goos := queryDefault(r, "os", runtime.GOOS)
+	goarch := queryDefault(r, "arch", runtime.GOARCH)
+
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithValues(
+		"artifact", ns+"/"+name,
+		"type", "plugin",
+		"os", goos,
+		"arch", goarch,
+		"caller", r.RemoteAddr,
+		"node", r.Header.Get(NodeNameHeader),
+	)
+	logger.V(1).Info("Artifact request received")
+
+	platformKey := goos + "-" + goarch
+	blobPath, ok := s.cache.Lookup("plugin", ns, name, platformKey)
+	if !ok {
+		cacheLookupsTotal.WithLabelValues("plugin", "miss").Inc()
+		logger.Info("Plugin not yet cached — waiting for aggregator reconcile")
+		w.Header().Set("Retry-After", "10")
+		http.Error(w, "artifact not yet available — retry shortly", http.StatusServiceUnavailable)
+		requestsTotal.WithLabelValues("plugin", strconv.Itoa(http.StatusServiceUnavailable)).Inc()
+		requestDuration.WithLabelValues("plugin").Observe(time.Since(start).Seconds())
+		return
+	}
+	cacheLookupsTotal.WithLabelValues("plugin", "hit").Inc()
+
+	logger.V(1).Info("Serving plugin blob", "blob", blobPath)
+	status := serveBlob(w, r, blobPath)
+	requestsTotal.WithLabelValues("plugin", strconv.Itoa(status)).Inc()
+	requestDuration.WithLabelValues("plugin").Observe(time.Since(start).Seconds())
+}
+
+// serveRulesfile handles GET /v1/artifacts/rulesfiles/{namespace}/{name}
+// Rulesfiles are platform-agnostic; the binary must already be cached by the Rulesfile
+// aggregator controller.
+func (s *Server) serveRulesfile(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(http.StatusMethodNotAllowed)).Inc()
+		return
+	}
+
+	ns, name, ok := parsePath(r.URL.Path, "/v1/artifacts/rulesfiles/")
+	if !ok {
+		http.Error(w, "path must be /v1/artifacts/rulesfiles/{namespace}/{name}", http.StatusBadRequest)
+		requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(http.StatusBadRequest)).Inc()
+		return
+	}
+
+	ctx := r.Context()
+	logger := log.FromContext(ctx).WithValues(
+		"artifact", ns+"/"+name,
+		"type", "rulesfile",
+		"caller", r.RemoteAddr,
+		"node", r.Header.Get(NodeNameHeader),
+	)
+	logger.V(1).Info("Artifact request received")
+
+	blobPath, ok := s.cache.Lookup("rulesfile", ns, name, "")
+	if !ok {
+		cacheLookupsTotal.WithLabelValues("rulesfile", "miss").Inc()
+		logger.Info("Rulesfile not yet cached — waiting for aggregator reconcile")
+		w.Header().Set("Retry-After", "10")
+		http.Error(w, "artifact not yet available — retry shortly", http.StatusServiceUnavailable)
+		requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(http.StatusServiceUnavailable)).Inc()
+		requestDuration.WithLabelValues("rulesfile").Observe(time.Since(start).Seconds())
+		return
+	}
+	cacheLookupsTotal.WithLabelValues("rulesfile", "hit").Inc()
+
+	logger.V(1).Info("Serving rulesfile blob", "blob", blobPath)
+	status := serveBlob(w, r, blobPath)
+	requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(status)).Inc()
+	requestDuration.WithLabelValues("rulesfile").Observe(time.Since(start).Seconds())
+}
+
+// statusCapturingWriter wraps an http.ResponseWriter and records the status code written,
+// since http.ServeContent does not return one.
+type statusCapturingWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusCapturingWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// serveBlob streams the cached blob at blobPath to w via http.ServeContent, which adds Range
+// and If-Modified-Since/If-Range support. Blobs are content-addressed and immutable once
+// written, so a Range read never races a concurrent write. The original file mode is sent in
+// the X-Artifact-Mode header for the artifact-operator to apply when writing the file. Returns
+// the status code that was ultimately written, for metrics.
+func serveBlob(w http.ResponseWriter, r *http.Request, blobPath string) int {
+	perm := artifactcache.ReadPerm(blobPath)
+
+	f, err := os.Open(blobPath) //nolint:gosec // blobPath is derived from artifactcache.BlobPath(), not raw external input
+	if err != nil {
+		http.Error(w, "cached blob unavailable — retry shortly", http.StatusServiceUnavailable)
+		return http.StatusServiceUnavailable
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		http.Error(w, "cached blob unavailable — retry shortly", http.StatusServiceUnavailable)
+		return http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Artifact-Mode", strconv.FormatUint(uint64(perm), 10))
+
+	sw := &statusCapturingWriter{ResponseWriter: w, status: http.StatusOK}
+	http.ServeContent(sw, r, filepath.Base(blobPath), stat.ModTime(), f)
+	return sw.status
+}
+
+// parsePath splits a URL path of the form {prefix}{namespace}/{name} into namespace and name.
+func parsePath(urlPath, prefix string) (namespace, name string, ok bool) {
+	tail := strings.TrimPrefix(urlPath, prefix)
+	parts := strings.SplitN(tail, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func queryDefault(r *http.Request, key, def string) string {
+	if v := r.URL.Query().Get(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/pkg/artifactserver/server_internal_test.go
+++ b/internal/pkg/artifactserver/server_internal_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactserver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestServer_httpServer_DefaultTimeouts asserts the constructed http.Server carries the
+// baseline hardening timeouts unconditionally.
+func TestServer_httpServer_DefaultTimeouts(t *testing.T) {
+	s := &Server{}
+	srv := s.httpServer(":0", func(net.Listener) context.Context { return context.Background() })
+
+	assert.Equal(t, DefaultReadHeaderTimeout, srv.ReadHeaderTimeout)
+	assert.Equal(t, DefaultReadTimeout, srv.ReadTimeout)
+	assert.Equal(t, DefaultWriteTimeout, srv.WriteTimeout)
+	assert.Equal(t, DefaultIdleTimeout, srv.IdleTimeout)
+	assert.Equal(t, DefaultMaxHeaderBytes, srv.MaxHeaderBytes)
+}

--- a/internal/pkg/artifactserver/server_test.go
+++ b/internal/pkg/artifactserver/server_test.go
@@ -1,0 +1,609 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactserver_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
+	"github.com/falcosecurity/falco-operator/internal/pkg/tlsutil"
+)
+
+func seedPlugin(t *testing.T, cache *artifactcache.Cache, ns, name, goos, goarch string, content []byte, perm fs.FileMode) {
+	t.Helper()
+	blobPath := artifactcache.BlobPath(cache.Dir(), "plugin", ns+"/"+name, "sha256:deadbeef", goos, goarch)
+	require.NoError(t, artifactcache.Store(blobPath, content, perm))
+	require.NoError(t, cache.Set("plugin", ns, name, goos+"-"+goarch, blobPath))
+}
+
+func seedRulesfile(t *testing.T, cache *artifactcache.Cache, name string, content []byte) {
+	t.Helper()
+	const ns = "default"
+	blobPath := artifactcache.BlobPath(cache.Dir(), "rulesfile", ns+"/"+name, "sha256:deadbeef", "", "")
+	require.NoError(t, artifactcache.Store(blobPath, content, 0o644))
+	require.NoError(t, cache.Set("rulesfile", ns, name, "", blobPath))
+}
+
+// servePluginCase and serveRulesfileCase share this shape: seed the cache (or don't), issue one
+// request against a fresh server, and check the response.
+type serveCase struct {
+	name string
+	seed func(t *testing.T, cache *artifactcache.Cache) // nil means "leave the cache empty"
+
+	method     string            // defaults to GET
+	path       string            // appended to the httptest server's URL
+	reqHeaders map[string]string // extra request headers, e.g. Range/If-Modified-Since
+
+	wantStatus       int
+	wantHeaders      map[string]string
+	wantBodyContains string
+	wantBodyEquals   string // when set, asserts exact body content instead of substring
+}
+
+func runServeCase(t *testing.T, tc *serveCase) {
+	t.Helper()
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+	if tc.seed != nil {
+		tc.seed(t, cache)
+	}
+
+	ts := httptest.NewServer(artifactserver.New(cache).Handler())
+	defer ts.Close()
+
+	method := tc.method
+	if method == "" {
+		method = http.MethodGet
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, ts.URL+tc.path, http.NoBody)
+	require.NoError(t, err)
+	for key, val := range tc.reqHeaders {
+		req.Header.Set(key, val)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, tc.wantStatus, resp.StatusCode)
+	for key, want := range tc.wantHeaders {
+		assert.Equal(t, want, resp.Header.Get(key), "header %q", key)
+	}
+	if tc.wantBodyContains != "" {
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), tc.wantBodyContains)
+	}
+	if tc.wantBodyEquals != "" {
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, tc.wantBodyEquals, string(body))
+	}
+}
+
+func TestServer_ServePlugin(t *testing.T) {
+	tests := []serveCase{
+		{
+			name: "returns the cached binary with its mode header",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				seedPlugin(t, cache, "default", "json", "linux", "amd64", []byte("binary-content"), 0o755)
+			},
+			path:       "/v1/artifacts/plugins/default/json?os=linux&arch=amd64",
+			wantStatus: http.StatusOK,
+			wantHeaders: map[string]string{
+				"Content-Type":    "application/octet-stream",
+				"X-Artifact-Mode": "493", // 0o755 in decimal
+			},
+			wantBodyContains: "binary-content",
+		},
+		{
+			name: "defaults os/arch to the server's own runtime when the query is omitted",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				seedPlugin(t, cache, "default", "json", runtime.GOOS, runtime.GOARCH, []byte("binary-content"), 0o755)
+			},
+			path:       "/v1/artifacts/plugins/default/json",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "not yet cached returns 503 with a Retry-After hint",
+			path:       "/v1/artifacts/plugins/default/missing?os=linux&arch=amd64",
+			wantStatus: http.StatusServiceUnavailable,
+			wantHeaders: map[string]string{
+				"Retry-After": "10",
+			},
+		},
+		{
+			name: "indexed but missing from disk returns 503",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				blobPath := artifactcache.BlobPath(cache.Dir(), "plugin", "default/json", "sha256:deadbeef", "linux", "amd64")
+				require.NoError(t, cache.Set("plugin", "default", "json", "linux-amd64", blobPath)) // no Store call
+			},
+			path:       "/v1/artifacts/plugins/default/json?os=linux&arch=amd64",
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "path missing the name segment returns 400",
+			path:       "/v1/artifacts/plugins/onlyns",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-GET method returns 405",
+			method:     http.MethodPost,
+			path:       "/v1/artifacts/plugins/default/json",
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runServeCase(t, &tt) })
+	}
+}
+
+func TestServer_ServeRulesfile(t *testing.T) {
+	tests := []serveCase{
+		{
+			name: "returns the cached rulesfile with its mode header",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				seedRulesfile(t, cache, "myrules", []byte("rule content"))
+			},
+			path:       "/v1/artifacts/rulesfiles/default/myrules",
+			wantStatus: http.StatusOK,
+			wantHeaders: map[string]string{
+				"X-Artifact-Mode": "420", // 0o644 in decimal
+			},
+			wantBodyContains: "rule content",
+		},
+		{
+			name:       "not yet cached returns 503",
+			path:       "/v1/artifacts/rulesfiles/default/missing",
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "path missing the name segment returns 400",
+			path:       "/v1/artifacts/rulesfiles/onlyns",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-GET method returns 405",
+			method:     http.MethodPost,
+			path:       "/v1/artifacts/rulesfiles/default/myrules",
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name: "Range request returns partial content",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				seedRulesfile(t, cache, "myrules", []byte("rule content"))
+			},
+			path:           "/v1/artifacts/rulesfiles/default/myrules",
+			reqHeaders:     map[string]string{"Range": "bytes=0-3"},
+			wantStatus:     http.StatusPartialContent,
+			wantBodyEquals: "rule",
+		},
+		{
+			name: "If-Modified-Since in the future returns 304",
+			seed: func(t *testing.T, cache *artifactcache.Cache) {
+				seedRulesfile(t, cache, "myrules", []byte("rule content"))
+			},
+			path: "/v1/artifacts/rulesfiles/default/myrules",
+			reqHeaders: map[string]string{
+				"If-Modified-Since": time.Now().Add(time.Hour).UTC().Format(http.TimeFormat),
+			},
+			wantStatus: http.StatusNotModified,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { runServeCase(t, &tt) })
+	}
+}
+
+// reserveAddr opens a listener on an ephemeral loopback port, closes it immediately, and
+// returns the address it was bound to — for handing to code that wants to bind it itself.
+func reserveAddr(t *testing.T) string {
+	t.Helper()
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
+}
+
+// waitForListening blocks until addr accepts a bare TCP connection (regardless of whatever
+// application-layer protocol, plaintext or TLS, is spoken on top), or fails the test.
+func waitForListening(t *testing.T, addr string) {
+	t.Helper()
+	dialer := &net.Dialer{Timeout: 100 * time.Millisecond}
+	require.Eventually(t, func() bool {
+		conn, dialErr := dialer.DialContext(context.Background(), "tcp", addr)
+		if dialErr != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, 2*time.Second, 20*time.Millisecond, "server never started listening")
+}
+
+// TestServer_Start_ListensAndShutsDown starts the server in a goroutine, waits for it to accept
+// connections, then cancels the context and confirms Start returns.
+func TestServer_Start_ListensAndShutsDown(t *testing.T) {
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+	addr := reserveAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- artifactserver.New(cache).Start(ctx, addr) }()
+
+	waitForListening(t, addr)
+
+	cancel()
+
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// recordingSink is a minimal, thread-safe logr.LogSink that records every Info call's
+// accumulated name (from WithName) and key-values (from WithValues plus the call site),
+// so a test can assert on what a request handler actually logged. mu is shared across every
+// value returned by WithName/WithValues, since logr chains create new sink instances that
+// must all serialize access to the same underlying records slice.
+type recordingSink struct {
+	mu      *sync.Mutex
+	name    string
+	values  []any
+	records *[]loggedRecord
+}
+
+type loggedRecord struct {
+	name          string
+	msg           string
+	keysAndValues []any
+}
+
+func newRecordingLogger() (logr.Logger, *[]loggedRecord) {
+	records := &[]loggedRecord{}
+	return logr.New(&recordingSink{mu: &sync.Mutex{}, records: records}), records
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo) {}
+func (s *recordingSink) Enabled(int) bool      { return true }
+func (s *recordingSink) Error(err error, msg string, keysAndValues ...any) {
+	s.Info(0, msg, append(append([]any{}, keysAndValues...), "error", err)...)
+}
+
+func (s *recordingSink) Info(_ int, msg string, keysAndValues ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	all := append(append([]any{}, s.values...), keysAndValues...)
+	*s.records = append(*s.records, loggedRecord{name: s.name, msg: msg, keysAndValues: all})
+}
+
+func (s *recordingSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return &recordingSink{
+		mu: s.mu, name: s.name,
+		values:  append(append([]any{}, s.values...), keysAndValues...),
+		records: s.records,
+	}
+}
+
+func (s *recordingSink) WithName(name string) logr.LogSink {
+	newName := name
+	if s.name != "" {
+		newName = s.name + "." + name
+	}
+	return &recordingSink{mu: s.mu, name: newName, values: s.values, records: s.records}
+}
+
+// valueFor searches a logr key-values slice for key and returns its value.
+func valueFor(t *testing.T, keysAndValues []any, key string) any {
+	t.Helper()
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		if keysAndValues[i] == key {
+			return keysAndValues[i+1]
+		}
+	}
+	t.Fatalf("key %q not found in %v", key, keysAndValues)
+	return nil
+}
+
+// TestServer_Start_RequestLogsAreNamedAndCarryNodeHeader verifies that requests handled via a
+// real Start call use the named logger (WithName("artifact-server")) and log the X-Node-Name
+// header (set by artifact.Fetcher.FetchOCI).
+func TestServer_Start_RequestLogsAreNamedAndCarryNodeHeader(t *testing.T) {
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+	seedPlugin(t, cache, "default", "json", "linux", "amd64", []byte("bin"), 0o755)
+
+	addr := reserveAddr(t)
+	logger, records := newRecordingLogger()
+	ctx, cancel := context.WithCancel(ctrllog.IntoContext(context.Background(), logger))
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- artifactserver.New(cache).Start(ctx, addr) }()
+
+	waitForListening(t, addr)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		fmt.Sprintf("http://%s/v1/artifacts/plugins/default/json?os=linux&arch=amd64", addr), http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set(artifactserver.NodeNameHeader, "worker-7")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	cancel()
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+
+	var found bool
+	for _, rec := range *records {
+		if rec.msg != "Artifact request received" {
+			continue
+		}
+		found = true
+		assert.Contains(t, rec.name, "artifact-server", "request logger must carry the name Start set")
+		assert.Equal(t, "worker-7", valueFor(t, rec.keysAndValues, "node"))
+	}
+	assert.True(t, found, "expected an 'Artifact request received' log entry")
+}
+
+// TestServer_Start_AddressInUse is Start's one remaining failure mode: cache-dir creation
+// moved to Cache.Load (covered by TestCache_Load_BlobsDirCannotBeCreated), so binding an
+// already-occupied address is the only way left to make Start itself return an error.
+func TestServer_Start_AddressInUse(t *testing.T) {
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+
+	startErr := artifactserver.New(cache).Start(context.Background(), l.Addr().String())
+	require.Error(t, startErr)
+	assert.Contains(t, startErr.Error(), "artifact server")
+}
+
+// --- mTLS test certificate helpers ---
+
+// testCA is a self-signed CA certificate, along with the parsed cert and key needed to sign
+// leaf certificates with it.
+type testCA struct {
+	certPEM []byte
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+}
+
+func newTestCA(t *testing.T, commonName string) testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return testCA{
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		cert:    cert,
+		key:     key,
+	}
+}
+
+// signLeaf issues a leaf certificate signed by ca, returning cert+key PEM bytes. ipSANs is
+// non-nil for a server cert (the IP the client dials); nil for a client cert (client-cert
+// verification doesn't check hostname).
+func signLeaf(t *testing.T, ca testCA, commonName string, ipSANs []net.IP, extKeyUsage x509.ExtKeyUsage) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{extKeyUsage},
+		IPAddresses:  ipSANs,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func certPool(t *testing.T, certPEM []byte) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(certPEM))
+	return pool
+}
+
+// TestServer_Start_MTLS covers the full mTLS round trip: a client with no certificate is
+// rejected at the handshake, a client with a CA-signed certificate succeeds, and — the CA
+// hot-reload regression case — rotating the trusted CA on disk (as cert-manager renewing the
+// CA Certificate would) is picked up by a *new* connection without restarting the server.
+func TestServer_Start_MTLS(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "test-root-ca")
+
+	serverCertPEM, serverKeyPEM := signLeaf(t, ca, "artifact-server", []net.IP{net.ParseIP("127.0.0.1")}, x509.ExtKeyUsageServerAuth)
+	clientCertPEM, clientKeyPEM := signLeaf(t, ca, "artifact-client", nil, x509.ExtKeyUsageClientAuth)
+
+	caFile := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(caFile, ca.certPEM, 0o600))
+	serverCertFile := filepath.Join(dir, "tls.crt")
+	serverKeyFile := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(serverCertFile, serverCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(serverKeyFile, serverKeyPEM, 0o600))
+
+	certWatcher, err := certwatcher.New(serverCertFile, serverKeyFile)
+	require.NoError(t, err)
+	caWatcher, err := tlsutil.NewCAWatcher(caFile)
+	require.NoError(t, err)
+
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+	seedRulesfile(t, cache, "secure", []byte("secure content"))
+
+	addr := reserveAddr(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := artifactserver.New(cache, artifactserver.WithTLS(certWatcher), artifactserver.WithClientCAs(caWatcher))
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx, addr) }()
+
+	waitForListening(t, addr)
+
+	url := "https://" + addr + "/v1/artifacts/rulesfiles/default/secure"
+	rootCAs := certPool(t, ca.certPEM)
+
+	t.Run("no client cert is rejected at handshake", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}}}
+		resp, doErr := client.Get(url) //nolint:noctx // test-only, short-lived
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		require.Error(t, doErr)
+	})
+
+	clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	require.NoError(t, err)
+
+	t.Run("valid client cert succeeds", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs, Certificates: []tls.Certificate{clientCert},
+		}}}
+		resp, doErr := client.Get(url) //nolint:noctx // test-only, short-lived
+		require.NoError(t, doErr)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("CA hot-reload: a cert signed by a rotated CA is accepted without a restart", func(t *testing.T) {
+		caCtx, caCancel := context.WithCancel(context.Background())
+		defer caCancel()
+		caErrCh := make(chan error, 1)
+		// A short poll interval keeps this deterministic: an atomic rename-over-an-existing
+		// path doesn't reliably fire an fsnotify event on every platform, so the test can't
+		// depend on that alone within a short timeout.
+		go func() { caErrCh <- caWatcher.WithWatchInterval(50 * time.Millisecond).Start(caCtx) }()
+
+		newCA := newTestCA(t, "test-root-ca-v2")
+		newClientCertPEM, newClientKeyPEM := signLeaf(t, newCA, "artifact-client-v2", nil, x509.ExtKeyUsageClientAuth)
+		newClientCert, keyErr := tls.X509KeyPair(newClientCertPEM, newClientKeyPEM)
+		require.NoError(t, keyErr)
+
+		tmp := caFile + ".tmp"
+		require.NoError(t, os.WriteFile(tmp, newCA.certPEM, 0o600))
+		require.NoError(t, os.Rename(tmp, caFile))
+
+		require.Eventually(t, func() bool {
+			// The server's own certificate is unchanged (still signed by the original ca) —
+			// only its ClientCAs trust pool is being rotated, so the test client keeps
+			// trusting the server via the original rootCAs and only swaps its own client
+			// certificate to one signed by the new CA.
+			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+				RootCAs: rootCAs, Certificates: []tls.Certificate{newClientCert},
+			}}}
+			resp, getErr := client.Get(url) //nolint:noctx // test-only, short-lived
+			if getErr != nil {
+				return false
+			}
+			defer resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		}, 2*time.Second, 20*time.Millisecond, "server did not pick up the rotated CA")
+
+		caCancel()
+	})
+
+	cancel()
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// TestServer_Start_ClientCAsWithoutTLS_ReturnsConfigError guards against silently serving
+// plaintext when mTLS was requested but no server certificate was configured to go with it.
+func TestServer_Start_ClientCAsWithoutTLS_ReturnsConfigError(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "test-ca")
+	caFile := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(caFile, ca.certPEM, 0o600))
+
+	caWatcher, err := tlsutil.NewCAWatcher(caFile)
+	require.NoError(t, err)
+
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+
+	srv := artifactserver.New(cache, artifactserver.WithClientCAs(caWatcher))
+	startErr := srv.Start(context.Background(), reserveAddr(t))
+	require.Error(t, startErr)
+	assert.Contains(t, startErr.Error(), "client CAs configured without a TLS certificate watcher")
+}

--- a/internal/pkg/artifactserver/spiffeauth.go
+++ b/internal/pkg/artifactserver/spiffeauth.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactserver
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+)
+
+// verifyConnectionTimeout bounds the client-identity lookup performed by VerifyConnection.
+// tls.Config.VerifyConnection carries no context or deadline of its own.
+const verifyConnectionTimeout = 5 * time.Second
+
+// Authorizer checks that a client's SPIFFE URI SAN corresponds to a Falco instance that
+// actually exists. Chain verification alone cannot distinguish one instance's identity from
+// another, since every per-instance certificate is signed by the same CA.
+type Authorizer struct {
+	reader client.Reader // cache-backed; the manager's own client
+	logger logr.Logger
+}
+
+// NewAuthorizer returns an Authorizer backed by reader, expected to be the manager's
+// cache-backed client. logger records rejections distinctly from other TLS handshake failures.
+func NewAuthorizer(reader client.Reader, logger logr.Logger) *Authorizer {
+	return &Authorizer{reader: reader, logger: logger.WithName("artifact-server-authz")}
+}
+
+// VerifyConnection implements tls.Config.VerifyConnection, which runs for every connection,
+// including resumed ones, after chain verification has already succeeded. cs.PeerCertificates
+// is therefore guaranteed non-empty when this runs during a real handshake.
+func (a *Authorizer) VerifyConnection(cs tls.ConnectionState) error { //nolint:gocritic // must match tls.Config.VerifyConnection's exact signature
+	if len(cs.PeerCertificates) == 0 {
+		return errors.New("artifact server: no verified client certificate chain")
+	}
+
+	leaf := cs.PeerCertificates[0]
+	namespace, name, err := parseSPIFFEURI(leaf.URIs)
+	if err != nil {
+		a.logger.Info("Rejecting client: certificate has no valid SPIFFE URI SAN", "error", err.Error())
+		return fmt.Errorf("artifact server: client certificate missing a valid SPIFFE URI SAN: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), verifyConnectionTimeout)
+	defer cancel()
+
+	var falco instancev1alpha1.Falco
+	if err := a.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &falco); err != nil {
+		a.logger.Info("Rejecting client: SPIFFE identity does not match a known Falco instance",
+			"namespace", namespace, "name", name, "error", err.Error())
+		return fmt.Errorf("artifact server: client identity %s/%s does not correspond to a known Falco instance: %w",
+			namespace, name, err)
+	}
+
+	return nil
+}
+
+// parseSPIFFEURI extracts namespace/name from the first SPIFFE URI SAN matching
+// spiffe://<trust-domain>/ns/<namespace>/sa/<name>. The trust domain is not checked.
+func parseSPIFFEURI(uris []*url.URL) (namespace, name string, err error) {
+	for _, u := range uris {
+		if u == nil || u.Scheme != "spiffe" {
+			continue
+		}
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) == 4 && parts[0] == "ns" && parts[2] == "sa" && parts[1] != "" && parts[3] != "" {
+			return parts[1], parts[3], nil
+		}
+	}
+	return "", "", fmt.Errorf("no URI SAN matching spiffe://<trust-domain>/ns/<namespace>/sa/<name>")
+}

--- a/internal/pkg/artifactserver/spiffeauth_test.go
+++ b/internal/pkg/artifactserver/spiffeauth_test.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifactserver_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	instancev1alpha1 "github.com/falcosecurity/falco-operator/api/instance/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
+	"github.com/falcosecurity/falco-operator/internal/pkg/tlsutil"
+)
+
+// signSPIFFELeaf issues a client leaf certificate (signed by ca) carrying spiffeURI as its
+// only URI SAN — the identity the Authorizer checks against known Falco instances.
+func signSPIFFELeaf(t *testing.T, ca testCA, spiffeURI string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	u, err := url.Parse(spiffeURI)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "artifact-operator-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		URIs:         []*url.URL{u},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+// TestServer_SPIFFEAuthorizer proves that a CA-signed client certificate is necessary but not
+// sufficient: only a SPIFFE identity matching an actual, known Falco instance is accepted, even
+// though every case here presents a certificate signed by the same trusted CA.
+func TestServer_SPIFFEAuthorizer(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "test-root-ca")
+
+	serverCertPEM, serverKeyPEM := signLeaf(t, ca, "artifact-server", []net.IP{net.ParseIP("127.0.0.1")}, x509.ExtKeyUsageServerAuth)
+	serverCertFile := filepath.Join(dir, "tls.crt")
+	serverKeyFile := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(serverCertFile, serverCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(serverKeyFile, serverKeyPEM, 0o600))
+
+	caFile := filepath.Join(dir, "ca.crt")
+	require.NoError(t, os.WriteFile(caFile, ca.certPEM, 0o600))
+
+	certWatcher, err := certwatcher.New(serverCertFile, serverKeyFile)
+	require.NoError(t, err)
+	caWatcher, err := tlsutil.NewCAWatcher(caFile)
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, instancev1alpha1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&instancev1alpha1.Falco{
+			ObjectMeta: metav1.ObjectMeta{Name: "known-falco", Namespace: "default"},
+		}).
+		Build()
+	authorizer := artifactserver.NewAuthorizer(fakeClient, logr.Discard())
+
+	cache := artifactcache.NewCache(t.TempDir())
+	require.NoError(t, cache.Load())
+	seedRulesfile(t, cache, "secure", []byte("secure content"))
+
+	addr := reserveAddr(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := artifactserver.New(cache,
+		artifactserver.WithTLS(certWatcher),
+		artifactserver.WithClientCAs(caWatcher),
+		artifactserver.WithAuthorizer(authorizer))
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx, addr) }()
+	waitForListening(t, addr)
+
+	targetURL := "https://" + addr + "/v1/artifacts/rulesfiles/default/secure"
+	rootCAs := certPool(t, ca.certPEM)
+
+	t.Run("known Falco identity is accepted", func(t *testing.T) {
+		certPEM, keyPEM := signSPIFFELeaf(t, ca, "spiffe://cluster.local/ns/default/sa/known-falco")
+		clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs, Certificates: []tls.Certificate{clientCert},
+		}}}
+		resp, doErr := client.Get(targetURL) //nolint:noctx // test-only, short-lived
+		require.NoError(t, doErr)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("unknown Falco identity is rejected despite a valid CA-signed cert", func(t *testing.T) {
+		certPEM, keyPEM := signSPIFFELeaf(t, ca, "spiffe://cluster.local/ns/default/sa/unknown-falco")
+		clientCert, err := tls.X509KeyPair(certPEM, keyPEM)
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs, Certificates: []tls.Certificate{clientCert},
+		}}}
+		resp, doErr := client.Get(targetURL) //nolint:noctx // test-only, short-lived
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		require.Error(t, doErr, "an unknown SPIFFE identity must be rejected at the TLS layer, not just CA-verified")
+	})
+
+	t.Run("cert with no SPIFFE URI SAN is rejected", func(t *testing.T) {
+		clientCertPEM, clientKeyPEM := signLeaf(t, ca, "artifact-client", nil, x509.ExtKeyUsageClientAuth)
+		clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs, Certificates: []tls.Certificate{clientCert},
+		}}}
+		resp, doErr := client.Get(targetURL) //nolint:noctx // test-only, short-lived
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		require.Error(t, doErr)
+	})
+
+	cancel()
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}

--- a/internal/pkg/tlsutil/cawatcher.go
+++ b/internal/pkg/tlsutil/cawatcher.go
@@ -1,0 +1,188 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tlsutil provides a hot-reloadable CA trust anchor, filling a gap
+// sigs.k8s.io/controller-runtime/pkg/certwatcher doesn't cover: certwatcher.CertWatcher
+// hot-reloads a cert+key pair, but there's no equivalent for a bare CA bundle used to verify
+// a peer's certificate (mTLS client-cert verification on a server, or server-cert verification
+// on a client using a private CA). This matters because a cert-manager-issued CA rotates on a
+// schedule just like any other certificate; a CA loaded once at startup would silently start
+// rejecting connections after a rotation until every pod restarted.
+package tlsutil
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// defaultWatchInterval mirrors certwatcher's own polling fallback interval, used alongside
+// fsnotify in case an fsnotify event is missed (e.g. some overlay filesystems, or a rename
+// that fsnotify doesn't reliably surface).
+const defaultWatchInterval = 10 * time.Second
+
+// CAWatcher hot-reloads a PEM CA bundle from disk into an *x509.CertPool. New performs an
+// initial synchronous load and fails if the file is missing or invalid; Start (a
+// manager.Runnable) then watches the file via fsnotify plus a periodic poll fallback,
+// keeping the last-good pool and logging on any reload failure rather than serving with an
+// empty trust store.
+type CAWatcher struct {
+	mu   sync.RWMutex
+	pool *x509.CertPool
+
+	caFile   string
+	interval time.Duration
+	watcher  *fsnotify.Watcher
+	log      logr.Logger
+}
+
+// NewCAWatcher reads and parses caFile once, returning an error if it's missing or contains
+// no valid PEM certificates. The fsnotify watch on caFile is also registered here (not deferred
+// to Start), so a change to the file is never missed during the window between construction and
+// Start actually running (e.g. via mgr.Add, which may run well after New). Call Start to begin
+// processing watch events and the poll fallback.
+func NewCAWatcher(caFile string) (*CAWatcher, error) {
+	w := &CAWatcher{
+		caFile:   caFile,
+		interval: defaultWatchInterval,
+		log:      ctrllog.Log.WithName("cawatcher").WithValues("ca", caFile),
+	}
+
+	if err := w.reload(); err != nil {
+		return nil, err
+	}
+
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := fw.Add(caFile); err != nil {
+		_ = fw.Close()
+		return nil, fmt.Errorf("watch CA file: %w", err)
+	}
+	w.watcher = fw
+
+	return w, nil
+}
+
+// WithWatchInterval sets the poll-fallback interval and returns w, mirroring
+// certwatcher.CertWatcher.WithWatchInterval. The poll fallback matters because an atomic
+// rename-over-an-existing-path (as a Secret volume's symlink swap, or a plain
+// write-tmp-then-rename, produces) doesn't reliably fire an fsnotify event on every platform.
+func (w *CAWatcher) WithWatchInterval(interval time.Duration) *CAWatcher {
+	w.interval = interval
+	return w
+}
+
+// CertPool returns the currently loaded trust pool. Safe for concurrent use.
+func (w *CAWatcher) CertPool() *x509.CertPool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.pool
+}
+
+// reload reads and parses caFile, replacing the current pool on success. On failure, the
+// current pool is left untouched (caller decides whether that's the initial "no pool yet"
+// error or a logged-and-ignored reload failure).
+func (w *CAWatcher) reload() error {
+	data, err := os.ReadFile(w.caFile)
+	if err != nil {
+		return fmt.Errorf("read CA file: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return fmt.Errorf("no valid certificates found in CA file %q", w.caFile)
+	}
+
+	w.mu.Lock()
+	w.pool = pool
+	w.mu.Unlock()
+	return nil
+}
+
+// Start processes watch events on caFile until ctx is canceled, reloading the trust pool on
+// every change (and periodically, as a fallback). Implements manager.Runnable.
+func (w *CAWatcher) Start(ctx context.Context) error {
+	go w.watch()
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	w.log.Info("Starting CA poll+watcher", "interval", w.interval)
+	for {
+		select {
+		case <-ctx.Done():
+			return w.watcher.Close()
+		case <-ticker.C:
+			if err := w.reload(); err != nil {
+				w.log.Error(err, "failed to reload CA file")
+			}
+		}
+	}
+}
+
+// watch reads fsnotify events and reacts to changes, mirroring certwatcher.CertWatcher.Watch.
+func (w *CAWatcher) watch() {
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(event)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.log.Error(err, "CA watch error")
+		}
+	}
+}
+
+func (w *CAWatcher) handleEvent(event fsnotify.Event) {
+	switch {
+	case event.Op.Has(fsnotify.Write):
+	case event.Op.Has(fsnotify.Create):
+	case event.Op.Has(fsnotify.Chmod), event.Op.Has(fsnotify.Remove):
+		// The file was removed or renamed (e.g. a Secret volume's atomic symlink swap) —
+		// re-add the watch on the same path.
+		if err := w.watcher.Add(event.Name); err != nil {
+			w.log.Error(err, "error re-watching CA file")
+		}
+	default:
+		return
+	}
+
+	w.log.V(1).Info("CA file event", "event", event)
+	if err := w.reload(); err != nil {
+		w.log.Error(err, "error re-reading CA file")
+		return
+	}
+	w.log.Info("Updated CA trust pool")
+}
+
+// NeedLeaderElection reports that the CA watcher runs on every replica, not just the leader.
+func (w *CAWatcher) NeedLeaderElection() bool {
+	return false
+}

--- a/internal/pkg/tlsutil/cawatcher_test.go
+++ b/internal/pkg/tlsutil/cawatcher_test.go
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tlsutil_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falco-operator/internal/pkg/tlsutil"
+)
+
+// generateTestCA returns a PEM-encoded self-signed CA certificate with the given common name,
+// along with the parsed certificate itself (for verifying pool membership without relying on
+// the deprecated CertPool.Subjects()).
+func generateTestCA(t *testing.T, commonName string) (pemBytes []byte, cert *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), cert
+}
+
+// trusts reports whether pool currently trusts cert (used instead of the deprecated
+// CertPool.Subjects() to check pool membership).
+func trusts(cert *x509.Certificate, pool *x509.CertPool) bool {
+	_, err := cert.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny}})
+	return err == nil
+}
+
+func TestNewCAWatcher(t *testing.T) {
+	tests := []struct {
+		name            string
+		writeFile       func(t *testing.T, path string)
+		wantErrContains string
+	}{
+		{
+			name: "valid PEM succeeds",
+			writeFile: func(t *testing.T, path string) {
+				pemBytes, _ := generateTestCA(t, "test-ca")
+				require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
+			},
+		},
+		{
+			name:            "missing file errors",
+			writeFile:       func(t *testing.T, path string) {},
+			wantErrContains: "read CA file",
+		},
+		{
+			name: "non-PEM garbage errors",
+			writeFile: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, []byte("not a pem file"), 0o600))
+			},
+			wantErrContains: "no valid certificates found",
+		},
+		{
+			name: "empty file errors",
+			writeFile: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+			},
+			wantErrContains: "no valid certificates found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "ca.crt")
+			tt.writeFile(t, path)
+
+			w, err := tlsutil.NewCAWatcher(path)
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				assert.Nil(t, w)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, w)
+			assert.NotNil(t, w.CertPool())
+		})
+	}
+}
+
+func TestCAWatcher_Start_ReloadsOnFileChange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	v1PEM, v1Cert := generateTestCA(t, "ca-v1")
+	require.NoError(t, os.WriteFile(path, v1PEM, 0o600))
+
+	w, err := tlsutil.NewCAWatcher(path)
+	require.NoError(t, err)
+	require.True(t, trusts(v1Cert, w.CertPool()), "initial pool must trust the v1 CA")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Start(ctx) }()
+
+	// Replace the CA file with a different cert, write-then-rename (as a Secret volume's
+	// atomic symlink swap does), so the watcher's re-add-on-remove path gets exercised too.
+	v2PEM, v2Cert := generateTestCA(t, "ca-v2")
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, v2PEM, 0o600))
+	require.NoError(t, os.Rename(tmp, path))
+
+	require.Eventually(t, func() bool {
+		return trusts(v2Cert, w.CertPool())
+	}, 2*time.Second, 20*time.Millisecond, "CA pool was not reloaded after the file changed")
+	assert.False(t, trusts(v1Cert, w.CertPool()), "old CA must no longer be trusted after reload")
+
+	cancel()
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**


> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

  - Adds internal/pkg/tlsutil.CAWatcher: re-reads a CA bundle from disk on change and exposes the current trust pool as a *x509.CertPool, for tls.Config.ClientCAs without a server restart on
  rotation.
  - Adds internal/pkg/artifactserver.Server: serves cached plugin and rulesfile blobs over GET /v1/artifacts/{plugins,rulesfiles}/{namespace}/{name}, written by the instance-level aggregator
  controllers.
  - Optional TLS with hot-reloadable certs (via controller-runtime's certwatcher), optional mTLS via CAWatcher plus a SPIFFE Authorizer that checks a client's SPIFFE URI SAN against a real 
  Falco instance (chain verification alone can't distinguish one instance's identity from another, since every per-instance cert shares the same CA).
  - Jittered 503 backpressure limit on concurrent blob transfers, and Prometheus request/latency/cache-lookup metrics on controller-runtime's shared registry.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
