### PR TITLE
test(chainsaw): add instance-operator and validation e2e suites

### DIFF
--- a/.github/workflows/test-e2e-chainsaw.yml
+++ b/.github/workflows/test-e2e-chainsaw.yml
@@ -6,17 +6,79 @@ on:
       - main
   pull_request:
 
+env:
+  IMG_INSTANCE: falco-operator:e2e
+  IMG_ARTIFACT: artifact-operator:e2e
+
 jobs:
+  # Builds both operator binaries once; downstream jobs just `docker build` from them.
+  build-e2e-binaries:
+    name: build-e2e-binaries
+    runs-on: ubuntu-latest
+    env:
+      PROJECT: github.com/falcosecurity/falco-operator
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build instance-operator binary
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          go build -ldflags "-s -w -X '${PROJECT}/internal/pkg/version.ArtifactOperatorImage=${IMG_ARTIFACT}'" \
+            -o bin/linux/amd64/instance-manager ./cmd/instance/main.go
+
+      - name: Build artifact-operator binary
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          go build -ldflags "-s -w" -o bin/linux/amd64/artifact-manager ./cmd/artifact/main.go
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-binaries
+          path: |
+            bin/linux/amd64/instance-manager
+            bin/linux/amd64/artifact-manager
+          retention-days: 1
+
+  # Split by what each group of tests exercises, each on its own runner.
   test-e2e-chainsaw:
-    name: tests-e2e-chainsaw (${{ matrix.mode }})
+    name: tests-e2e-chainsaw (${{ matrix.category.name }}, ${{ matrix.mode.name }})
+    needs: build-e2e-binaries
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - mode: http
+        category:
+          - name: config
+            path: ./test/e2e/chainsaw/artifact-operator/config-*
+          - name: plugin
+            path: ./test/e2e/chainsaw/artifact-operator/plugin-*
+          - name: rulesfile
+            path: ./test/e2e/chainsaw/artifact-operator/rulesfile-*
+          # artifact-* doesn't fit config/plugin/rulesfile: some exercise all three kinds
+          # together, others use only Plugin to test kind-agnostic shared plumbing.
+          - name: artifact-shared
+            path: ./test/e2e/chainsaw/artifact-operator/artifact-*
+          - name: instance-operator
+            path: ./test/e2e/chainsaw/instance-operator/
+          - name: scenarios
+            path: ./test/e2e/chainsaw/scenarios/
+        mode:
+          - name: http
             mtls_enabled: false
-          - mode: mtls
+          - name: mtls
             mtls_enabled: true
     env:
       # renovate: datasource=github-releases depName=helm/helm
@@ -36,17 +98,9 @@ jobs:
       # renovate: datasource=github-releases depName=falcosecurity/falco
       FALCO_VERSION: "0.44.1"
       NAMESPACE: falco-operator
-      IMG_INSTANCE: falco-operator:e2e
-      IMG_ARTIFACT: artifact-operator:e2e
-      PROJECT: github.com/falcosecurity/falco-operator
     steps:
       - name: Clone the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -74,23 +128,18 @@ jobs:
           chmod +x falcoctl
           sudo mv falcoctl /usr/local/bin/falcoctl
 
-      - name: Build instance-operator image
-        env:
-          CGO_ENABLED: 0
-          GOOS: linux
-          GOARCH: amd64
-        run: |
-          go build -ldflags "-s -w -X '${PROJECT}/internal/pkg/version.ArtifactOperatorImage=${IMG_ARTIFACT}'" \
-            -o bin/linux/amd64/manager ./cmd/instance/main.go
-          docker build -t "${IMG_INSTANCE}" -f build/Dockerfile .
+      - name: Download e2e binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-binaries
+          path: bin/linux/amd64
 
-      - name: Build artifact-operator image
-        env:
-          CGO_ENABLED: 0
-          GOOS: linux
-          GOARCH: amd64
+      - name: Build operator images
         run: |
-          go build -ldflags "-s -w" -o bin/linux/amd64/manager ./cmd/artifact/main.go
+          chmod +x bin/linux/amd64/instance-manager bin/linux/amd64/artifact-manager
+          cp bin/linux/amd64/instance-manager bin/linux/amd64/manager
+          docker build -t "${IMG_INSTANCE}" -f build/Dockerfile .
+          cp bin/linux/amd64/artifact-manager bin/linux/amd64/manager
           docker build -t "${IMG_ARTIFACT}" -f build/Dockerfile .
 
       - name: Create kind cluster
@@ -109,7 +158,7 @@ jobs:
         run: kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Install cert-manager
-        if: matrix.mtls_enabled
+        if: matrix.mode.mtls_enabled
         run: |
           helm repo add jetstack https://charts.jetstack.io --force-update
           helm repo update jetstack
@@ -122,7 +171,7 @@ jobs:
             --wait --timeout 180s
 
       - name: Install trust-manager
-        if: matrix.mtls_enabled
+        if: matrix.mode.mtls_enabled
         run: |
           helm repo add jetstack https://charts.jetstack.io --force-update
           helm upgrade --install trust-manager jetstack/trust-manager \
@@ -137,7 +186,7 @@ jobs:
       # this label by hand, deliberately; this is just the e2e job automating that one manual
       # step for its own operator namespace.
       - name: Label namespace for mTLS trust distribution
-        if: matrix.mtls_enabled
+        if: matrix.mode.mtls_enabled
         run: kubectl label namespace "${NAMESPACE}" artifact.falcosecurity.dev/trust=true --overwrite
 
       - name: Install KWOK
@@ -150,7 +199,7 @@ jobs:
           helm upgrade --install falco-operator chart/falco-operator --namespace "${NAMESPACE}" --create-namespace \
             --set image.repository="${IMG_INSTANCE%:*}" --set-string image.tag="${IMG_INSTANCE##*:}" \
             --set-string extraEnv[0].name=ARTIFACT_OPERATOR_IMAGE,extraEnv[0].value="${IMG_ARTIFACT}" \
-            --set mtls.enabled=${{ matrix.mtls_enabled }} \
+            --set mtls.enabled=${{ matrix.mode.mtls_enabled }} \
             --wait --timeout 180s
 
       - name: Deploy local OCI registry
@@ -164,7 +213,7 @@ jobs:
           CHAINSAW_FALCO_IMAGE: docker.io/falcosecurity/falco:${{ env.FALCO_VERSION }}
           CHAINSAW_ARTIFACT_OPERATOR_IMAGE: ${{ env.IMG_ARTIFACT }}
         run: |
-          chainsaw test ./test/e2e/chainsaw/ --quiet --config ./test/e2e/chainsaw/.chainsaw.yaml --repeat-count 1
+          chainsaw test ${{ matrix.category.path }} --quiet --config ./test/e2e/chainsaw/.chainsaw.yaml --repeat-count 1
 
       # Every chainsaw test's `catch:` block (see test/e2e/chainsaw/common/scripts/debug_snapshot.sh)
       # already writes a failure snapshot here by default. This just surfaces it as a downloadable
@@ -173,7 +222,85 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: chainsaw-debug-snapshots-${{ matrix.mode }}
+          name: chainsaw-debug-snapshots-${{ matrix.category.name }}-${{ matrix.mode.name }}
+          path: /tmp/chainsaw
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # CRD admission validation only: rejected by the API server before any controller sees it,
+  # so no KWOK/OCI registry/mTLS needed, and no need to run twice for http/mtls.
+  test-e2e-chainsaw-validation:
+    name: tests-e2e-chainsaw (validation)
+    needs: build-e2e-binaries
+    runs-on: ubuntu-latest
+    env:
+      HELM_VERSION: v3.20.2
+      KIND_VERSION: v0.32.0
+      CHAINSAW_VERSION: v0.2.15
+      NAMESPACE: falco-operator
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install chainsaw
+        uses: kyverno/action-install-chainsaw@1223ef75bedeb59c4e7b5455463d4316e76dff01 # v0.2.15
+        with:
+          release: ${{ env.CHAINSAW_VERSION }}
+          verify: true
+
+      - name: Download e2e binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-binaries
+          path: bin/linux/amd64
+
+      - name: Build operator images
+        run: |
+          chmod +x bin/linux/amd64/instance-manager bin/linux/amd64/artifact-manager
+          cp bin/linux/amd64/instance-manager bin/linux/amd64/manager
+          docker build -t "${IMG_INSTANCE}" -f build/Dockerfile .
+          cp bin/linux/amd64/artifact-manager bin/linux/amd64/manager
+          docker build -t "${IMG_ARTIFACT}" -f build/Dockerfile .
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          cluster_name: kind
+          config: .github/e2e/kind-config.yaml
+
+      - name: Load operator images into kind
+        run: |
+          kind load docker-image "${IMG_INSTANCE}" --name kind
+          kind load docker-image "${IMG_ARTIFACT}" --name kind
+
+      - name: Ensure namespace exists
+        run: kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy falco-operator chart
+        run: |
+          helm upgrade --install falco-operator chart/falco-operator --namespace "${NAMESPACE}" --create-namespace \
+            --set image.repository="${IMG_INSTANCE%:*}" --set-string image.tag="${IMG_INSTANCE##*:}" \
+            --set-string extraEnv[0].name=ARTIFACT_OPERATOR_IMAGE,extraEnv[0].value="${IMG_ARTIFACT}" \
+            --wait --timeout 180s
+
+      - name: Run chainsaw e2e tests
+        run: |
+          chainsaw test ./test/e2e/chainsaw/validation --quiet --config ./test/e2e/chainsaw/.chainsaw.yaml --repeat-count 1
+
+      - name: Upload chainsaw debug snapshots
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: chainsaw-debug-snapshots-validation
           path: /tmp/chainsaw
           if-no-files-found: ignore
           retention-days: 7

--- a/test/e2e/chainsaw/artifact-operator/artifact-selector-matching/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/artifact-operator/artifact-selector-matching/chainsaw-test.yaml
@@ -205,7 +205,25 @@ spec:
                 namespace: ($namespace)
 
     - name: "Step 05: Cleanup-scenario-1"
+      description: |
+        Deletes the pods pinned to node_notin_match/node_notin_excluded before the Nodes
+        themselves: a Node delete doesn't cascade-delete pods bound to it (no ownerRef), so
+        skipping this would leave two orphaned pods (referencing a now-gone Node) for
+        PodGC to notice and reap asynchronously - unnecessary API churn right before Step 06
+        creates a new fake Node and immediately needs KWOK's attention for it.
       try:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Pod
+              name: ($falco_pod_notin_match_name)
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Pod
+              name: ($falco_pod_notin_excluded_name)
+              namespace: ($namespace)
         - delete:
             ref:
               apiVersion: artifact.falcosecurity.dev/v1alpha1
@@ -384,6 +402,12 @@ spec:
       try:
         - delete:
             ref:
+              apiVersion: v1
+              kind: Pod
+              name: ($falco_pod_dynamic_name)
+              namespace: ($namespace)
+        - delete:
+            ref:
               apiVersion: artifact.falcosecurity.dev/v1alpha1
               kind: Plugin
               name: ($plugin_dynamic_name)
@@ -549,6 +573,12 @@ spec:
 
     - name: "Step 20: Cleanup-scenario-3"
       try:
+        - delete:
+            ref:
+              apiVersion: v1
+              kind: Pod
+              name: ($falco_pod_fanout_name)
+              namespace: ($namespace)
         - delete:
             ref:
               apiVersion: artifact.falcosecurity.dev/v1alpha1

--- a/test/e2e/chainsaw/common/_step_templates/apply-fake-node.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-fake-node.yaml
@@ -27,6 +27,11 @@
 # JMESPath function rejects an empty-object argument at the type check (`invalid type for:
 # map[], expected: []functions.JpType{"object"}`), so a variadic "merge caller-supplied labels
 # over fixed ones" design isn't safe to default to {}.
+#
+# The status block below is documentation-of-intent, not a real effect: Node has a status
+# subresource, so the API server strips .status from this write. KWOK's own controller
+# PATCHes /status asynchronously once it sees the kwok.x-k8s.io/node=fake annotation. The
+# wait below blocks on that, so callers pinning a pod here right after aren't racing it.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
@@ -73,3 +78,12 @@ spec:
               kubeProxyVersion: fake
               operatingSystem: ($node_os)
             phase: Running
+    - wait:
+        apiVersion: v1
+        kind: Node
+        name: ($node_name)
+        timeout: 30s
+        for:
+          condition:
+            name: Ready
+            value: "true"

--- a/test/e2e/chainsaw/common/_step_templates/assert-component-status.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/assert-component-status.yaml
@@ -1,0 +1,43 @@
+# Asserts a Component CR's status in detail: resourceType, version, replica counts, and
+# the Reconciled/Available condition statuses individually.
+#
+# apply-assert-component.yaml only waits for every condition to reach 'True' generically.
+# Use this instead for tests checking the Component controller's own resource-management
+# behavior.
+#
+# Required bindings:
+#   - component_name:     Name of the Component CR.
+#   - namespace:           Namespace of the Component CR.
+#   - expected_replicas:   Expected desiredReplicas and availableReplicas count.
+#   - expected_version:    Expected status.version value.
+#
+# Optional bindings:
+#   - expected_reconciled: Expected Reconciled condition status. Default: "True".
+#   - expected_available:  Expected Available condition status. Default: "True".
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: assert-component-status
+spec:
+  bindings:
+    - name: expected_reconciled
+      value: "True"
+    - name: expected_available
+      value: "True"
+  try:
+    - assert:
+        resource:
+          apiVersion: instance.falcosecurity.dev/v1alpha1
+          kind: Component
+          metadata:
+            name: ($component_name)
+            namespace: ($namespace)
+          status:
+            resourceType: Deployment
+            version: ($expected_version)
+            desiredReplicas: ($expected_replicas)
+            availableReplicas: ($expected_replicas)
+            (conditions[?type == 'Reconciled']):
+              - status: ($expected_reconciled)
+            (conditions[?type == 'Available']):
+              - status: ($expected_available)

--- a/test/e2e/chainsaw/common/_step_templates/assert-falco-status.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/assert-falco-status.yaml
@@ -1,0 +1,40 @@
+# Asserts a Falco CR's status in detail: resourceType, version, and the
+# Reconciled/Available condition statuses individually.
+#
+# apply-assert-falco.yaml only waits for every condition to reach 'True' generically. Use
+# this instead for tests checking the Falco controller's own resource-management behavior.
+#
+# Required bindings:
+#   - falco_name:            Name of the Falco CR.
+#   - namespace:              Namespace of the Falco CR.
+#   - expected_resource_type: "DaemonSet" or "Deployment".
+#   - expected_version:       Expected status.version value.
+#
+# Optional bindings:
+#   - expected_reconciled: Expected Reconciled condition status. Default: "True".
+#   - expected_available:  Expected Available condition status. Default: "True".
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: assert-falco-status
+spec:
+  bindings:
+    - name: expected_reconciled
+      value: "True"
+    - name: expected_available
+      value: "True"
+  try:
+    - assert:
+        resource:
+          apiVersion: instance.falcosecurity.dev/v1alpha1
+          kind: Falco
+          metadata:
+            name: ($falco_name)
+            namespace: ($namespace)
+          status:
+            resourceType: ($expected_resource_type)
+            version: ($expected_version)
+            (conditions[?type == 'Reconciled']):
+              - status: ($expected_reconciled)
+            (conditions[?type == 'Available']):
+              - status: ($expected_available)

--- a/test/e2e/chainsaw/common/_step_templates/wait-falco-pod-ready.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/wait-falco-pod-ready.yaml
@@ -1,0 +1,28 @@
+# Waits until every pod in the test namespace reports Ready.
+#
+# Unlike apply-assert-falco.yaml's assert, which only waits on the Falco CR's own
+# conditions, this waits on the actual pod - for tests that need it (e.g. asserting
+# numberReady, or checking pod restarts). One Falco instance per namespace, so no
+# selector needed.
+#
+# Runs wait_pods_ready.sh instead of chainsaw's native `wait:` (kubectl wait --all): that
+# snapshots the pod list once and fails hard with NotFound if a pod it saw gets deleted
+# before it's checked - exactly what happens right after a Falco type switch, when the old
+# pods are still terminating as the new ones come up.
+#
+# Required bindings:
+#   - namespace: Namespace to wait in.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: wait-falco-pod-ready
+spec:
+  try:
+    - script:
+        env:
+          - name: NAMESPACE
+            value: ($namespace)
+        content: |
+          bash ../../common/scripts/wait_pods_ready.sh
+        check:
+          (to_string(json_parse($stdout).status) == 'success'): true

--- a/test/e2e/chainsaw/common/scripts/check_no_pod_restarts.sh
+++ b/test/e2e/chainsaw/common/scripts/check_no_pod_restarts.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Verify the Falco pod's containers have not restarted. A point-in-time check, not a
+# retry-until-true wait: the caller is expected to have already waited for the pod to be
+# Ready (see wait-falco-pod-ready.yaml), so a restart count above 0 here means something
+# actually crashed and recovered, not that the pod hasn't come up yet.
+# Env vars:
+#   NAMESPACE:  Namespace of the Falco pod.
+#   FALCO_NAME: Value of app.kubernetes.io/name label on the Falco pod.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+FALCO_NAME="${FALCO_NAME}"
+
+if ! POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$FALCO_NAME" \
+    -o jsonpath='{.items[0].metadata.name}' 2>&1); then
+  echo "{\"status\": \"failure\", \"message\": \"kubectl get pods failed\", \"error\": $(printf '%s' "$POD" | jq -Rs .)}"
+  exit 1
+fi
+if [ -z "$POD" ]; then
+  echo "{\"status\": \"failure\", \"message\": \"no pod found for app.kubernetes.io/name=$FALCO_NAME in $NAMESPACE\"}"
+  exit 1
+fi
+
+if ! RESTARTS=$(kubectl get pod -n "$NAMESPACE" "$POD" \
+    -o jsonpath='{.status.containerStatuses[*].restartCount}' 2>&1); then
+  echo "{\"status\": \"failure\", \"message\": \"kubectl get pod failed\", \"pod\": \"$POD\", \"error\": $(printf '%s' "$RESTARTS" | jq -Rs .)}"
+  exit 1
+fi
+
+for count in $RESTARTS; do
+  if [ "$count" != "0" ]; then
+    cat <<EOF
+{
+  "status": "failure",
+  "message": "pod container restarted",
+  "namespace": "$NAMESPACE",
+  "falco_name": "$FALCO_NAME",
+  "pod": "$POD",
+  "restart_counts": "$RESTARTS"
+}
+EOF
+    exit 1
+  fi
+done
+
+cat <<EOF
+{
+  "status": "success",
+  "message": "no container restarts",
+  "namespace": "$NAMESPACE",
+  "falco_name": "$FALCO_NAME",
+  "pod": "$POD",
+  "restart_counts": "$RESTARTS"
+}
+EOF

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -62,6 +62,12 @@ capture deployments kubectl get deployments -n "$NAMESPACE" -o yaml
 capture controllerrevisions kubectl get controllerrevisions -n "$NAMESPACE" -o yaml
 capture pods kubectl get pods -n "$NAMESPACE" -o wide
 capture pods-describe kubectl describe pods -n "$NAMESPACE"
+# Cluster-scoped, covers real and KWOK-simulated fake nodes. Tells us whether KWOK ever
+# finished staging a fake Node (see apply-fake-node.yaml).
+capture nodes kubectl get nodes -o wide
+capture nodes-describe kubectl describe nodes
+# KWOK's own controller log. Absent if KWOK isn't installed for this test category.
+capture kwok-controller-logs kubectl logs -n kube-system -l app=kwok-controller --tail=200
 capture operator-pods kubectl get pods -n "$OPERATOR_NAMESPACE" -o wide
 # The instance-operator ("manager" container) is the single Deployment in
 # OPERATOR_NAMESPACE; control-plane=falco-operator is a hardcoded pod-template

--- a/test/e2e/chainsaw/common/scripts/wait_pods_ready.sh
+++ b/test/e2e/chainsaw/common/scripts/wait_pods_ready.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Wait until every pod currently in the namespace reports Ready.
+#
+# Re-lists pods on every poll instead of snapshotting once (unlike `kubectl wait --all`,
+# which fails hard with NotFound if a pod it saw at the start gets deleted before it's
+# checked - exactly what happens right after a Falco type switch, when the old
+# DaemonSet's pods are still being torn down as the new Deployment's pod comes up).
+#
+# Env vars:
+#   NAMESPACE: Namespace to check.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+MAX_RETRIES="${MAX_RETRIES:-200}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+LAST_ERROR="no attempts made"
+
+for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
+  if ! STATUSES=$(kubectl get pods -n "$NAMESPACE" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>&1); then
+    LAST_ERROR="kubectl get pods failed: $STATUSES"
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  if [ -z "$STATUSES" ]; then
+    LAST_ERROR="no pods found in $NAMESPACE"
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  if ! printf '%s\n' "$STATUSES" | grep -qv ' True$'; then
+    echo "{\"status\": \"success\", \"message\": \"all pods ready\", \"namespace\": \"$NAMESPACE\"}"
+    exit 0
+  fi
+  LAST_ERROR="not all pods ready: $(printf '%s' "$STATUSES" | tr '\n' ';')"
+  sleep "$RETRY_DELAY"
+done
+
+echo "{\"status\": \"failure\", \"message\": \"not all pods ready after $MAX_RETRIES attempts\", \"namespace\": \"$NAMESPACE\", \"last_error\": $(printf '%s' "$LAST_ERROR" | jq -Rs .)}"
+exit 1

--- a/test/e2e/chainsaw/instance-operator/falco-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/falco-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,210 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: falco-lifecycle
+spec:
+  description: |
+    Falco controller resource-management lifecycle, distinct from the artifact-operator
+    suite (which only ever exercises Plugin/Rulesfile/Config against an already-existing
+    Falco and never touches the Falco CR's own reconciliation):
+    1. Create as DaemonSet; assert the DaemonSet, and the Falco CR's resourceType/version/
+       conditions, are all correct.
+    2. Re-apply the identical spec; assert the reconcile is a no-op (no pod restart), proving
+       ensureDeployment/ensureDaemonSet compares before writing rather than always updating.
+    3. Patch spec.type to Deployment; assert the DaemonSet is torn down, a Deployment takes
+       its place and becomes ready, and the Falco CR reflects the new resourceType.
+    4. Delete the Falco CR; assert every owned namespaced (Deployment, ServiceAccount, Role,
+       RoleBinding) and cluster-scoped (ClusterRole, ClusterRoleBinding) resource is gone.
+
+  bindings:
+    - name: falco_name
+      value: falco-lifecycle-test
+    - name: test_name
+      value: falco-lifecycle
+
+  steps:
+    - name: Create-falco-as-daemonset
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_type
+              value: DaemonSet
+
+    - name: Wait-for-falco-pod-ready
+      use:
+        template: ../../common/_step_templates/wait-falco-pod-ready.yaml
+
+    - name: Assert-daemonset-ready
+      description: |
+        The DaemonSet itself, not just the Falco CR's conditions, is up. Compares
+        numberReady/desiredNumberScheduled against each other rather than a hardcoded count.
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              status:
+                (desiredNumberScheduled >= `1`): true
+                (numberReady == desiredNumberScheduled): true
+
+    - name: Assert-falco-status-as-daemonset
+      use:
+        template: ../../common/_step_templates/assert-falco-status.yaml
+        with:
+          bindings:
+            - name: falco_name
+              value: ($falco_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_resource_type
+              value: DaemonSet
+            - name: expected_version
+              value: "0.44.1"
+
+    - name: Reapply-identical-falco-spec
+      description: Re-applying the same spec must be a no-op reconcile, not a pod restart.
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_type
+              value: DaemonSet
+
+    - name: Assert-no-pod-restart-after-reapply
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+            content: |
+              bash ../../common/scripts/check_no_pod_restarts.sh
+            check:
+              (to_string(json_parse($stdout).status) == 'success'): true
+
+    - name: Switch-falco-type-to-deployment
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                type: Deployment
+                replicas: 1
+
+    - name: Assert-daemonset-torn-down
+      try:
+        - error:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+
+    - name: Assert-deployment-ready
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+    - name: Assert-falco-status-as-deployment
+      use:
+        template: ../../common/_step_templates/assert-falco-status.yaml
+        with:
+          bindings:
+            - name: falco_name
+              value: ($falco_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_resource_type
+              value: Deployment
+            - name: expected_version
+              value: "0.44.1"
+
+    - name: Delete-falco
+      try:
+        - delete:
+            ref:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              name: ($falco_name)
+              namespace: ($namespace)
+
+    - name: Assert-namespaced-resources-gone
+      try:
+        - error:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: Role
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+
+    - name: Assert-cluster-scoped-resources-gone
+      description: |
+        ClusterRole/ClusterRoleBinding names are "<falco_name>--<namespace>"
+        (resources.GenerateUniqueName), since they're cluster-scoped and must stay unique
+        across every Falco instance in every namespace.
+      try:
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: (join('--', [$falco_name, $namespace]))
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: (join('--', [$falco_name, $namespace]))
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/falco-podtemplate/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/falco-podtemplate/chainsaw-test.yaml
@@ -1,0 +1,152 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: falco-podtemplate
+spec:
+  description: |
+    Custom spec.podTemplateSpec fields (pod labels, tolerations, per-container resource
+    limits) applied on top of an already-running Falco are picked up by the DaemonSet's
+    rollout, and don't clobber the operator's own artifact-operator sidecar: every
+    reconcile, generateApplyConfiguration.go merges the user's podTemplateSpec overlay onto
+    resources.FalcoDefaults's base template (instance.MergeApplyConfiguration, a
+    structured-merge-diff typed merge against the real apps/v1 DaemonSet/Deployment schema,
+    which merges spec.template.spec.containers by name). Since artifact-operator lives in
+    the base template, it survives a user overlay that only mentions "falco" by name.
+    This is NOT a general property of the Falco CR's own podTemplateSpec field, though:
+    that field has no list-map merge key of its own, so patching spec.podTemplateSpec.spec
+    .containers replaces the CR's own array wholesale. A container that exists only because
+    a *previous* user overlay added it - not because it's in FalcoDefaults - will disappear
+    the moment a later patch's containers list omits it.
+
+  bindings:
+    - name: falco_name
+      value: falco-podtemplate-test
+    - name: test_name
+      value: falco-podtemplate
+
+  steps:
+    - name: Create-falco
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_type
+              value: DaemonSet
+
+    - name: Wait-for-falco-pod-ready
+      use:
+        template: ../../common/_step_templates/wait-falco-pod-ready.yaml
+
+    - name: Patch-custom-podtemplate-fields
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                podTemplateSpec:
+                  metadata:
+                    labels:
+                      custom-label: test-value
+                  spec:
+                    tolerations:
+                      - key: test-toleration
+                        operator: Exists
+                        effect: NoSchedule
+                    containers:
+                      - name: falco
+                        resources:
+                          limits:
+                            cpu: 500m
+                            memory: 1Gi
+
+    - name: Assert-daemonset-rolled-out
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              status:
+                (updatedNumberScheduled == desiredNumberScheduled): true
+                (numberReady == desiredNumberScheduled): true
+
+    - name: Assert-pod-has-custom-label-and-toleration
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: ($namespace)
+                labels:
+                  app.kubernetes.io/instance: ($falco_name)
+                  custom-label: test-value
+              spec:
+                (tolerations[?key == 'test-toleration']):
+                  - operator: Exists
+                    effect: NoSchedule
+              status:
+                phase: Running
+
+    - name: Assert-base-default-sidecar-survives-user-overlay
+      description: |
+        artifact-operator comes from resources.FalcoDefaults, unconditionally merged back in
+        every reconcile - it must survive even though the patch's own containers list only
+        mentions "falco".
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  spec:
+                    (containers[?name == 'falco']):
+                      - resources:
+                          limits:
+                            cpu: 500m
+                            memory: 1Gi
+                    (containers[?name == 'artifact-operator']):
+                      - name: artifact-operator
+
+    - name: Assert-user-only-sidecar-does-not-survive-overlay-replace
+      description: |
+        netshoot only ever existed because apply-assert-falco.yaml's own user overlay added
+        it, not because it's part of FalcoDefaults. The patch's containers list didn't
+        mention it, and the Falco CR's own podTemplateSpec.spec.containers field has no
+        list-map merge key (unlike the real DaemonSet this generates), so the patch replaced
+        that field's array wholesale and netshoot is gone from the rolled-out DaemonSet.
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  spec:
+                    (containers[?name == 'netshoot']): []
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/falco-scale/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/falco-scale/chainsaw-test.yaml
@@ -1,0 +1,83 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: falco-scale
+spec:
+  description: |
+    Falco Deployment replica scaling: spec.replicas is propagated to the underlying
+    Deployment and the controller reconciles it back up after a scale-up. Distinct from
+    falco-lifecycle, which only ever runs a single replica and never touches spec.replicas.
+
+  bindings:
+    - name: falco_name
+      value: falco-scale-test
+    - name: test_name
+      value: falco-scale
+
+  steps:
+    - name: Create-falco-as-deployment
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_type
+              value: Deployment
+
+    - name: Wait-for-falco-pod-ready
+      use:
+        template: ../../common/_step_templates/wait-falco-pod-ready.yaml
+
+    - name: Assert-deployment-single-replica
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 1
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+    - name: Scale-deployment-to-two-replicas
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 2
+
+    - name: Assert-deployment-scaled-up
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 2
+              status:
+                availableReplicas: 2
+                readyReplicas: 2
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/falco-version/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/falco-version/chainsaw-test.yaml
@@ -1,0 +1,173 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: falco-version
+spec:
+  description: |
+    Falco version resolution: spec.version drives the resolved image tag
+    (docker.io/falcosecurity/falco:<version>), and an explicit podTemplateSpec image
+    override takes precedence over spec.version once set.
+
+    Deliberately does NOT go through apply-assert-falco.yaml: that template pins the falco
+    container's image to $CHAINSAW_FALCO_IMAGE via its own podTemplateSpec override, which
+    would make spec.version cosmetic and defeat the point of this test. Uses real published
+    Falco images from docker.io instead of the CI-pinned version.
+
+    Uses type: Deployment (engine.kind: nodriver, see deploymentFalcoConfig in
+    internal/pkg/resources/falco.go), not DaemonSet, and deliberately never waits for the
+    pod to become Ready or asserts the Available condition: this test is only about the
+    Falco *controller's* image-tag resolution, a synchronous, pod-health-independent
+    concern. DaemonSet mode needs the real eBPF probe (engine.kind: modern_ebpf) to
+    actually load, which ties pod health to the CI kernel's compatibility with whatever
+    specific old Falco version happens to be pinned here - a real failure hit in practice
+    (0.40.0's modern_ebpf probe failed scap_init against a CI kernel, unrelated to anything
+    this test is meant to verify). Asserting only the resolved image field and the
+    Reconciled condition (which internal/pkg/resources' generation confirms goes True
+    independent of whether the container the DaemonSet/Deployment describes ever actually
+    starts) keeps this test's outcome fully decoupled from Falco's runtime behavior.
+
+  bindings:
+    - name: falco_name
+      value: falco-version-test
+    - name: test_name
+      value: falco-version
+    - name: initial_version
+      value: "0.40.0"
+    - name: upgraded_version
+      value: "0.43.0"
+    - name: initial_image
+      value: docker.io/falcosecurity/falco:0.40.0
+    - name: upgraded_image
+      value: docker.io/falcosecurity/falco:0.43.0
+
+  steps:
+    - name: Create-falco-with-initial-version
+      try:
+        - apply:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                type: Deployment
+                replicas: 1
+                version: ($initial_version)
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  spec:
+                    # JMESPath filter, not a direct array assert: chainsaw does strict
+                    # element-count matching and the Deployment has multiple containers
+                    # (falco + artifact-operator sidecar).
+                    (containers[?name == 'falco']):
+                      - image: ($initial_image)
+
+    - name: Assert-falco-status-matches-initial-version
+      try:
+        - assert:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              status:
+                resourceType: Deployment
+                version: ($initial_version)
+                (conditions[?type == 'Reconciled']):
+                  - status: 'True'
+
+    - name: Patch-falco-version-to-upgraded-version
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                version: ($upgraded_version)
+
+    - name: Assert-deployment-image-updated
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  spec:
+                    (containers[?name == 'falco']):
+                      - image: ($upgraded_image)
+
+    - name: Assert-falco-status-matches-upgraded-version
+      try:
+        - assert:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              status:
+                resourceType: Deployment
+                version: ($upgraded_version)
+                (conditions[?type == 'Reconciled']):
+                  - status: 'True'
+
+    - name: Patch-image-override-via-podtemplatespec
+      description: An explicit image override must win over spec.version's resolved tag.
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                podTemplateSpec:
+                  spec:
+                    containers:
+                      - name: falco
+                        image: ($initial_image)
+
+    - name: Assert-deployment-image-overridden
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($falco_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  spec:
+                    (containers[?name == 'falco']):
+                      - image: ($initial_image)
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/falcosidekick-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/falcosidekick-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,159 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: falcosidekick-lifecycle
+spec:
+  description: |
+    Component controller resource-management lifecycle for the falcosidekick type. Unlike
+    metacollector-lifecycle, falcosidekick's RBAC is namespace-scoped (Role/RoleBinding, not
+    ClusterRole/ClusterRoleBinding): FalcosidekickDefaults only sets RoleRules, and the
+    Component controller only creates cluster-scoped RBAC when ClusterRoleRules is non-empty
+    (see controllers/instance/component/controller.go). Runs with 2 replicas throughout, so
+    this also covers a non-default replica count the metacollector tests don't touch.
+
+  bindings:
+    - name: component_name
+      value: falcosidekick-lifecycle-test
+    - name: test_name
+      value: falcosidekick-lifecycle
+
+  steps:
+    - name: Create-component
+      use:
+        template: ../../common/_step_templates/apply-assert-component.yaml
+        with:
+          bindings:
+            - name: component_type
+              value: falcosidekick
+
+    - name: Scale-to-two-replicas
+      description: apply-assert-component.yaml doesn't set replicas; do it as a follow-up patch.
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 2
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              status:
+                availableReplicas: 2
+                readyReplicas: 2
+
+    - name: Assert-component-status
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 2
+            # Must track internal/pkg/image/const.go's FalcosidekickTag.
+            - name: expected_version
+              value: "2.32.0"
+
+    - name: Assert-sub-resources-exist
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: Role
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                ports:
+                  - port: 2801
+
+    - name: Delete-component
+      try:
+        - delete:
+            ref:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              name: ($component_name)
+              namespace: ($namespace)
+
+    - name: Assert-namespaced-resources-gone
+      try:
+        - error:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: Role
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/metacollector-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/metacollector-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,172 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: metacollector-lifecycle
+spec:
+  description: |
+    Component controller resource-management lifecycle for the metacollector type, distinct
+    from the scenarios/metacollector-k8smeta integration test (which wires a metacollector
+    Component into a full Falco + k8smeta Plugin stack and never touches the Component
+    controller's own create/idempotent/delete behavior in isolation):
+    1. Create; assert sub-resources (ServiceAccount, ClusterRole, ClusterRoleBinding,
+       Service) and the Component CR's resourceType/version/replicas/conditions.
+    2. Re-apply the identical spec; assert the reconcile is a no-op (Deployment stays
+       stable), proving the controller compares before writing rather than always updating.
+    3. Delete the Component CR; assert every owned namespaced (Deployment, ServiceAccount,
+       Service) and cluster-scoped (ClusterRole, ClusterRoleBinding) resource is gone.
+
+  bindings:
+    - name: component_name
+      value: metacollector-lifecycle-test
+    - name: test_name
+      value: metacollector-lifecycle
+
+  steps:
+    - name: Create-component
+      use:
+        template: ../../common/_step_templates/apply-assert-component.yaml
+        with:
+          bindings:
+            - name: component_type
+              value: metacollector
+
+    - name: Assert-component-status
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 1
+            # Must track internal/pkg/image/const.go's MetacollectorTag.
+            - name: expected_version
+              value: "0.1.2"
+
+    - name: Assert-sub-resources-exist
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: (join('--', [$component_name, $namespace]))
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: (join('--', [$component_name, $namespace]))
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+
+    - name: Reapply-identical-component-spec
+      description: Re-applying the same spec must be a no-op reconcile.
+      use:
+        template: ../../common/_step_templates/apply-assert-component.yaml
+        with:
+          bindings:
+            - name: component_type
+              value: metacollector
+
+    - name: Assert-component-status-stable-after-reapply
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 1
+            - name: expected_version
+              value: "0.1.2"
+
+    - name: Assert-deployment-stable-after-reapply
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+    - name: Delete-component
+      try:
+        - delete:
+            ref:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              name: ($component_name)
+              namespace: ($namespace)
+
+    - name: Assert-namespaced-resources-gone
+      try:
+        - error:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+
+    - name: Assert-cluster-scoped-resources-gone
+      try:
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: (join('--', [$component_name, $namespace]))
+        - error:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: (join('--', [$component_name, $namespace]))
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/metacollector-podtemplate/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/metacollector-podtemplate/chainsaw-test.yaml
@@ -1,0 +1,116 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: metacollector-podtemplate
+spec:
+  description: |
+    Component-level customization beyond the plain type/replicas path: custom pod labels
+    and annotations via podTemplateSpec, and a Deployment strategy override.
+
+  bindings:
+    - name: component_name
+      value: metacollector-podtemplate-test
+    - name: test_name
+      value: metacollector-podtemplate
+
+  steps:
+    - name: Create-component-with-custom-pod-labels
+      try:
+        - apply:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                component:
+                  type: metacollector
+                replicas: 1
+                podTemplateSpec:
+                  metadata:
+                    labels:
+                      custom-label: test-value
+                    annotations:
+                      custom-annotation: test-annotation
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+    - name: Assert-pod-template-has-custom-label-and-annotation
+      try:
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                template:
+                  metadata:
+                    labels:
+                      custom-label: test-value
+                    annotations:
+                      custom-annotation: test-annotation
+
+    - name: Assert-component-status
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 1
+            # Must track internal/pkg/image/const.go's MetacollectorTag.
+            - name: expected_version
+              value: "0.1.2"
+
+    - name: Patch-deployment-strategy-to-recreate
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                strategy:
+                  type: Recreate
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                strategy:
+                  type: Recreate
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/instance-operator/metacollector-scale/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/instance-operator/metacollector-scale/chainsaw-test.yaml
@@ -1,0 +1,106 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: metacollector-scale
+spec:
+  description: |
+    Component replica scaling: created with replicas=2, then scaled down to 1. Distinct from
+    metacollector-lifecycle, which only ever runs a single replica and never touches
+    spec.replicas.
+
+  bindings:
+    - name: component_name
+      value: metacollector-scale-test
+    - name: test_name
+      value: metacollector-scale
+
+  steps:
+    - name: Create-component-with-two-replicas
+      try:
+        - apply:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                component:
+                  type: metacollector
+                replicas: 2
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              status:
+                availableReplicas: 2
+                readyReplicas: 2
+
+    - name: Assert-component-status-with-two-replicas
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 2
+            # Must track internal/pkg/image/const.go's MetacollectorTag.
+            - name: expected_version
+              value: "0.1.2"
+
+    - name: Scale-down-to-one-replica
+      try:
+        - patch:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 1
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ($component_name)
+                namespace: ($namespace)
+              spec:
+                replicas: 1
+              status:
+                availableReplicas: 1
+                readyReplicas: 1
+
+    - name: Assert-component-status-after-scale-down
+      use:
+        template: ../../common/_step_templates/assert-component-status.yaml
+        with:
+          bindings:
+            - name: component_name
+              value: ($component_name)
+            - name: namespace
+              value: ($namespace)
+            - name: expected_replicas
+              value: 1
+            - name: expected_version
+              value: "0.1.2"
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/validation/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/validation/chainsaw-test.yaml
@@ -1,0 +1,203 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validation
+spec:
+  description: |
+    CRD-level admission validation (CEL rules and kubebuilder markers on the API types
+    themselves), distinct from every other test in this suite, which only ever exercises
+    valid specs and controller-level (not admission-level) behavior. Cross-cutting across
+    both artifact.falcosecurity.dev (Config, Rulesfile, Plugin) and
+    instance.falcosecurity.dev (Falco, Component), so it doesn't belong under either the
+    artifact-operator or instance-operator category on its own.
+    Each case creates a deliberately invalid resource and asserts the API server itself
+    rejects it (chainsaw's $error), never reaching a controller.
+
+  bindings:
+    - name: test_name
+      value: validation
+
+  steps:
+    - name: Reject-invalid-falco-type
+      try:
+        - create:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: invalid-type
+                namespace: ($namespace)
+              spec:
+                type: StatefulSet
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-falco-replicas-zero
+      try:
+        - create:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Falco
+              metadata:
+                name: invalid-replicas
+                namespace: ($namespace)
+              spec:
+                type: Deployment
+                replicas: 0
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-config-priority-over-99
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Config
+              metadata:
+                name: invalid-priority-high
+                namespace: ($namespace)
+              spec:
+                priority: 100
+                config: "test: true"
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-config-priority-below-0
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Config
+              metadata:
+                name: invalid-priority-low
+                namespace: ($namespace)
+              spec:
+                priority: -1
+                config: "test: true"
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-rulesfile-ociartifact-without-image-repository
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Rulesfile
+              metadata:
+                name: invalid-oci-no-repo
+                namespace: ($namespace)
+              spec:
+                priority: 50
+                ociArtifact:
+                  image: {}
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-plugin-ociartifact-without-image
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Plugin
+              metadata:
+                name: invalid-oci-no-image
+                namespace: ($namespace)
+              spec:
+                ociArtifact: {}
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-rulesfile-plainhttp-and-tls-both-set
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Rulesfile
+              metadata:
+                name: invalid-oci-plainhttp-tls
+                namespace: ($namespace)
+              spec:
+                priority: 50
+                ociArtifact:
+                  image:
+                    repository: falcosecurity/rules/falco-rules
+                  registry:
+                    plainHTTP: true
+                    tls:
+                      insecureSkipVerify: true
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-plugin-plainhttp-and-tls-both-set
+      try:
+        - create:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Plugin
+              metadata:
+                name: invalid-plugin-plainhttp-tls
+                namespace: ($namespace)
+              spec:
+                ociArtifact:
+                  image:
+                    repository: falcosecurity/plugins/plugin/json
+                  registry:
+                    plainHTTP: true
+                    tls:
+                      insecureSkipVerify: true
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-invalid-component-type
+      try:
+        - create:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: invalid-type
+                namespace: ($namespace)
+              spec:
+                component:
+                  type: invalid
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Reject-component-replicas-zero
+      try:
+        - create:
+            resource:
+              apiVersion: instance.falcosecurity.dev/v1alpha1
+              kind: Component
+              metadata:
+                name: invalid-replicas
+                namespace: ($namespace)
+              spec:
+                component:
+                  type: metacollector
+                replicas: 0
+            expect:
+              - check:
+                  ($error != null): true
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../common/scripts/debug_snapshot.sh


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

  Add Falco/Component lifecycle, scale, version, and podTemplateSpec
  coverage under instance-operator/, plus CRD admission-validation
  tests. Verified against a real cluster.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
