### PR TITLE
fix(artifact): pin OCI downloads to resolved digests

### DIFF
--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -387,7 +387,7 @@ func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Co
 		// unadvanced, rather than persisting an incomplete ArtifactMeta that could let a per-node
 		// operator install the rulesfile without its real plugin dependencies enforced.
 		logger.Info("Fetching rulesfile ArtifactMeta from OCI content layer", "ref", ref)
-		content, contentErr := am.FetchContent(ctx, rulesfile.Spec.OCIArtifact)
+		content, contentErr := am.FetchContent(ctx, rulesfile.Spec.OCIArtifact, digest)
 		if contentErr != nil {
 			logger.Error(contentErr, "Unable to fetch rulesfile OCI content; ArtifactMeta will remain stale", "ref", ref)
 			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactProgramFailed,

--- a/controllers/instance/artifact/rulesfile/controller_test.go
+++ b/controllers/instance/artifact/rulesfile/controller_test.go
@@ -793,17 +793,19 @@ func TestFetchAndCacheArtifactMeta_OCICacheMiss(t *testing.T) {
 		ConfigResult: &puller.ArtifactConfig{
 			Requirements: []puller.ArtifactRequirement{{Name: "engine_version", Version: "0.36.0"}},
 		},
-		ConfigDigest:  "sha256:new",
+		ConfigDigest:  testRulesfileDigest,
 		ContentResult: nil, // no content
 	}
 	rf := newTestRulesfile(withRulesfileOCI())
+	rf.Spec.OCIArtifact.Image.Repository = "test/rulesfile"
 	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
 
 	err := r.fetchAndCacheArtifactMeta(context.Background(), rf)
 	require.NoError(t, err)
 	assert.Len(t, mockPuller.FetchConfigCalls, 1)
+	assert.Equal(t, []string{"ghcr.io/test/rulesfile@" + testRulesfileDigest}, mockPuller.FetchContentCalls)
 	require.NotNil(t, rf.Status.ArtifactMeta)
-	assert.Equal(t, "sha256:new", rf.Status.ArtifactMeta.Digest)
+	assert.Equal(t, testRulesfileDigest, rf.Status.ArtifactMeta.Digest)
 	require.Len(t, rf.Status.ArtifactMeta.Requirements, 1)
 }
 
@@ -827,7 +829,7 @@ func TestFetchAndCacheArtifactMeta_OCIContentFetchError(t *testing.T) {
 	// required_plugin_versions, so a content fetch error is fatal and metadata is not persisted.
 	mockPuller := &pullerfake.MockOCIPuller{
 		ConfigResult:    &puller.ArtifactConfig{},
-		ConfigDigest:    "sha256:ok",
+		ConfigDigest:    testRulesfileDigest,
 		FetchContentErr: fmt.Errorf("content layer missing"),
 	}
 	rf := newTestRulesfile(withRulesfileOCI())
@@ -846,7 +848,7 @@ func TestFetchAndCacheArtifactMeta_OCIWithContentRequirements(t *testing.T) {
 	yamlContent := []byte(`- required_engine_version: 22`)
 	mockPuller := &pullerfake.MockOCIPuller{
 		ConfigResult:  &puller.ArtifactConfig{},
-		ConfigDigest:  "sha256:content",
+		ConfigDigest:  testRulesfileDigest,
 		ContentResult: yamlContent,
 	}
 	rf := newTestRulesfile(withRulesfileOCI())
@@ -1415,7 +1417,7 @@ func TestFetchAndCacheArtifactMeta_OCIWithDependencies(t *testing.T) {
 				},
 			},
 		},
-		ConfigDigest:  "sha256:deps",
+		ConfigDigest:  testRulesfileDigest,
 		ContentResult: nil,
 	}
 	rf := newTestRulesfile(withRulesfileOCI())

--- a/internal/pkg/artifact/manager.go
+++ b/internal/pkg/artifact/manager.go
@@ -96,8 +96,9 @@ func (am *Manager) FetchConfig(ctx context.Context, ociArtifact *commonv1alpha1.
 	return am.ociPuller.FetchConfig(ctx, ref, creds, ResolveRegistryOptions(ociArtifact))
 }
 
-// FetchContent downloads the artifact content layer for ociArtifact and returns the extracted file bytes.
-func (am *Manager) FetchContent(ctx context.Context, ociArtifact *commonv1alpha1.OCIArtifact) ([]byte, error) {
+// FetchContent downloads the artifact content layer at the root digest returned by
+// FetchConfig and returns the extracted file bytes.
+func (am *Manager) FetchContent(ctx context.Context, ociArtifact *commonv1alpha1.OCIArtifact, digest string) ([]byte, error) {
 	secretRef := authSecretRef(ociArtifact)
 	authSecret, err := am.fetchOCIAuthSecret(ctx, secretRef)
 	if err != nil {
@@ -107,7 +108,10 @@ func (am *Manager) FetchContent(ctx context.Context, ociArtifact *commonv1alpha1
 	if err != nil {
 		return nil, fmt.Errorf("derive credentials: %w", err)
 	}
-	ref := ResolveReference(ociArtifact)
+	ref, err := pinReferenceToDigest(ResolveReference(ociArtifact), digest)
+	if err != nil {
+		return nil, fmt.Errorf("pin OCI reference: %w", err)
+	}
 	return am.ociPuller.FetchContent(ctx, ref, creds, ResolveRegistryOptions(ociArtifact))
 }
 
@@ -146,7 +150,6 @@ func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArt
 			return "", fmt.Errorf("resolve digest for %q: %w", ref, err)
 		}
 	}
-
 	blobPath := artifactcache.BlobPath(cache.Dir(), string(artifactType), ref, digest, goos, goarch)
 
 	if cache.BlobExists(blobPath) {
@@ -154,20 +157,29 @@ func (am *Manager) EnsureBlob(ctx context.Context, ociArt *commonv1alpha1.OCIArt
 		return blobPath, nil
 	}
 
+	pinnedRef, err := pinReferenceToDigest(ref, digest)
+	if err != nil {
+		return "", fmt.Errorf("pin OCI reference %q to %q: %w", ref, digest, err)
+	}
+
 	pullGOOS, pullGOARCH := goos, goarch
 	if pullGOOS == "" || pullGOARCH == "" {
 		pullGOOS, pullGOARCH = runtime.GOOS, runtime.GOARCH
 	}
 
-	logger.Info("Pulling OCI blob", "ref", ref, "os", pullGOOS, "arch", pullGOARCH)
+	logger.Info("Pulling OCI blob", "ref", pinnedRef, "os", pullGOOS, "arch", pullGOARCH)
 
 	var buf bytes.Buffer
-	res, err := am.ociPuller.Pull(ctx, ref, pullGOOS, pullGOARCH, creds, opts, &buf)
+	res, err := am.ociPuller.Pull(ctx, pinnedRef, pullGOOS, pullGOARCH, creds, opts, &buf)
 	if err != nil {
-		return "", fmt.Errorf("pull %q (%s/%s): %w", ref, pullGOOS, pullGOARCH, err)
+		return "", fmt.Errorf("pull %q (%s/%s): %w", pinnedRef, pullGOOS, pullGOARCH, err)
 	}
 	if res == nil {
 		return "", fmt.Errorf("puller returned nil result for %q", ref)
+	}
+	// Compare the root digest, not the selected platform manifest's digest.
+	if res.RootDigest != digest {
+		return "", fmt.Errorf("pulled OCI root digest %q does not match expected digest %q", res.RootDigest, digest)
 	}
 	if !isExpectedOCIArtifactType(artifactType, res.Type) {
 		return "", fmt.Errorf("pulled OCI artifact type %q does not match expected %q", res.Type, artifactType)

--- a/internal/pkg/artifact/manager_ensure_blob_test.go
+++ b/internal/pkg/artifact/manager_ensure_blob_test.go
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
+	pullerfake "github.com/falcosecurity/falco-operator/internal/pkg/oci/puller/fake"
+)
+
+const (
+	testDigest         = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testResolvedDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testOtherDigest    = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+func TestManager_EnsureBlob_PinsDigest(t *testing.T) {
+	layer, err := pullerfake.MakeTarGz("plugin.so", []byte("binary content"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		knownDigest    string
+		resolvedDigest string
+		rootDigest     string
+		manifestDigest string
+		pullErr        error
+		wantErr        string
+		wantPull       bool
+	}{
+		{
+			name:        "uses the known digest without resolving the tag again",
+			knownDigest: testDigest,
+			rootDigest:  testDigest,
+			wantPull:    true,
+		},
+		{
+			name:           "resolves once then pulls by digest",
+			resolvedDigest: testResolvedDigest,
+			rootDigest:     testResolvedDigest,
+			wantPull:       true,
+		},
+		{
+			name:           "accepts a platform manifest within the pinned index",
+			knownDigest:    testDigest,
+			rootDigest:     testDigest,
+			manifestDigest: testOtherDigest,
+			wantPull:       true,
+		},
+		{
+			name:        "rejects a different root digest before storing content",
+			knownDigest: testDigest,
+			rootDigest:  testOtherDigest,
+			wantErr:     "does not match expected digest",
+			wantPull:    true,
+		},
+		{
+			name:        "reports the pinned reference when the pull fails",
+			knownDigest: testDigest,
+			pullErr:     errors.New("registry unavailable"),
+			wantErr:     "pull \"ghcr.io/test/plugin@" + testDigest + "\" (linux/arm64): registry unavailable",
+			wantPull:    true,
+		},
+		{
+			name:        "rejects a missing root digest before storing content",
+			knownDigest: testDigest,
+			wantErr:     "does not match expected digest",
+			wantPull:    true,
+		},
+		{
+			name:        "rejects an invalid known digest before pulling",
+			knownDigest: "not-a-digest",
+			wantErr:     "pin OCI reference",
+		},
+		{
+			name:           "rejects an invalid resolved digest before pulling",
+			resolvedDigest: "sha256:short",
+			wantErr:        "pin OCI reference",
+		},
+		{
+			name:    "rejects an empty resolved digest before pulling",
+			wantErr: "pin OCI reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := artifactcache.NewCache(t.TempDir())
+			mockPuller := &pullerfake.MockOCIPuller{
+				PullErr:             tt.pullErr,
+				ResolveDigestResult: tt.resolvedDigest,
+				Result: &puller.RegistryResult{
+					RootDigest: tt.rootDigest,
+					Digest:     tt.manifestDigest,
+					Type:       puller.Plugin,
+				},
+				LayerContent: layer,
+			}
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace", WithOCIPuller(mockPuller),
+			)
+			ociArt := &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "test/plugin", Tag: "latest"},
+			}
+			original := ociArt.DeepCopy()
+			digest := tt.knownDigest
+			if digest == "" {
+				digest = tt.resolvedDigest
+			}
+			wantPath := artifactcache.BlobPath(cache.Dir(), string(TypePlugin), ResolveReference(ociArt), digest, "linux", "arm64")
+
+			path, err := manager.EnsureBlob(context.Background(), ociArt, TypePlugin, "linux", "arm64", cache, tt.knownDigest)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, path)
+				assert.NoFileExists(t, wantPath)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, wantPath, path)
+				content, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Equal(t, "binary content", string(content))
+			}
+			if tt.wantPull {
+				require.Len(t, mockPuller.PullCalls, 1)
+				assert.Equal(t, "ghcr.io/test/plugin@"+digest, mockPuller.PullCalls[0].Ref)
+				assert.Equal(t, "linux", mockPuller.PullCalls[0].OS)
+				assert.Equal(t, "arm64", mockPuller.PullCalls[0].Arch)
+			} else {
+				assert.Empty(t, mockPuller.PullCalls)
+			}
+			if tt.knownDigest == "" {
+				assert.Equal(t, []string{ResolveReference(ociArt)}, mockPuller.ResolveDigestCalls)
+			} else {
+				assert.Empty(t, mockPuller.ResolveDigestCalls)
+			}
+			assert.Equal(t, original, ociArt, "pinning must not modify the artifact spec")
+		})
+	}
+}
+
+func TestManager_EnsureBlob_PinnedPlatformsAndCacheHits(t *testing.T) {
+	cache := artifactcache.NewCache(t.TempDir())
+	mockPuller := &pullerfake.MockOCIPuller{}
+	manager := NewManagerWithOptions(
+		fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+		"test-namespace", WithOCIPuller(mockPuller),
+	)
+	ociArt := &commonv1alpha1.OCIArtifact{
+		Image: commonv1alpha1.ImageSpec{Repository: "test/artifact", Tag: "latest"},
+	}
+	tests := []struct {
+		name         string
+		artifactType Type
+		ociType      puller.ArtifactType
+		os, arch     string
+		pullOS       string
+		pullArch     string
+	}{
+		{"amd64 plugin", TypePlugin, puller.Plugin, "linux", "amd64", "linux", "amd64"},
+		{"arm64 plugin", TypePlugin, puller.Plugin, "linux", "arm64", "linux", "arm64"},
+		{"platform-agnostic rulesfile", TypeRulesfile, puller.Rulesfile, "", "", runtime.GOOS, runtime.GOARCH},
+	}
+	paths := make(map[string]bool)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			mockPuller.LayerContent, err = pullerfake.MakeTarGz("artifact", []byte(tt.name))
+			require.NoError(t, err)
+			mockPuller.Result = &puller.RegistryResult{RootDigest: testDigest, Digest: testOtherDigest, Type: tt.ociType}
+			mockPuller.PullCalls = nil
+
+			path, err := manager.EnsureBlob(context.Background(), ociArt, tt.artifactType, tt.os, tt.arch, cache, testDigest)
+			require.NoError(t, err)
+			assert.Equal(t, artifactcache.BlobPath(cache.Dir(), string(tt.artifactType), ResolveReference(ociArt), testDigest, tt.os, tt.arch), path)
+			assert.False(t, paths[path], "each platform needs a separate cached file")
+			paths[path] = true
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.name, string(content))
+			platformKey := ""
+			if tt.os != "" && tt.arch != "" {
+				platformKey = tt.os + "-" + tt.arch
+			}
+			require.NoError(t, cache.Set(string(tt.artifactType), "test-namespace", "test-artifact", platformKey, path))
+
+			cached, err := manager.EnsureBlob(context.Background(), ociArt, tt.artifactType, tt.os, tt.arch, cache, testDigest)
+			require.NoError(t, err)
+			assert.Equal(t, path, cached)
+			require.Len(t, mockPuller.PullCalls, 1, "a cache hit must not download the artifact again")
+			assert.Equal(t, "ghcr.io/test/artifact@"+testDigest, mockPuller.PullCalls[0].Ref)
+			assert.Equal(t, tt.pullOS, mockPuller.PullCalls[0].OS)
+			assert.Equal(t, tt.pullArch, mockPuller.PullCalls[0].Arch)
+			assert.Empty(t, mockPuller.ResolveDigestCalls)
+		})
+	}
+}

--- a/internal/pkg/artifact/manager_fetch_test.go
+++ b/internal/pkg/artifact/manager_fetch_test.go
@@ -115,7 +115,8 @@ func TestManager_FetchContent(t *testing.T) {
 
 			content, err := manager.FetchContent(context.Background(), &commonv1alpha1.OCIArtifact{
 				Image: commonv1alpha1.ImageSpec{Repository: "example.com/myrules", Tag: "latest"},
-			})
+			}, testDigest)
+			assert.Equal(t, []string{"ghcr.io/example.com/myrules@" + testDigest}, mockPuller.FetchContentCalls)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -124,6 +125,24 @@ func TestManager_FetchContent(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantContent, content)
 			require.Len(t, mockPuller.FetchContentCalls, 1)
+		})
+	}
+}
+
+func TestManager_FetchContent_RejectsInvalidDigest(t *testing.T) {
+	for _, digest := range []string{"", "latest", "sha256:short"} {
+		t.Run(digest, func(t *testing.T) {
+			mockPuller := &pullerfake.MockOCIPuller{}
+			manager := NewManagerWithOptions(
+				fake.NewClientBuilder().WithScheme(createTestScheme(t)).Build(),
+				"test-namespace", WithOCIPuller(mockPuller),
+			)
+			content, err := manager.FetchContent(context.Background(), &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "test/rules", Tag: "latest"},
+			}, digest)
+			require.ErrorContains(t, err, "pin OCI reference")
+			assert.Nil(t, content)
+			assert.Empty(t, mockPuller.FetchContentCalls)
 		})
 	}
 }

--- a/internal/pkg/artifact/oci_test.go
+++ b/internal/pkg/artifact/oci_test.go
@@ -180,7 +180,7 @@ func TestFetchContent(t *testing.T) {
 				WithOCIPuller(mockPuller),
 			)
 
-			got, err := manager.FetchContent(context.Background(), tt.ociArtifact)
+			got, err := manager.FetchContent(context.Background(), tt.ociArtifact, testDigest)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/internal/pkg/artifact/registry.go
+++ b/internal/pkg/artifact/registry.go
@@ -19,6 +19,8 @@ package artifact
 import (
 	"strings"
 
+	"oras.land/oras-go/v2/registry"
+
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
 )
@@ -45,6 +47,20 @@ func ResolveReference(artifact *commonv1alpha1.OCIArtifact) string {
 	}
 
 	return ref
+}
+
+// pinReferenceToDigest replaces a tag with the resolved root digest so later
+// downloads cannot follow a tag that has moved to a different artifact revision.
+func pinReferenceToDigest(ref, digest string) (string, error) {
+	pinned, err := registry.ParseReference(ref)
+	if err != nil {
+		return "", err
+	}
+	pinned.Reference = digest
+	if err := pinned.ValidateReferenceAsDigest(); err != nil {
+		return "", err
+	}
+	return pinned.String(), nil
 }
 
 // ResolveRegistryHost returns the registry hostname used for an OCIArtifact.

--- a/internal/pkg/artifact/registry_test.go
+++ b/internal/pkg/artifact/registry_test.go
@@ -118,6 +118,46 @@ func TestResolveReference(t *testing.T) {
 	}
 }
 
+func TestPinReferenceToDigest(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "replaces a tag",
+			ref:  "ghcr.io/test/plugin:latest",
+			want: "ghcr.io/test/plugin@" + testDigest,
+		},
+		{
+			name: "preserves a custom registry port",
+			ref:  "localhost:5000/test/plugin:v1",
+			want: "localhost:5000/test/plugin@" + testDigest,
+		},
+		{
+			name: "accepts an already pinned reference",
+			ref:  "ghcr.io/test/plugin@" + testDigest,
+			want: "ghcr.io/test/plugin@" + testDigest,
+		},
+		{
+			name: "rejects an invalid reference",
+			ref:  "https://ghcr.io/test/plugin:latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pinReferenceToDigest(tt.ref, testDigest)
+			if tt.want == "" {
+				require.Error(t, err)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveRegistryOptions(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area instance-operator

> /area artifact-operator

> /area chart

/area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

Pin rulesfile content reads and artifact cache downloads to the resolved OCI digest instead of fetching the mutable tag again. This prevents a tag update from mixing metadata from one artifact version with files from another.

Reject downloaded artifacts whose root digest differs from the expected digest before writing them to cache. Plugin architecture selection and per-platform caching remain unchanged.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

**Special notes for your reviewer**:
