### PR TITLE
fix(e2e): verify mock version transfers

### DIFF
--- a/test/e2e/chainsaw/common/scripts/write_file_on_node.sh
+++ b/test/e2e/chainsaw/common/scripts/write_file_on_node.sh
@@ -27,6 +27,14 @@ LOCAL_FILE="${LOCAL_FILE}"
 MAX_RETRIES="${MAX_RETRIES:-200}"
 RETRY_DELAY="${RETRY_DELAY:-1}"
 
+# An exec can exit successfully even if its stdin arrived empty or incomplete.
+# Compare the received bytes before replacing the file served by the mock.
+if command -v sha256sum >/dev/null 2>&1; then
+  EXPECTED_HASH=$(sha256sum <"$LOCAL_FILE" | awk '{print $1}')
+else
+  EXPECTED_HASH=$(shasum -a 256 <"$LOCAL_FILE" | awk '{print $1}')
+fi
+
 LAST_ERROR="no attempts made"
 PODS=""
 
@@ -49,7 +57,20 @@ for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
   WRITTEN_PODS=""
   for POD in $PODS; do
     if ! OUTPUT=$(kubectl exec -i -n "$NAMESPACE" "$POD" -c "$CONTAINER" -- \
-        sh -c "cat > \"$REMOTE_PATH\"" <"$LOCAL_FILE" 2>&1); then
+        sh -ec '
+          target=$1
+          expected=$2
+          tmp=$(mktemp "${target}.XXXXXX")
+          trap '\''rm -f "$tmp"'\'' EXIT
+          cat > "$tmp"
+          actual=$(sha256sum < "$tmp")
+          if [ "${actual%% *}" != "$expected" ]; then
+            echo "received content does not match local file" >&2
+            exit 1
+          fi
+          chmod 644 "$tmp"
+          mv -f "$tmp" "$target"
+        ' sh "$REMOTE_PATH" "$EXPECTED_HASH" <"$LOCAL_FILE" 2>&1); then
       LAST_ERROR="kubectl exec failed on pod $POD: $OUTPUT"
       ATTEMPT_FAILED=1
       break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

/kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

/area automation

**What this PR does / why we need it**:

Prevent mock version updates from reporting success when a pod receives an empty or incomplete file. Keep the previous content until the transfer is verified, and retry failed writes on all Falco pods.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

**Special notes for your reviewer**:
