### PR TITLE
feat(instance): propagate --enforce-requirements to artifact-operatorsidecar

### DIFF
--- a/chart/falco-operator/README.md
+++ b/chart/falco-operator/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the falco-operator char
 | affinity | object | `{}` | Affinity rules |
 | dnsConfig | object | `{}` | Pod DNS config. Requires dnsPolicy to be set to None to take full effect. |
 | dnsPolicy | string | `""` | Pod DNS policy. One of ClusterFirst, ClusterFirstWithHostNet, Default or None. |
+| enforceRequirements | bool | `true` | When false, the artifact-operator sidecar installs artifacts regardless of Falco version or plugin dependency constraints. Useful when compatibility metadata is unavailable or incorrect. |
 | excludedLabels | list | `[]` | Label keys that must NOT be propagated onto operator-generated resources. Supports the '*' wildcard (e.g. `kustomize.toolkit.fluxcd.io/*`). |
 | extraArgs | list | `[]` | Additional CLI arguments passed to the operator binary. mTLS's own flags are added natively when mtls.enabled is true; no need to list them here. |
 | extraEnv | list | `[]` | Extra environment variables |

--- a/chart/falco-operator/templates/deployment.yaml
+++ b/chart/falco-operator/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             {{- range .Values.excludedLabels }}
             - --excluded-labels={{ . }}
             {{- end }}
+            {{- if not .Values.enforceRequirements }}
+            - --enforce-requirements=false
+            {{- end }}
             {{- if .Values.mtls.enabled }}
             - --artifact-server-cert-path=/etc/artifact-server-certs
             - --artifact-server-client-ca-file=/etc/artifact-server-trust/ca-bundle.crt

--- a/chart/falco-operator/values.yaml
+++ b/chart/falco-operator/values.yaml
@@ -167,6 +167,10 @@ excludedLabels: []
   # - kustomize.toolkit.fluxcd.io/name
   # - kustomize.toolkit.fluxcd.io/namespace
 
+# -- When false, the artifact-operator sidecar installs artifacts regardless of Falco version
+# or plugin dependency constraints. Useful when compatibility metadata is unavailable or incorrect.
+enforceRequirements: true
+
 # -- Additional CLI arguments passed to the operator binary. mTLS's own flags are added
 # natively when mtls.enabled is true; no need to list them here.
 extraArgs: []

--- a/cmd/instance/main.go
+++ b/cmd/instance/main.go
@@ -127,6 +127,7 @@ func main() {
 	var artifactCABundleConfigMapName string
 	var artifactClientCertDuration, artifactClientCertRenewBefore time.Duration
 	var artifactOperatorImage string
+	var artifactOperatorEnforceRequirements bool
 	var artifactServerMaxConcurrentRequests int
 	flag.StringVar(&artifactServeAddr, "artifact-serve-addr", ":8082",
 		"Address the artifact HTTP server binds to. Per-node artifact-operators download OCI artifacts from this server.")
@@ -170,6 +171,9 @@ func main() {
 			"baked in at build time (version.ArtifactOperatorImage, via -ldflags) to match the release pair; "+
 			"set this (or the ARTIFACT_OPERATOR_IMAGE env var) to repoint an already-built binary at a "+
 			"different image, e.g. a private registry mirror or a local dev build, without rebuilding.")
+	flag.BoolVar(&artifactOperatorEnforceRequirements, "enforce-requirements", true,
+		"Whether the artifact-operator sidecar enforces artifact compatibility requirements. "+
+			"Set to false to install artifacts regardless of Falco version or plugin dependency constraints.")
 	flag.IntVar(&artifactServerMaxConcurrentRequests, "artifact-server-max-concurrent-requests", 0,
 		"Maximum number of concurrent artifact blob transfers the server handles simultaneously. "+
 			"Excess requests receive 503 with a jittered Retry-After so retries spread out. "+
@@ -189,6 +193,7 @@ func main() {
 	// Reassigning version.ArtifactOperatorImage above has no effect on FalcoDefaults, which was
 	// already initialized from it at package-init time; this call applies the override directly.
 	resources.SetArtifactOperatorImage(version.ArtifactOperatorImage)
+	resources.SetArtifactOperatorEnforceRequirements(artifactOperatorEnforceRequirements)
 
 	ctrl.SetLogger(logging.FilterEventRejectionOnTerminatingNamespace(zap.New(zap.UseFlagOptions(&opts))))
 

--- a/internal/pkg/resources/falco.go
+++ b/internal/pkg/resources/falco.go
@@ -307,6 +307,20 @@ func SetArtifactOperatorImage(img string) {
 	FalcoDefaults.SidecarContainers[0].Image = img
 }
 
+// SetArtifactOperatorEnforceRequirements propagates the --enforce-requirements flag to every
+// artifact-operator sidecar by injecting ENFORCE_REQUIREMENTS into its environment.
+// Call this once during falco-operator startup.
+func SetArtifactOperatorEnforceRequirements(enforce bool) {
+	if enforce {
+		return
+	}
+	sidecar := &FalcoDefaults.SidecarContainers[0]
+	sidecar.Env = append(sidecar.Env, corev1.EnvVar{
+		Name:  "ENFORCE_REQUIREMENTS",
+		Value: "false",
+	})
+}
+
 // artifactClientCertsMountPath is the mount path for the client cert Secret in the
 // artifact-operator sidecar. cmd/artifact/main.go reads this same path via
 // ARTIFACT_CLIENT_CERT_PATH and ARTIFACT_SERVER_CA_FILE.

--- a/internal/pkg/resources/falco_test.go
+++ b/internal/pkg/resources/falco_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// saveSidecarEnv returns a cleanup func that restores the sidecar env to its state at call time.
+func saveSidecarEnv(t *testing.T) {
+	t.Helper()
+	original := make([]corev1.EnvVar, len(FalcoDefaults.SidecarContainers[0].Env))
+	copy(original, FalcoDefaults.SidecarContainers[0].Env)
+	t.Cleanup(func() {
+		FalcoDefaults.SidecarContainers[0].Env = original
+	})
+}
+
+func TestSetArtifactOperatorEnforceRequirements(t *testing.T) {
+	t.Run("true is a no-op", func(t *testing.T) {
+		saveSidecarEnv(t)
+		before := len(FalcoDefaults.SidecarContainers[0].Env)
+		SetArtifactOperatorEnforceRequirements(true)
+		assert.Len(t, FalcoDefaults.SidecarContainers[0].Env, before)
+	})
+
+	t.Run("false injects ENFORCE_REQUIREMENTS=false", func(t *testing.T) {
+		saveSidecarEnv(t)
+		SetArtifactOperatorEnforceRequirements(false)
+		env := FalcoDefaults.SidecarContainers[0].Env
+		var found *corev1.EnvVar
+		for i := range env {
+			if env[i].Name == "ENFORCE_REQUIREMENTS" {
+				found = &env[i]
+				break
+			}
+		}
+		if assert.NotNil(t, found, "ENFORCE_REQUIREMENTS env var should be present") {
+			assert.Equal(t, "false", found.Value)
+		}
+	})
+}


### PR DESCRIPTION
 



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

> /area artifact-operator

> /area chart

> /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

Add enforceRequirements chart value and --enforce-requirements flag to the instance operator so it injects ENFORCE_REQUIREMENTS into the sidecar env at startup, allowing artifact compatibility checks to be disabled at deploy time.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
