### PR TITLE
fix(artifact): keep OCI revisions consistent across nodes

### DIFF
--- a/controllers/artifact/config/controller_test.go
+++ b/controllers/artifact/config/controller_test.go
@@ -63,7 +63,7 @@ func newTestFetcher(cl client.Client) *testFetcher {
 	return &testFetcher{delegate: &artifact.Fetcher{K8sClient: cl}}
 }
 
-func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type) (artifact.FetchResult, error) {
+func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type, _ string) (artifact.FetchResult, error) {
 	if f.ociErr != nil {
 		return artifact.FetchResult{}, f.ociErr
 	}

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -433,8 +433,10 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 	}
 
 	parentSpecHash := ""
+	expectedDigest := ""
 	if plugin.Status.ArtifactMeta != nil {
 		parentSpecHash = plugin.Status.ArtifactMeta.SpecHash
+		expectedDigest = plugin.Status.ArtifactMeta.Digest
 	}
 	current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
 
@@ -455,7 +457,7 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 		}
 	}
 
-	result, err := r.fetcher.FetchOCI(ctx, plugin.Namespace, plugin.Name, artifact.TypePlugin)
+	result, err := r.fetcher.FetchOCI(ctx, plugin.Namespace, plugin.Name, artifact.TypePlugin, expectedDigest)
 	if err != nil {
 		logger.Error(err, "unable to fetch plugin artifact")
 		artifact.RecordWarning(r.recorder, plugin, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -22,9 +22,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +45,8 @@ import (
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	"github.com/falcosecurity/falco-operator/controllers/testutil"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	compatfake "github.com/falcosecurity/falco-operator/internal/pkg/compat/fake"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
@@ -74,7 +79,7 @@ func newTestFetcher(cl client.Client) *testFetcher {
 	return &testFetcher{delegate: &artifact.Fetcher{K8sClient: cl}}
 }
 
-func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type) (artifact.FetchResult, error) {
+func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type, _ string) (artifact.FetchResult, error) {
 	f.ociCallCount++
 	if f.ociErr != nil {
 		return artifact.FetchResult{}, f.ociErr
@@ -1428,4 +1433,84 @@ func TestHandleDeletion_BlockedByRequiringRulesfileDoesNotRemoveFinalizer(t *tes
 	done, err = r.handleDeletion(context.Background(), nodeObj)
 	require.NoError(t, err)
 	assert.True(t, done)
+}
+
+func TestEnsurePlugin_WaitsForExpectedOCIDigest(t *testing.T) {
+	for _, alreadyInstalled := range []bool{false, true} {
+		name := "first installation"
+		if alreadyInstalled {
+			name = "update preserves installed revision"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			cache := artifactcache.NewCache(t.TempDir())
+			require.NoError(t, cache.Load())
+			goos, goarch, platform := runtime.GOOS, runtime.GOARCH, runtime.GOOS+"-"+runtime.GOARCH
+			oldDigest := digest.FromString("old OCI manifest").String()
+			newDigest := digest.FromString("new OCI manifest").String()
+			oldPath := artifactcache.BlobPath(cache.Dir(), "plugin", "artifact:old", oldDigest, goos, goarch)
+			newPath := artifactcache.BlobPath(cache.Dir(), "plugin", "artifact:new", newDigest, goos, goarch)
+			require.NoError(t, cache.Store(oldPath, []byte("old artifact bytes"), 0o755))
+			require.NoError(t, cache.Set("plugin", "default", "artifact", platform, oldPath))
+
+			srv := httptest.NewServer(artifactserver.New(cache).Handler())
+			defer srv.Close()
+			fs := fsfake.NewMockFileSystem()
+			reconciler := &PluginReconciler{
+				recorder: events.NewFakeRecorder(20),
+				fetcher:  &artifact.Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()},
+				store:    nodeartifacts.NewManager(&artifact.LocalStore{FS: fs, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil)),
+			}
+			parent := &artifactv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "artifact", Namespace: "default", Generation: 1},
+				Spec: artifactv1alpha1.PluginSpec{OCIArtifact: &commonv1alpha1.OCIArtifact{
+					Image: commonv1alpha1.ImageSpec{Repository: "artifact", Tag: "old"},
+				}},
+				Status: artifactv1alpha1.PluginStatus{
+					ObservedGeneration: 1,
+					ArtifactMeta:       &commonv1alpha1.ArtifactMeta{SpecHash: "spec-old", Digest: oldDigest},
+				},
+			}
+			node := &artifactv1alpha1.ArtifactNode{}
+			if alreadyInstalled {
+				require.NoError(t, reconciler.ensurePlugin(ctx, parent, node))
+			}
+			previous := node.DeepCopy().Status.InstalledArtifacts
+
+			// The parent metadata is published before the aggregator replaces the cache entry.
+			parent.Generation = 2
+			parent.Spec.OCIArtifact.Image.Tag = "new"
+			parent.Status.ObservedGeneration = 2
+			parent.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{SpecHash: "spec-new", Digest: newDigest}
+
+			err := reconciler.ensurePlugin(ctx, parent, node)
+			var retryErr *artifact.RetryableError
+			require.ErrorAs(t, err, &retryErr, "an old cached revision must not be accepted as the new spec")
+			require.Equal(t, previous, node.Status.InstalledArtifacts)
+			if alreadyInstalled {
+				require.Equal(t, []byte("old artifact bytes"), fs.Files[previous[0].Path])
+			} else {
+				require.Empty(t, fs.Files)
+			}
+			condition := apimeta.FindStatusCondition(node.Status.Conditions, commonv1alpha1.ConditionOCIArtifactProgrammed.String())
+			require.NotNil(t, condition)
+			require.Equal(t, metav1.ConditionFalse, condition.Status)
+
+			// Once the expected digest is available, the retry installs it and records its spec.
+			require.NoError(t, cache.Store(newPath, []byte("new artifact bytes"), 0o755))
+			require.NoError(t, cache.Set("plugin", "default", "artifact", platform, newPath))
+			require.NoError(t, reconciler.ensurePlugin(ctx, parent, node))
+			require.Len(t, node.Status.InstalledArtifacts, 1)
+			installed := node.Status.InstalledArtifacts[0]
+			require.Equal(t, "spec-new", installed.SpecHash)
+			require.Equal(t, []byte("new artifact bytes"), fs.Files[installed.Path])
+			condition = apimeta.FindStatusCondition(node.Status.Conditions, commonv1alpha1.ConditionOCIArtifactProgrammed.String())
+			require.Equal(t, metav1.ConditionTrue, condition.Status)
+			require.Equal(t, int64(2), condition.ObservedGeneration)
+
+			// A verified, installed revision remains usable without another download.
+			srv.Close()
+			require.NoError(t, reconciler.ensurePlugin(ctx, parent, node))
+		})
+	}
 }

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -486,8 +486,10 @@ func (r *RulesfileReconciler) ensureOCIRulesfile(
 	p := rulesfile.Spec.Priority
 
 	parentSpecHash := ""
+	expectedDigest := ""
 	if rulesfile.Status.ArtifactMeta != nil {
 		parentSpecHash = rulesfile.Status.ArtifactMeta.SpecHash
+		expectedDigest = rulesfile.Status.ArtifactMeta.Digest
 	}
 	current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
 
@@ -507,7 +509,7 @@ func (r *RulesfileReconciler) ensureOCIRulesfile(
 	}
 
 	if needFetch {
-		result, err := r.fetcher.FetchOCI(ctx, rulesfile.Namespace, rulesfile.Name, artifact.TypeRulesfile)
+		result, err := r.fetcher.FetchOCI(ctx, rulesfile.Namespace, rulesfile.Name, artifact.TypeRulesfile, expectedDigest)
 		if err != nil {
 			logger.Error(err, "unable to fetch Rulesfile OCI artifact")
 			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -22,10 +22,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +44,8 @@ import (
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	"github.com/falcosecurity/falco-operator/controllers/testutil"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
 	"github.com/falcosecurity/falco-operator/internal/pkg/common"
 	compatfake "github.com/falcosecurity/falco-operator/internal/pkg/compat/fake"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
@@ -67,7 +71,7 @@ func newTestFetcher(cl client.Client) *testFetcher {
 	return &testFetcher{delegate: &artifact.Fetcher{K8sClient: cl}}
 }
 
-func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type) (artifact.FetchResult, error) {
+func (f *testFetcher) FetchOCI(_ context.Context, _, _ string, _ artifact.Type, _ string) (artifact.FetchResult, error) {
 	f.ociCallCount++
 	if f.ociErr != nil {
 		return artifact.FetchResult{}, f.ociErr
@@ -1913,4 +1917,84 @@ func TestReconcile_RegistersDependenciesWithNodeArtifactManager(t *testing.T) {
 	blocked, ok := errors.AsType[*nodeartifacts.BlockedError](err)
 	require.True(t, ok)
 	assert.Equal(t, nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: testRulesfileName}, blocked.BlockedBy[0])
+}
+
+func TestEnsureRulesfile_WaitsForExpectedOCIDigest(t *testing.T) {
+	for _, alreadyInstalled := range []bool{false, true} {
+		name := "first installation"
+		if alreadyInstalled {
+			name = "update preserves installed revision"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			cache := artifactcache.NewCache(t.TempDir())
+			require.NoError(t, cache.Load())
+			goos, goarch, platform := "", "", ""
+			oldDigest := digest.FromString("old OCI manifest").String()
+			newDigest := digest.FromString("new OCI manifest").String()
+			oldPath := artifactcache.BlobPath(cache.Dir(), "rulesfile", "artifact:old", oldDigest, goos, goarch)
+			newPath := artifactcache.BlobPath(cache.Dir(), "rulesfile", "artifact:new", newDigest, goos, goarch)
+			require.NoError(t, cache.Store(oldPath, []byte("old artifact bytes"), 0o755))
+			require.NoError(t, cache.Set("rulesfile", "default", "artifact", platform, oldPath))
+
+			srv := httptest.NewServer(artifactserver.New(cache).Handler())
+			defer srv.Close()
+			fs := fsfake.NewMockFileSystem()
+			reconciler := &RulesfileReconciler{
+				recorder: events.NewFakeRecorder(20),
+				fetcher:  &artifact.Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()},
+				store:    nodeartifacts.NewManager(&artifact.LocalStore{FS: fs, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil)),
+			}
+			parent := &artifactv1alpha1.Rulesfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "artifact", Namespace: "default", Generation: 1},
+				Spec: artifactv1alpha1.RulesfileSpec{OCIArtifact: &commonv1alpha1.OCIArtifact{
+					Image: commonv1alpha1.ImageSpec{Repository: "artifact", Tag: "old"},
+				}},
+				Status: artifactv1alpha1.RulesfileStatus{
+					ObservedGeneration: 1,
+					ArtifactMeta:       &commonv1alpha1.ArtifactMeta{SpecHash: "spec-old", Digest: oldDigest},
+				},
+			}
+			node := &artifactv1alpha1.ArtifactNode{}
+			if alreadyInstalled {
+				require.NoError(t, reconciler.ensureOCIRulesfile(ctx, parent, node))
+			}
+			previous := node.DeepCopy().Status.InstalledArtifacts
+
+			// The parent metadata is published before the aggregator replaces the cache entry.
+			parent.Generation = 2
+			parent.Spec.OCIArtifact.Image.Tag = "new"
+			parent.Status.ObservedGeneration = 2
+			parent.Status.ArtifactMeta = &commonv1alpha1.ArtifactMeta{SpecHash: "spec-new", Digest: newDigest}
+
+			err := reconciler.ensureOCIRulesfile(ctx, parent, node)
+			var retryErr *artifact.RetryableError
+			require.ErrorAs(t, err, &retryErr, "an old cached revision must not be accepted as the new spec")
+			require.Equal(t, previous, node.Status.InstalledArtifacts)
+			if alreadyInstalled {
+				require.Equal(t, []byte("old artifact bytes"), fs.Files[previous[0].Path])
+			} else {
+				require.Empty(t, fs.Files)
+			}
+			condition := apimeta.FindStatusCondition(node.Status.Conditions, commonv1alpha1.ConditionOCIArtifactProgrammed.String())
+			require.NotNil(t, condition)
+			require.Equal(t, metav1.ConditionFalse, condition.Status)
+
+			// Once the expected digest is available, the retry installs it and records its spec.
+			require.NoError(t, cache.Store(newPath, []byte("new artifact bytes"), 0o755))
+			require.NoError(t, cache.Set("rulesfile", "default", "artifact", platform, newPath))
+			require.NoError(t, reconciler.ensureOCIRulesfile(ctx, parent, node))
+			require.Len(t, node.Status.InstalledArtifacts, 1)
+			installed := node.Status.InstalledArtifacts[0]
+			require.Equal(t, "spec-new", installed.SpecHash)
+			require.Equal(t, []byte("new artifact bytes"), fs.Files[installed.Path])
+			condition = apimeta.FindStatusCondition(node.Status.Conditions, commonv1alpha1.ConditionOCIArtifactProgrammed.String())
+			require.Equal(t, metav1.ConditionTrue, condition.Status)
+			require.Equal(t, int64(2), condition.ObservedGeneration)
+
+			// A verified, installed revision remains usable without another download.
+			srv.Close()
+			require.NoError(t, reconciler.ensureOCIRulesfile(ctx, parent, node))
+		})
+	}
 }

--- a/controllers/instance/artifact/plugin/controller.go
+++ b/controllers/instance/artifact/plugin/controller.go
@@ -290,7 +290,7 @@ func (r *PluginAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Conte
 
 	ref := artifact.ResolveReference(plugin.Spec.OCIArtifact)
 	logger.Info("Fetching plugin ArtifactMeta from OCI config layer", "ref", ref)
-	fetched, digest, fetchErr := am.FetchConfig(ctx, plugin.Spec.OCIArtifact)
+	fetched, digest, fetchErr := am.FetchConfig(ctx, plugin.Spec.OCIArtifact, "")
 	if fetchErr != nil {
 		logger.Error(fetchErr, "Unable to fetch plugin OCI config; ArtifactMeta will remain stale", "ref", ref)
 		artifact.RecordWarning(r.recorder, plugin, artifact.ReasonOCIArtifactProgramFailed,

--- a/controllers/instance/artifact/plugin/controller_test.go
+++ b/controllers/instance/artifact/plugin/controller_test.go
@@ -19,6 +19,9 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"oras.land/oras-go/v2/registry/remote/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -42,6 +46,7 @@ import (
 	"github.com/falcosecurity/falco-operator/controllers/testutil"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
@@ -753,6 +758,48 @@ func TestFetchAndCacheArtifactMeta_CacheHitIgnoresDigest(t *testing.T) {
 	assert.Equal(t, "sha256:old", plugin.Status.ArtifactMeta.Digest, "stale digest must not be updated on cache hit")
 }
 
+func TestFetchAndCacheArtifactMeta_ResolutionPolicy(t *testing.T) {
+	const nextDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	for _, tc := range []struct {
+		name    string
+		change  func(*artifactv1alpha1.Plugin)
+		resolve bool
+	}{
+		{"tag moves without a spec change", func(_ *artifactv1alpha1.Plugin) {}, false},
+		{"plugin configuration changes", func(p *artifactv1alpha1.Plugin) {
+			p.Spec.Config = &artifactv1alpha1.PluginConfig{OpenParams: "new params"}
+		}, false},
+		{"selector changes", withPluginSelector(), false},
+		{"tag changes", func(p *artifactv1alpha1.Plugin) { p.Spec.OCIArtifact.Image.Tag = "v2" }, true},
+		{"repository changes", func(p *artifactv1alpha1.Plugin) { p.Spec.OCIArtifact.Image.Repository = "test/replacement" }, true},
+		{"digest is explicitly pinned", func(p *artifactv1alpha1.Plugin) { p.Spec.OCIArtifact.Image.Tag = nextDigest }, true},
+		{"CR is recreated", func(p *artifactv1alpha1.Plugin) {
+			p.UID = "replacement"
+			p.Status = artifactv1alpha1.PluginStatus{}
+		}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			plugin := newTestPlugin(withPluginOCI())
+			mockPuller := &pullerfake.MockOCIPuller{ConfigResult: &puller.ArtifactConfig{}, ConfigDigest: testPluginDigest}
+			r, _ := newTestReconcilerWithPuller(t, mockPuller, plugin)
+			require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, plugin))
+			previous := plugin.Status.ArtifactMeta.DeepCopy()
+			firstRef := artifact.ResolveReference(plugin.Spec.OCIArtifact)
+			mockPuller.ConfigDigest = nextDigest
+			tc.change(plugin)
+			require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, plugin))
+			if tc.resolve {
+				require.Equal(t, nextDigest, plugin.Status.ArtifactMeta.Digest)
+				require.Equal(t, []string{firstRef, artifact.ResolveReference(plugin.Spec.OCIArtifact)}, mockPuller.FetchConfigCalls)
+			} else {
+				require.Equal(t, previous, plugin.Status.ArtifactMeta)
+				require.Equal(t, []string{firstRef}, mockPuller.FetchConfigCalls, "unchanged OCI metadata must be reused without fetching")
+			}
+		})
+	}
+}
+
 func TestFetchAndCacheArtifactMeta_NoCacheNoStatus(t *testing.T) {
 	mockPuller := &pullerfake.MockOCIPuller{
 		ConfigResult: &puller.ArtifactConfig{},
@@ -1141,6 +1188,119 @@ func TestFetchAndCacheBinaries_MultiplePlatforms(t *testing.T) {
 
 	require.NoError(t, r.fetchAndCacheBlobs(context.Background(), plugin, []corev1.Node{*node1, *node2}))
 	assert.Len(t, mockPuller.PullCalls, 2)
+}
+
+// Each platform has distinct bytes so a cross-architecture cache mix-up is observable.
+type platformPluginPuller struct {
+	*pullerfake.MockOCIPuller
+	layers map[string][]byte
+}
+
+func (p *platformPluginPuller) Pull(
+	ctx context.Context, ref, goos, goarch string, creds auth.CredentialFunc, opts *puller.RegistryOptions, dst io.Writer,
+) (*puller.RegistryResult, error) {
+	p.LayerContent = p.layers[goarch]
+	return p.MockOCIPuller.Pull(ctx, ref, goos, goarch, creds, opts, dst)
+}
+
+func TestReconcile_NewNodesKeepResolvedRevision(t *testing.T) {
+	const amd64Arch, arm64Arch = "amd64", "arm64"
+	const emptyCache = "empty after restart"
+	ctx := context.Background()
+	plugin := newTestPlugin(withPluginOCI())
+	plugin.Spec.OCIArtifact.Image.Repository = "test/plugin"
+	plugin.Generation = 1
+	node := newTestNode(testutil.TestNodeName, map[string]string{corev1.LabelOSStable: "linux", corev1.LabelArchStable: amd64Arch})
+	mockPuller := &platformPluginPuller{
+		MockOCIPuller: &pullerfake.MockOCIPuller{
+			ConfigResult: &puller.ArtifactConfig{}, ConfigDigest: testPluginDigest,
+			Result: &puller.RegistryResult{RootDigest: testPluginDigest, Type: puller.Plugin},
+		},
+		layers: make(map[string][]byte),
+	}
+	for _, arch := range []string{amd64Arch, arm64Arch} {
+		layer, err := pullerfake.MakeTarGz("plugin.so", []byte("revision A for "+arch))
+		require.NoError(t, err)
+		mockPuller.layers[arch] = layer
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, t.TempDir(), plugin, node, newTestFalco(), newRunningFalcoPod())
+	_, err := r.Reconcile(ctx, testutil.Request(plugin.Name))
+	require.NoError(t, err)
+	require.Len(t, mockPuller.FetchConfigCalls, 1)
+	require.Len(t, mockPuller.PullCalls, 1)
+
+	// Any accidental new tag resolution now yields B, even though the CR still desires A.
+	mockPuller.ConfigDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	mockPuller.ResolveDigestResult = mockPuller.ConfigDigest
+	for _, arch := range []string{amd64Arch, arm64Arch} {
+		t.Run("new node "+arch, func(t *testing.T) {
+			added := newTestNode("new-"+arch, map[string]string{corev1.LabelOSStable: "linux", corev1.LabelArchStable: arch})
+			require.NoError(t, r.Create(ctx, added))
+			pod := newRunningFalcoPod()
+			pod.Name = "falco-" + arch
+			pod.Spec.NodeName = added.Name
+			require.NoError(t, r.Create(ctx, pod))
+			if arch == arm64Arch {
+				mockPuller.PullErr = fmt.Errorf("platform unavailable")
+				_, reconcileErr := r.Reconcile(ctx, testutil.Request(plugin.Name))
+				require.ErrorContains(t, reconcileErr, "platform unavailable")
+				_, ok := r.cache.Lookup("plugin", plugin.Namespace, plugin.Name, "linux-"+arm64Arch)
+				require.False(t, ok, "a failed pull must not publish a cache entry")
+				mockPuller.PullErr = nil
+			}
+			_, reconcileErr := r.Reconcile(ctx, testutil.Request(plugin.Name))
+			require.NoError(t, reconcileErr)
+			child := &artifactv1alpha1.ArtifactNode{}
+			require.NoError(t, r.Get(ctx, client.ObjectKey{
+				Namespace: plugin.Namespace,
+				Name:      controllerhelper.NodeObjectName(controllerhelper.ArtifactKindPlugin, plugin.Name, added.Name),
+			}, child))
+			require.Equal(t, added.Name, child.Spec.NodeName)
+			if arch == amd64Arch {
+				require.Len(t, mockPuller.PullCalls, 1, "a new node of a cached architecture needs no new registry pull")
+			}
+		})
+	}
+
+	for _, state := range []string{"warm", "reloaded", emptyCache} {
+		t.Run(state, func(t *testing.T) {
+			if state != "warm" {
+				cacheDir := r.cache.Dir()
+				if state == emptyCache {
+					cacheDir = t.TempDir()
+				}
+				r.cache = artifactcache.NewCache(cacheDir)
+				require.NoError(t, r.cache.Load())
+			}
+			pullsBefore := len(mockPuller.PullCalls)
+			_, reconcileErr := r.Reconcile(ctx, testutil.Request(plugin.Name))
+			require.NoError(t, reconcileErr)
+			wantPulls := pullsBefore
+			if state == emptyCache {
+				wantPulls += 2
+			}
+			require.Len(t, mockPuller.PullCalls, wantPulls)
+			got := &artifactv1alpha1.Plugin{}
+			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(plugin), got))
+			require.Equal(t, testPluginDigest, got.Status.ArtifactMeta.Digest)
+			require.Equal(t, got.Generation, got.Status.ObservedGeneration)
+			require.Len(t, mockPuller.FetchConfigCalls, 1)
+			require.Empty(t, mockPuller.ResolveDigestCalls)
+			for _, call := range mockPuller.PullCalls {
+				require.Equal(t, "ghcr.io/test/plugin@"+testPluginDigest, call.Ref)
+				require.Equal(t, "linux", call.OS)
+			}
+			for _, arch := range []string{amd64Arch, arm64Arch} {
+				request := httptest.NewRequestWithContext(ctx, http.MethodGet,
+					"/v1/artifacts/plugins/"+plugin.Namespace+"/"+plugin.Name+"?os=linux&arch="+arch+"&digest="+testPluginDigest, http.NoBody)
+				response := httptest.NewRecorder()
+				artifactserver.New(r.cache).Handler().ServeHTTP(response, request)
+				require.Equal(t, http.StatusOK, response.Code)
+				require.Equal(t, "revision A for "+arch, response.Body.String())
+				require.Equal(t, testPluginDigest, response.Header().Get(artifact.ArtifactDigestHeader))
+			}
+		})
+	}
 }
 
 func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {

--- a/controllers/instance/artifact/rulesfile/controller.go
+++ b/controllers/instance/artifact/rulesfile/controller.go
@@ -360,9 +360,15 @@ func (r *RulesfileAggregatorReconciler) fetchAndCacheArtifactMeta(ctx context.Co
 		}
 		am := artifact.NewManagerWithOptions(r.Client, rulesfile.Namespace, opts...)
 
+		// A ConfigMap/inline change rebuilds the aggregate, but must not update an unchanged
+		// OCI source by following its tag. Re-read that source at its previously resolved digest.
+		var knownDigest string
+		if cached := rulesfile.Status.ArtifactMeta; artifact.ArtifactMetaCacheHit(cached, sources.OCIArtifactSpecHash) {
+			knownDigest = cached.Digest
+		}
 		ref := artifact.ResolveReference(rulesfile.Spec.OCIArtifact)
 		logger.Info("Fetching rulesfile ArtifactMeta from OCI config layer", "ref", ref)
-		fetched, digest, fetchErr := am.FetchConfig(ctx, rulesfile.Spec.OCIArtifact)
+		fetched, digest, fetchErr := am.FetchConfig(ctx, rulesfile.Spec.OCIArtifact, knownDigest)
 		if fetchErr != nil {
 			logger.Error(fetchErr, "Unable to fetch rulesfile OCI config; ArtifactMeta will remain stale", "ref", ref)
 			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactProgramFailed,

--- a/controllers/instance/artifact/rulesfile/controller_test.go
+++ b/controllers/instance/artifact/rulesfile/controller_test.go
@@ -19,6 +19,8 @@ package rulesfile
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"oras.land/oras-go/v2/registry/remote/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -43,6 +46,7 @@ import (
 	"github.com/falcosecurity/falco-operator/controllers/testutil"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifactcache"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifactserver"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/oci/puller"
@@ -50,8 +54,11 @@ import (
 )
 
 const (
-	testRulesfileName   = "test-rulesfile"
-	testRulesfileDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testRulesfileName       = "test-rulesfile"
+	testRulesfileDigest     = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testNextRulesfileDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testRulesfileRepository = "test/rulesfile"
+	testEngine22Rules       = "- required_engine_version: 22"
 )
 
 func testRulesfileNodeName() string {
@@ -845,7 +852,7 @@ func TestFetchAndCacheArtifactMeta_OCIContentFetchError(t *testing.T) {
 
 func TestFetchAndCacheArtifactMeta_OCIWithContentRequirements(t *testing.T) {
 	// Content YAML declares engine version requirement.
-	yamlContent := []byte(`- required_engine_version: 22`)
+	yamlContent := []byte(testEngine22Rules)
 	mockPuller := &pullerfake.MockOCIPuller{
 		ConfigResult:  &puller.ArtifactConfig{},
 		ConfigDigest:  testRulesfileDigest,
@@ -895,7 +902,7 @@ func TestFetchAndCacheArtifactMeta_ConfigMapMissing(t *testing.T) {
 func TestFetchAndCacheArtifactMeta_ConfigMapRequiredKeyMissing(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-rules-cm", Namespace: testutil.TestNamespace},
-		Data:       map[string]string{"other.yaml": "- required_engine_version: 22"},
+		Data:       map[string]string{"other.yaml": testEngine22Rules},
 	}
 	rf := newTestRulesfile(withRulesfileConfigMapRef(cm.Name))
 	r, _ := newTestReconciler(t, rf, cm)
@@ -1012,7 +1019,7 @@ func TestFetchAndCacheArtifactMeta_ConfigMapChangeRebuildsCompleteAggregate(t *t
 
 	updatedCM := &corev1.ConfigMap{}
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(cm), updatedCM))
-	updatedCM.Data[commonv1alpha1.ConfigMapRulesKey] = `- required_engine_version: 22`
+	updatedCM.Data[commonv1alpha1.ConfigMapRulesKey] = testEngine22Rules
 	require.NoError(t, cl.Update(context.Background(), updatedCM))
 
 	require.NoError(t, r.fetchAndCacheArtifactMeta(context.Background(), rf))
@@ -1121,7 +1128,7 @@ func TestFetchAndCacheArtifactMeta_CombinesConstraintsWithoutMaskingConflicts(t 
 
 func TestAppendYAMLRequirements_EngineVersionInt(t *testing.T) {
 	meta := &commonv1alpha1.ArtifactMeta{}
-	content := []byte(`- required_engine_version: 22`)
+	content := []byte(testEngine22Rules)
 	require.NoError(t, appendYAMLRequirements(meta, content))
 	require.Len(t, meta.Requirements, 1)
 	assert.Equal(t, "engine_version", meta.Requirements[0].Name)
@@ -1606,6 +1613,87 @@ func TestFetchAndCacheBinary_PullError(t *testing.T) {
 	assert.Contains(t, err.Error(), "registry down")
 }
 
+func TestReconcile_NewNodeKeepsResolvedRevision(t *testing.T) {
+	const emptyCache = "empty after restart"
+	ctx := context.Background()
+	rf := newTestRulesfile(withRulesfileOCI())
+	rf.Spec.OCIArtifact.Image.Repository = testRulesfileRepository
+	rf.Generation = 1
+	layer, err := pullerfake.MakeTarGz("rules.yaml", []byte("rules from revision A"))
+	require.NoError(t, err)
+	mockPuller := &pullerfake.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{}, ConfigDigest: testRulesfileDigest,
+		Result:       &puller.RegistryResult{RootDigest: testRulesfileDigest, Type: puller.Rulesfile},
+		LayerContent: layer,
+	}
+	r := newTestReconcilerWithCacheAndPuller(t, mockPuller, t.TempDir(), rf, newTestNode(), newTestFalco(), newRunningFalcoPod())
+	_, err = r.Reconcile(ctx, testutil.Request(rf.Name))
+	require.NoError(t, err)
+	require.Len(t, mockPuller.PullCalls, 1)
+
+	mockPuller.ConfigDigest = testNextRulesfileDigest
+	mockPuller.ResolveDigestResult = mockPuller.ConfigDigest
+	added := newTestNode()
+	added.Name = "new-node"
+	require.NoError(t, r.Create(ctx, added))
+	pod := newRunningFalcoPod()
+	pod.Name = "new-falco"
+	pod.Spec.NodeName = added.Name
+	require.NoError(t, r.Create(ctx, pod))
+
+	for _, state := range []string{"warm", "reloaded", emptyCache} {
+		t.Run(state, func(t *testing.T) {
+			if state != "warm" {
+				cacheDir := r.cache.Dir()
+				if state == emptyCache {
+					cacheDir = t.TempDir()
+				}
+				r.cache = artifactcache.NewCache(cacheDir)
+				require.NoError(t, r.cache.Load())
+			}
+			if state == emptyCache {
+				mockPuller.PullErr = fmt.Errorf("revision unavailable")
+				_, reconcileErr := r.Reconcile(ctx, testutil.Request(rf.Name))
+				require.ErrorContains(t, reconcileErr, "revision unavailable")
+				_, ok := r.cache.Lookup("rulesfile", rf.Namespace, rf.Name, "")
+				require.False(t, ok)
+				mockPuller.PullErr = nil
+			}
+			pullsBefore := len(mockPuller.PullCalls)
+			_, reconcileErr := r.Reconcile(ctx, testutil.Request(rf.Name))
+			require.NoError(t, reconcileErr)
+			wantPulls := pullsBefore
+			if state == emptyCache {
+				wantPulls++
+			}
+			require.Len(t, mockPuller.PullCalls, wantPulls)
+			child := &artifactv1alpha1.ArtifactNode{}
+			require.NoError(t, r.Get(ctx, client.ObjectKey{
+				Namespace: rf.Namespace,
+				Name:      controllerhelper.NodeObjectName(controllerhelper.ArtifactKindRulesfile, rf.Name, added.Name),
+			}, child))
+			require.Equal(t, added.Name, child.Spec.NodeName)
+			got := &artifactv1alpha1.Rulesfile{}
+			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(rf), got))
+			require.Equal(t, testRulesfileDigest, got.Status.ArtifactMeta.Digest)
+			require.Equal(t, got.Generation, got.Status.ObservedGeneration)
+			require.Len(t, mockPuller.FetchConfigCalls, 1)
+			require.Len(t, mockPuller.FetchContentCalls, 1)
+			require.Empty(t, mockPuller.ResolveDigestCalls)
+			for _, call := range mockPuller.PullCalls {
+				require.Equal(t, "ghcr.io/test/rulesfile@"+testRulesfileDigest, call.Ref)
+			}
+			request := httptest.NewRequestWithContext(ctx, http.MethodGet,
+				"/v1/artifacts/rulesfiles/"+rf.Namespace+"/"+rf.Name+"?digest="+testRulesfileDigest, http.NoBody)
+			response := httptest.NewRecorder()
+			artifactserver.New(r.cache).Handler().ServeHTTP(response, request)
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Equal(t, "rules from revision A", response.Body.String())
+			require.Equal(t, testRulesfileDigest, response.Header().Get(artifact.ArtifactDigestHeader))
+		})
+	}
+}
+
 func TestReconcile_ClearFinalizersInStalePath_Error(t *testing.T) {
 	// Selector requires env=prod; plain node doesn't have that label → staleNode is stale.
 	// staleNode has a finalizer and a Falco pod still runs there, so orphan detection calls
@@ -1680,4 +1768,206 @@ func TestReconcile_FetchAndCacheBinaryError(t *testing.T) {
 	_, err := r.Reconcile(context.Background(), testutil.Request(testRulesfileName))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registry down")
+}
+
+type referenceConfigPuller struct {
+	*pullerfake.MockOCIPuller
+	fetchConfig func(string) (*puller.ArtifactConfig, string, error)
+}
+
+func (p *referenceConfigPuller) FetchConfig(
+	_ context.Context, ref string, _ auth.CredentialFunc, _ *puller.RegistryOptions,
+) (*puller.ArtifactConfig, string, error) {
+	p.FetchConfigCalls = append(p.FetchConfigCalls, ref)
+	return p.fetchConfig(ref)
+}
+
+func TestFetchAndCacheArtifactMeta_LocalChangesKeepResolvedDigest(t *testing.T) {
+	const newDigest = testNextRulesfileDigest
+	ctx := context.Background()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "rules", Namespace: testutil.TestNamespace},
+		Data:       map[string]string{commonv1alpha1.ConfigMapRulesKey: "- required_engine_version: 15"},
+	}
+	rf := newTestRulesfile(withRulesfileOCI(), withRulesfileConfigMapRef(cm.Name))
+	rf.Spec.OCIArtifact.Image.Repository = testRulesfileRepository
+	originalOCI := rf.Spec.OCIArtifact.DeepCopy()
+	tagRef := artifact.ResolveReference(originalOCI)
+	pinnedRef := "ghcr.io/test/rulesfile@" + testRulesfileDigest
+	oldConfig := &puller.ArtifactConfig{Dependencies: []puller.ArtifactDependency{{Name: "container", Version: "1.0.0"}}}
+	newConfig := &puller.ArtifactConfig{Dependencies: []puller.ArtifactDependency{{Name: "different-plugin", Version: "2.0.0"}}}
+	tagMoved := false
+	mockPuller := &referenceConfigPuller{
+		MockOCIPuller: &pullerfake.MockOCIPuller{},
+		fetchConfig: func(ref string) (*puller.ArtifactConfig, string, error) {
+			switch ref {
+			case pinnedRef:
+				return oldConfig, testRulesfileDigest, nil
+			case tagRef:
+				if !tagMoved {
+					return oldConfig, testRulesfileDigest, nil
+				}
+				return newConfig, newDigest, nil
+			case "ghcr.io/test/rulesfile:v2":
+				return newConfig, newDigest, nil
+			default:
+				return nil, "", fmt.Errorf("unexpected reference %q", ref)
+			}
+		},
+	}
+	r, cl := newTestReconcilerWithPuller(t, mockPuller, rf, cm)
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	originalSpecHash := rf.Status.ArtifactMeta.SpecHash
+	require.Equal(t, testRulesfileDigest, rf.Status.ArtifactMeta.Digest)
+	require.Equal(t, []string{tagRef}, mockPuller.FetchConfigCalls)
+
+	// Moving the registry tag alone must not cause a new resolution.
+	tagMoved = true
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	require.Len(t, mockPuller.FetchConfigCalls, 1)
+
+	for _, change := range []string{"configmap", "inline", "remove local sources"} {
+		t.Run(change, func(t *testing.T) {
+			previousSourcesHash := rf.Status.ArtifactMetaSourcesHash
+			switch change {
+			case "configmap":
+				updated := &corev1.ConfigMap{}
+				require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(cm), updated))
+				updated.Data[commonv1alpha1.ConfigMapRulesKey] = testEngine22Rules
+				require.NoError(t, cl.Update(ctx, updated))
+			case "inline":
+				rf.Spec.InlineRules = &apiextensionsv1.JSON{Raw: []byte(`- required_engine_version: "0.30.0"`)}
+			case "remove local sources":
+				rf.Spec.ConfigMapRef = nil
+				rf.Spec.InlineRules = nil
+			}
+			require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+			require.Equal(t, testRulesfileDigest, rf.Status.ArtifactMeta.Digest, "local source changes must not move the OCI tag")
+			require.Equal(t, originalSpecHash, rf.Status.ArtifactMeta.SpecHash)
+			require.Equal(t, originalOCI, rf.Spec.OCIArtifact, "pinning must not mutate the requested spec")
+			require.NotEqual(t, previousSourcesHash, rf.Status.ArtifactMetaSourcesHash)
+			require.Equal(t, pinnedRef, mockPuller.FetchConfigCalls[len(mockPuller.FetchConfigCalls)-1])
+			require.Equal(t, pinnedRef, mockPuller.FetchContentCalls[len(mockPuller.FetchContentCalls)-1])
+			require.Equal(t, []commonv1alpha1.ArtifactMetaDependency{{Name: "container", Version: "1.0.0"}}, rf.Status.ArtifactMeta.Dependencies)
+			var wantRequirements []commonv1alpha1.ArtifactMetaRequirement
+			if rf.Spec.ConfigMapRef != nil {
+				wantRequirements = append(wantRequirements, commonv1alpha1.ArtifactMetaRequirement{Name: "engine_version", Version: "22"})
+			}
+			if rf.Spec.InlineRules != nil {
+				wantRequirements = append(wantRequirements, commonv1alpha1.ArtifactMetaRequirement{Name: "engine_version_semver", Version: "0.30.0"})
+			}
+			require.ElementsMatch(t, wantRequirements, rf.Status.ArtifactMeta.Requirements, "local metadata must still be rebuilt completely")
+		})
+	}
+	// An explicit OCI spec change is allowed to resolve a new revision.
+	rf.Spec.OCIArtifact.Image.Tag = "v2"
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	require.Equal(t, newDigest, rf.Status.ArtifactMeta.Digest)
+	require.NotEqual(t, originalSpecHash, rf.Status.ArtifactMeta.SpecHash)
+	require.Equal(t, "ghcr.io/test/rulesfile:v2", mockPuller.FetchConfigCalls[len(mockPuller.FetchConfigCalls)-1])
+
+	// A recreated CR has no previous metadata, even if its name and OCI spec are identical.
+	recreated := newTestRulesfile(withRulesfileOCI())
+	recreated.UID = "replacement"
+	recreated.Spec.OCIArtifact = originalOCI.DeepCopy()
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, recreated))
+	require.Equal(t, newDigest, recreated.Status.ArtifactMeta.Digest)
+	require.Equal(t, originalSpecHash, recreated.Status.ArtifactMeta.SpecHash)
+	require.Equal(t, tagRef, mockPuller.FetchConfigCalls[len(mockPuller.FetchConfigCalls)-1])
+	require.Equal(t, "ghcr.io/test/rulesfile@"+newDigest, mockPuller.FetchContentCalls[len(mockPuller.FetchContentCalls)-1])
+}
+
+func TestFetchAndCacheArtifactMeta_PinnedFetchFailurePreservesAggregate(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		fail         func(*pullerfake.MockOCIPuller)
+		wantErr      string
+		contentCalls int
+	}{
+		{
+			name:         "config unavailable",
+			fail:         func(p *pullerfake.MockOCIPuller) { p.FetchConfigErr = fmt.Errorf("manifest unavailable") },
+			wantErr:      "manifest unavailable",
+			contentCalls: 1,
+		},
+		{
+			name: "unexpected digest",
+			fail: func(p *pullerfake.MockOCIPuller) {
+				p.ConfigDigest = testNextRulesfileDigest
+			},
+			wantErr:      "does not match expected digest",
+			contentCalls: 1,
+		},
+		{
+			name:         "content unavailable",
+			fail:         func(p *pullerfake.MockOCIPuller) { p.FetchContentErr = fmt.Errorf("content unavailable") },
+			wantErr:      "content unavailable",
+			contentCalls: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			rf := newTestRulesfile(withRulesfileOCI(), withInlineRules("- required_engine_version: 15"))
+			rf.Spec.OCIArtifact.Image.Repository = testRulesfileRepository
+			mockPuller := &pullerfake.MockOCIPuller{
+				ConfigResult: &puller.ArtifactConfig{Dependencies: []puller.ArtifactDependency{{Name: "container", Version: "1.0.0"}}},
+				ConfigDigest: testRulesfileDigest,
+			}
+			r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+			require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+			previousMeta := rf.Status.ArtifactMeta.DeepCopy()
+			previousHash := rf.Status.ArtifactMetaSourcesHash
+
+			rf.Spec.InlineRules.Raw = []byte(testEngine22Rules)
+			tc.fail(mockPuller)
+			require.ErrorContains(t, r.fetchAndCacheArtifactMeta(ctx, rf), tc.wantErr)
+			require.Equal(t, previousMeta, rf.Status.ArtifactMeta, "a failed pinned fetch must not replace the last complete aggregate")
+			require.Equal(t, previousHash, rf.Status.ArtifactMetaSourcesHash)
+			pinnedRef := "ghcr.io/test/rulesfile@" + testRulesfileDigest
+			require.Equal(t, []string{artifact.ResolveReference(rf.Spec.OCIArtifact), pinnedRef}, mockPuller.FetchConfigCalls,
+				"a failed pinned fetch must not fall back to the tag")
+			require.Len(t, mockPuller.FetchContentCalls, tc.contentCalls)
+			for _, ref := range mockPuller.FetchContentCalls {
+				require.Equal(t, pinnedRef, ref)
+			}
+
+			// A later successful retry applies the local change at the same OCI revision.
+			mockPuller.FetchConfigErr = nil
+			mockPuller.FetchContentErr = nil
+			mockPuller.ConfigDigest = testRulesfileDigest
+			require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+			require.Equal(t, testRulesfileDigest, rf.Status.ArtifactMeta.Digest)
+			require.Equal(t, previousMeta.Dependencies, rf.Status.ArtifactMeta.Dependencies)
+			require.Equal(t, []commonv1alpha1.ArtifactMetaRequirement{{Name: "engine_version", Version: "22"}}, rf.Status.ArtifactMeta.Requirements)
+			require.NotEqual(t, previousHash, rf.Status.ArtifactMetaSourcesHash)
+			require.Equal(t, pinnedRef, mockPuller.FetchConfigCalls[len(mockPuller.FetchConfigCalls)-1])
+			require.Equal(t, pinnedRef, mockPuller.FetchContentCalls[len(mockPuller.FetchContentCalls)-1])
+		})
+	}
+}
+
+func TestFetchAndCacheArtifactMeta_RemovingAndReaddingOCIResolvesAgain(t *testing.T) {
+	ctx := context.Background()
+	rf := newTestRulesfile(withRulesfileOCI(), withInlineRules(testEngine22Rules))
+	mockPuller := &pullerfake.MockOCIPuller{
+		ConfigResult: &puller.ArtifactConfig{Dependencies: []puller.ArtifactDependency{{Name: "container", Version: "1.0.0"}}},
+		ConfigDigest: testRulesfileDigest,
+	}
+	r, _ := newTestReconcilerWithPuller(t, mockPuller, rf)
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	oci := rf.Spec.OCIArtifact.DeepCopy()
+	rf.Spec.OCIArtifact = nil
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	require.Empty(t, rf.Status.ArtifactMeta.Digest)
+	require.Empty(t, rf.Status.ArtifactMeta.SpecHash)
+	require.Empty(t, rf.Status.ArtifactMeta.Dependencies)
+	require.Equal(t, []commonv1alpha1.ArtifactMetaRequirement{{Name: "engine_version", Version: "22"}}, rf.Status.ArtifactMeta.Requirements)
+	require.Len(t, mockPuller.FetchConfigCalls, 1)
+
+	mockPuller.ConfigDigest = testNextRulesfileDigest
+	rf.Spec.OCIArtifact = oci
+	require.NoError(t, r.fetchAndCacheArtifactMeta(ctx, rf))
+	require.Equal(t, mockPuller.ConfigDigest, rf.Status.ArtifactMeta.Digest)
+	require.Equal(t, []string{artifact.ResolveReference(oci), artifact.ResolveReference(oci)}, mockPuller.FetchConfigCalls,
+		"re-adding an OCI source is a new resolution, not reuse of removed metadata")
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.43.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/stretchr/testify v1.12.1
@@ -200,7 +201,6 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/norwoodj/helm-docs v1.11.0 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/internal/pkg/artifact/fetch.go
+++ b/internal/pkg/artifact/fetch.go
@@ -25,10 +25,12 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strconv"
 	"time"
 
+	"github.com/opencontainers/go-digest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,8 +42,8 @@ import (
 // no server-advertised Retry-After (a transport error, or a 503 with no header).
 const DefaultRetryDelay = 10 * time.Second
 
-// RetryableError wraps a transient FetchOCI failure (a transport error, or the artifact
-// server's 503 "not cached yet" signal), so the caller can requeue via
+// RetryableError wraps a transient FetchOCI failure (transport, availability, or a revision
+// that is not ready yet), so the caller can requeue via
 // ctrl.Result{RequeueAfter: ...}.
 type RetryableError struct {
 	Err error
@@ -80,8 +82,9 @@ type FetchResult struct {
 
 // OCIFetcher downloads a pre-extracted artifact binary from the central artifact server.
 // The sidecar never touches the OCI registry directly; the server handles that.
+// Only content belonging to expectedDigest may be returned successfully.
 type OCIFetcher interface {
-	FetchOCI(ctx context.Context, namespace, name string, artifactType Type) (FetchResult, error)
+	FetchOCI(ctx context.Context, namespace, name string, artifactType Type, expectedDigest string) (FetchResult, error)
 }
 
 // ConfigMapFetcher retrieves artifact content from a Kubernetes ConfigMap.
@@ -106,6 +109,10 @@ type ArtifactFetcher interface {
 // requesting node to the artifact server.
 const NodeNameHeader = "X-Node-Name"
 
+// ArtifactDigestHeader identifies the OCI root manifest or index served by the artifact
+// server. It is not the hash of the extracted file (FetchResult.ContentHash).
+const ArtifactDigestHeader = "X-Artifact-Digest"
+
 // Fetcher implements ArtifactFetcher.
 // OCI: HTTP GET to the central artifact server (no puller, no registry auth).
 // ConfigMap: K8s API call.
@@ -122,16 +129,19 @@ type Fetcher struct {
 
 // FetchOCI streams the pre-extracted artifact binary for (namespace, name, type) from the
 // central artifact server, computes a SHA-256 content hash, and returns a FetchResult. It makes
-// exactly one attempt. A transient failure (a transport error, or a 503 meaning the artifact
-// isn't cached yet) is returned as a *RetryableError for the caller to requeue via
+// exactly one attempt, requiring the server to confirm expectedDigest. Missing metadata or
+// an unconfirmed revision is deferred without accepting the response content.
+// A transient failure is returned as a *RetryableError for the caller to requeue via
 // ctrl.Result{RequeueAfter: ...} (see RequeueDelay); a permanent failure (a non-503 error
 // status, or a request-build/body-read failure) is returned as a plain error.
-func (f *Fetcher) FetchOCI(ctx context.Context, namespace, name string, artifactType Type) (FetchResult, error) {
+func (f *Fetcher) FetchOCI(ctx context.Context, namespace, name string, artifactType Type, expectedDigest string) (FetchResult, error) {
 	var rawURL string
+	query := url.Values{"digest": {expectedDigest}}
 	switch artifactType {
 	case TypePlugin:
-		rawURL = fmt.Sprintf("%s/v1/artifacts/plugins/%s/%s?os=%s&arch=%s",
-			f.ServerURL, namespace, name, runtime.GOOS, runtime.GOARCH)
+		rawURL = fmt.Sprintf("%s/v1/artifacts/plugins/%s/%s", f.ServerURL, namespace, name)
+		query.Set("os", runtime.GOOS)
+		query.Set("arch", runtime.GOARCH)
 	case TypeRulesfile:
 		rawURL = fmt.Sprintf("%s/v1/artifacts/rulesfiles/%s/%s",
 			f.ServerURL, namespace, name)
@@ -139,7 +149,15 @@ func (f *Fetcher) FetchOCI(ctx context.Context, namespace, name string, artifact
 		return FetchResult{}, fmt.Errorf("artifact server does not support type %q", artifactType)
 	}
 
-	result, retryAfter, retryable, err := f.fetchOCIOnce(ctx, rawURL, namespace, name)
+	if expectedDigest == "" {
+		return FetchResult{}, &RetryableError{Err: fmt.Errorf("OCI digest for %s/%s is not yet resolved", namespace, name)}
+	}
+	if err := digest.Digest(expectedDigest).Validate(); err != nil {
+		return FetchResult{}, fmt.Errorf("invalid expected OCI digest for %s/%s: %w", namespace, name, err)
+	}
+	rawURL += "?" + query.Encode()
+
+	result, retryAfter, retryable, err := f.fetchOCIOnce(ctx, rawURL, namespace, name, expectedDigest)
 	if err != nil && retryable {
 		return FetchResult{}, &RetryableError{Err: err, RetryAfter: retryAfter}
 	}
@@ -148,10 +166,10 @@ func (f *Fetcher) FetchOCI(ctx context.Context, namespace, name string, artifact
 
 // fetchOCIOnce performs a single HTTP GET to the artifact server. retryAfter is the parsed
 // Retry-After header value (meaningful only when retryable is true); retryable reports
-// whether FetchOCI's caller should retry; true for a transient transport error or a 503
-// (the artifact server's "not cached yet" signal), false for anything else (a permanent
-// client error, or a failure building the request or reading the response body).
-func (f *Fetcher) fetchOCIOnce(ctx context.Context, rawURL, namespace, name string) (result FetchResult, retryAfter time.Duration, retryable bool, err error) {
+// whether FetchOCI's caller should retry; true for a transient transport error, a 503,
+// or a response that does not confirm the requested revision; false for a permanent
+// client error, or a failure building the request or reading the response body.
+func (f *Fetcher) fetchOCIOnce(ctx context.Context, rawURL, namespace, name, expectedDigest string) (result FetchResult, retryAfter time.Duration, retryable bool, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return FetchResult{}, 0, false, fmt.Errorf("build artifact server request: %w", err)
@@ -175,6 +193,10 @@ func (f *Fetcher) fetchOCIOnce(ctx context.Context, rawURL, namespace, name stri
 			}
 		}
 		return FetchResult{}, ra, retryable, fmt.Errorf("artifact server returned %d for %s/%s", resp.StatusCode, namespace, name)
+	}
+
+	if got := resp.Header.Get(ArtifactDigestHeader); got != expectedDigest {
+		return FetchResult{}, 0, true, fmt.Errorf("artifact server did not confirm OCI digest for %s/%s: expected %s, got %q", namespace, name, expectedDigest, got)
 	}
 
 	perm := fs.FileMode(0o755)

--- a/internal/pkg/artifact/fetch_test.go
+++ b/internal/pkg/artifact/fetch_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"testing/iotest"
@@ -32,6 +33,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testFetchDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
 
 func TestFetcher_FetchOCI(t *testing.T) {
 	tests := []struct {
@@ -49,8 +52,8 @@ func TestFetcher_FetchOCI(t *testing.T) {
 			artifactType: TypePlugin,
 			nodeName:     "node-1",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "linux", r.URL.Query().Get("os"))
-				assert.Equal(t, "amd64", r.URL.Query().Get("arch"))
+				assert.Equal(t, runtime.GOOS, r.URL.Query().Get("os"))
+				assert.Equal(t, runtime.GOARCH, r.URL.Query().Get("arch"))
 				w.Header().Set("X-Artifact-Mode", "493") // 0o755
 				_, _ = w.Write([]byte("binary-content"))
 			},
@@ -118,13 +121,15 @@ func TestFetcher_FetchOCI(t *testing.T) {
 			var nodeHeaderSeen string
 			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				nodeHeaderSeen = r.Header.Get(NodeNameHeader)
+				assert.Equal(t, testFetchDigest, r.URL.Query().Get("digest"))
+				w.Header().Set(ArtifactDigestHeader, testFetchDigest)
 				tt.handler(w, r)
 			}))
 			srv.Start()
 			defer srv.Close()
 
 			f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client(), NodeName: tt.nodeName}
-			result, err := f.FetchOCI(context.Background(), "ns", "name", tt.artifactType)
+			result, err := f.FetchOCI(context.Background(), "ns", "name", tt.artifactType, testFetchDigest)
 
 			if tt.wantErrContains != "" {
 				require.Error(t, err)
@@ -148,7 +153,7 @@ func TestFetcher_FetchOCI(t *testing.T) {
 
 func TestFetcher_FetchOCI_UnsupportedType(t *testing.T) {
 	f := &Fetcher{ServerURL: "http://example.invalid", HTTPClient: http.DefaultClient}
-	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeConfig)
+	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeConfig, testFetchDigest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support type")
 }
@@ -157,7 +162,7 @@ func TestFetcher_FetchOCI_RequestError(t *testing.T) {
 	// A ServerURL containing a raw control character makes http.NewRequestWithContext fail to build the request.
 	// The resulting error is permanent, not retryable.
 	f := &Fetcher{ServerURL: "http://\x7f", HTTPClient: http.DefaultClient}
-	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "build artifact server request")
 	var retryErr *RetryableError
@@ -169,7 +174,7 @@ func TestFetcher_FetchOCI_ClientDoError(t *testing.T) {
 	srv.Close() // closed before use: any request against it fails at the transport level
 
 	f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
-	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "artifact server request for ns/name")
 	// A transport-level failure is retryable; this test only checks the error message text.
@@ -182,14 +187,14 @@ func (errBodyTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(iotest.ErrReader(errors.New("body read error"))),
-		Header:     make(http.Header),
+		Header:     http.Header{ArtifactDigestHeader: []string{testFetchDigest}},
 	}, nil
 }
 
 func TestFetcher_FetchOCI_BodyReadError(t *testing.T) {
 	// A body-read failure is permanent and not retryable.
 	f := &Fetcher{ServerURL: "http://example.invalid", HTTPClient: &http.Client{Transport: errBodyTransport{}}}
-	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+	_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read artifact server response body")
 	var retryErr *RetryableError
@@ -210,7 +215,7 @@ func TestFetcher_FetchOCI_Retryable(t *testing.T) {
 		defer srv.Close()
 
 		f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
-		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 		require.Error(t, err)
 
 		var retryErr *RetryableError
@@ -226,7 +231,7 @@ func TestFetcher_FetchOCI_Retryable(t *testing.T) {
 		defer srv.Close()
 
 		f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
-		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 		require.Error(t, err)
 
 		var retryErr *RetryableError
@@ -239,7 +244,7 @@ func TestFetcher_FetchOCI_Retryable(t *testing.T) {
 		srv.Close() // closed before use: any request against it fails at the transport level
 
 		f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
-		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 		require.Error(t, err)
 
 		var retryErr *RetryableError
@@ -256,7 +261,7 @@ func TestFetcher_FetchOCI_Retryable(t *testing.T) {
 		defer srv.Close()
 
 		f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
-		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile)
+		_, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, testFetchDigest)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "returned 400")
 
@@ -289,4 +294,66 @@ func TestRequeueDelay(t *testing.T) {
 		assert.GreaterOrEqual(t, delay, DefaultRetryDelay)
 		assert.Less(t, delay, DefaultRetryDelay+DefaultRetryDelay/2)
 	})
+}
+
+func TestFetcher_FetchOCI_RequiresConfirmedDigest(t *testing.T) {
+	for _, artifactType := range []Type{TypePlugin, TypeRulesfile} {
+		t.Run(string(artifactType), func(t *testing.T) {
+			for _, tc := range []struct{ name, servedDigest string }{
+				{name: "older server without digest"},
+				{name: "different revision", servedDigest: "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+				{name: "confirmed revision", servedDigest: testFetchDigest},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					var calls atomic.Int32
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						calls.Add(1)
+						assert.Equal(t, testFetchDigest, r.URL.Query().Get("digest"))
+						if tc.servedDigest != "" {
+							w.Header().Set(ArtifactDigestHeader, tc.servedDigest)
+						}
+						_, _ = w.Write([]byte("artifact bytes"))
+					}))
+					defer srv.Close()
+					f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
+					result, err := f.FetchOCI(context.Background(), "ns", "name", artifactType, testFetchDigest)
+					assert.EqualValues(t, 1, calls.Load())
+					if tc.servedDigest != testFetchDigest {
+						var retryErr *RetryableError
+						require.ErrorAs(t, err, &retryErr)
+						require.Equal(t, FetchResult{}, result, "unconfirmed bytes must not reach the local store")
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, []byte("artifact bytes"), result.Content)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestFetcher_FetchOCI_RequiresResolvedDigest(t *testing.T) {
+	for _, tc := range []struct {
+		name, expectedDigest string
+		retryable            bool
+	}{
+		{name: "metadata not ready", retryable: true},
+		{name: "malformed digest", expectedDigest: "sha256:not-a-digest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+			f := &Fetcher{ServerURL: srv.URL, HTTPClient: srv.Client()}
+			result, err := f.FetchOCI(context.Background(), "ns", "name", TypeRulesfile, tc.expectedDigest)
+			require.Error(t, err)
+			require.Equal(t, FetchResult{}, result)
+			var retryErr *RetryableError
+			require.Equal(t, tc.retryable, errors.As(err, &retryErr))
+			require.Zero(t, calls.Load(), "never issue an unversioned request")
+		})
+	}
 }

--- a/internal/pkg/artifact/manager.go
+++ b/internal/pkg/artifact/manager.go
@@ -82,7 +82,9 @@ func NewManagerWithOptions(cl client.Client, namespace string, opts ...ManagerOp
 
 // FetchConfig fetches the OCI artifact config layer for ociArtifact without downloading the binary.
 // It returns the parsed ArtifactConfig (which contains plugin requirements) and the root manifest digest.
-func (am *Manager) FetchConfig(ctx context.Context, ociArtifact *commonv1alpha1.OCIArtifact) (*puller.ArtifactConfig, string, error) {
+// Pass knownDigest to read an already resolved revision; an empty value resolves the spec's
+// reference. Like EnsureBlob, a pinned fetch must return the requested root digest.
+func (am *Manager) FetchConfig(ctx context.Context, ociArtifact *commonv1alpha1.OCIArtifact, knownDigest string) (*puller.ArtifactConfig, string, error) {
 	secretRef := authSecretRef(ociArtifact)
 	authSecret, err := am.fetchOCIAuthSecret(ctx, secretRef)
 	if err != nil {
@@ -93,7 +95,20 @@ func (am *Manager) FetchConfig(ctx context.Context, ociArtifact *commonv1alpha1.
 		return nil, "", fmt.Errorf("derive credentials: %w", err)
 	}
 	ref := ResolveReference(ociArtifact)
-	return am.ociPuller.FetchConfig(ctx, ref, creds, ResolveRegistryOptions(ociArtifact))
+	if knownDigest != "" {
+		ref, err = pinReferenceToDigest(ref, knownDigest)
+		if err != nil {
+			return nil, "", fmt.Errorf("pin OCI reference: %w", err)
+		}
+	}
+	config, digest, err := am.ociPuller.FetchConfig(ctx, ref, creds, ResolveRegistryOptions(ociArtifact))
+	if err != nil {
+		return nil, "", err
+	}
+	if knownDigest != "" && digest != knownDigest {
+		return nil, "", fmt.Errorf("fetched OCI root digest %q does not match expected digest %q", digest, knownDigest)
+	}
+	return config, digest, nil
 }
 
 // FetchContent downloads the artifact content layer at the root digest returned by

--- a/internal/pkg/artifact/manager_fetch_test.go
+++ b/internal/pkg/artifact/manager_fetch_test.go
@@ -32,23 +32,62 @@ import (
 
 func TestManager_FetchConfig(t *testing.T) {
 	const testNamespace = "test-namespace"
+	const tagRef = "ghcr.io/example.com/myplugin:latest"
+	const pinnedRef = "ghcr.io/example.com/myplugin@" + testDigest
 
 	tests := []struct {
 		name         string
+		knownDigest  string
 		configResult *puller.ArtifactConfig
 		configDigest string
 		fetchErr     error
-		wantErr      bool
+		wantRef      string
+		wantErr      string
 	}{
 		{
 			name:         "fetches config successfully",
 			configResult: &puller.ArtifactConfig{Name: "myplugin", Version: "1.0.0"},
-			configDigest: "sha256:abc",
+			configDigest: testDigest,
+			wantRef:      tagRef,
 		},
 		{
 			name:     "puller error propagates",
 			fetchErr: fmt.Errorf("registry unreachable"),
-			wantErr:  true,
+			wantRef:  tagRef,
+			wantErr:  "registry unreachable",
+		},
+		{
+			name:         "reads the known digest instead of the mutable tag",
+			knownDigest:  testDigest,
+			configResult: &puller.ArtifactConfig{Name: "myplugin", Version: "1.0.0"},
+			configDigest: testDigest,
+			wantRef:      pinnedRef,
+		},
+		{
+			name:         "rejects a different root digest",
+			knownDigest:  testDigest,
+			configResult: &puller.ArtifactConfig{Name: "wrong-revision"},
+			configDigest: testOtherDigest,
+			wantRef:      pinnedRef,
+			wantErr:      "does not match expected digest",
+		},
+		{
+			name:        "rejects a missing root digest",
+			knownDigest: testDigest,
+			wantRef:     pinnedRef,
+			wantErr:     "does not match expected digest",
+		},
+		{
+			name:        "rejects an invalid known digest before fetching",
+			knownDigest: "sha256:short",
+			wantErr:     "pin OCI reference",
+		},
+		{
+			name:        "does not fall back to the tag when the pinned revision is unavailable",
+			knownDigest: testDigest,
+			fetchErr:    fmt.Errorf("manifest unavailable"),
+			wantRef:     pinnedRef,
+			wantErr:     "manifest unavailable",
 		},
 	}
 
@@ -64,12 +103,22 @@ func TestManager_FetchConfig(t *testing.T) {
 			}
 			manager := NewManagerWithOptions(fakeClient, testNamespace, WithOCIPuller(mockPuller))
 
-			cfg, digest, err := manager.FetchConfig(context.Background(), &commonv1alpha1.OCIArtifact{
+			ociArtifact := &commonv1alpha1.OCIArtifact{
 				Image: commonv1alpha1.ImageSpec{Repository: "example.com/myplugin", Tag: "latest"},
-			})
+			}
+			original := ociArtifact.DeepCopy()
+			cfg, digest, err := manager.FetchConfig(context.Background(), ociArtifact, tt.knownDigest)
+			assert.Equal(t, original, ociArtifact)
+			if tt.wantRef == "" {
+				assert.Empty(t, mockPuller.FetchConfigCalls)
+			} else {
+				assert.Equal(t, []string{tt.wantRef}, mockPuller.FetchConfigCalls)
+			}
 
-			if tt.wantErr {
-				require.Error(t, err)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, cfg)
+				assert.Empty(t, digest)
 				return
 			}
 			require.NoError(t, err)

--- a/internal/pkg/artifactcache/cache.go
+++ b/internal/pkg/artifactcache/cache.go
@@ -48,11 +48,20 @@ const (
 // For platform-specific artifacts (plugins) pass goos and goarch; for platform-agnostic
 // artifacts (rulesfiles) pass empty strings.
 func BlobPath(cacheDir, artifactType, ref, digest, goos, goarch string) string {
-	name := strings.ReplaceAll(digest, ":", "-")
+	platformKey := ""
 	if goos != "" && goarch != "" {
-		name = fmt.Sprintf("%s-%s-%s", name, goos, goarch)
+		platformKey = goos + "-" + goarch
 	}
-	return filepath.Join(cacheDir, BlobsDir, artifactType, RefToPath(ref), name)
+	return filepath.Join(cacheDir, BlobsDir, artifactType, RefToPath(ref), blobName(digest, platformKey))
+}
+
+// blobName is the immutable digest/platform identity shared by writes and lookups.
+func blobName(digest, platformKey string) string {
+	name := strings.ReplaceAll(digest, ":", "-")
+	if platformKey != "" {
+		name += "-" + platformKey
+	}
+	return name
 }
 
 // Store atomically writes content to blobPath and records perm in the companion .perm file.

--- a/internal/pkg/artifactcache/index.go
+++ b/internal/pkg/artifactcache/index.go
@@ -163,6 +163,18 @@ func (c *Cache) Lookup(artifactType, namespace, name, platformKey string) (blobP
 	return blobPath, ok
 }
 
+// LookupDigest returns the indexed blob only if it matches the requested OCI root digest
+// and platform. The caller must supply a validated digest. It uses the same immutable blob
+// name as BlobPath, so existing snapshots need no migration or additional metadata.
+// A subsequent index update cannot change the identity of the returned path.
+func (c *Cache) LookupDigest(artifactType, namespace, name, platformKey, digest string) (string, bool) {
+	blobPath, ok := c.Lookup(artifactType, namespace, name, platformKey)
+	if !ok || digest == "" || filepath.Base(blobPath) != blobName(digest, platformKey) {
+		return "", false
+	}
+	return blobPath, true
+}
+
 // BlobExists reports whether blobPath is still known to the cache: either actively referenced
 // by an index entry, or dereferenced but still within its eviction grace period. A blob written
 // to disk but not yet indexed (e.g. a crash between Store and Set) reports false.

--- a/internal/pkg/artifactcache/index_test.go
+++ b/internal/pkg/artifactcache/index_test.go
@@ -528,3 +528,52 @@ func TestCache_RemoveAll(t *testing.T) {
 		assert.True(t, os.IsNotExist(err))
 	})
 }
+
+func TestCache_LookupDigest(t *testing.T) {
+	oldDigest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	newDigest := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	for _, tc := range []struct{ artifactType, goos, goarch, platform string }{
+		{"plugin", "linux", "amd64", "linux-amd64"},
+		{"plugin", "linux", "arm64", "linux-arm64"},
+		{"rulesfile", "", "", ""},
+	} {
+		t.Run(tc.artifactType+"/"+tc.platform, func(t *testing.T) {
+			cache := artifactcache.NewCache(t.TempDir())
+			require.NoError(t, cache.Load())
+			oldPath := artifactcache.BlobPath(cache.Dir(), tc.artifactType, "repo:old", oldDigest, tc.goos, tc.goarch)
+			newPath := artifactcache.BlobPath(cache.Dir(), tc.artifactType, "repo:new", newDigest, tc.goos, tc.goarch)
+			require.NoError(t, cache.Store(oldPath, []byte("old"), 0o644))
+			require.NoError(t, cache.Store(newPath, []byte("new"), 0o644))
+			require.NoError(t, cache.Set(tc.artifactType, "ns", "name", tc.platform, oldPath))
+
+			// Existing snapshots already encode digest and platform in the immutable blob path.
+			reloaded := artifactcache.NewCache(cache.Dir())
+			require.NoError(t, reloaded.Load())
+			selected, ok := reloaded.LookupDigest(tc.artifactType, "ns", "name", tc.platform, oldDigest)
+			require.True(t, ok)
+			require.Equal(t, oldPath, selected)
+			for _, requested := range []string{"", newDigest} {
+				path, found := reloaded.LookupDigest(tc.artifactType, "ns", "name", tc.platform, requested)
+				require.False(t, found)
+				require.Empty(t, path)
+			}
+			_, ok = reloaded.LookupDigest(tc.artifactType, "other-ns", "name", tc.platform, oldDigest)
+			require.False(t, ok)
+			_, ok = reloaded.LookupDigest(tc.artifactType, "ns", "other-name", tc.platform, oldDigest)
+			require.False(t, ok)
+			_, ok = reloaded.LookupDigest(tc.artifactType, "ns", "name", "other-platform", oldDigest)
+			require.False(t, ok)
+
+			require.NoError(t, reloaded.Set(tc.artifactType, "ns", "name", tc.platform, newPath))
+			// A lookup made before the index update still identifies the old bytes, not the new slot.
+			content, err := os.ReadFile(selected)
+			require.NoError(t, err)
+			require.Equal(t, []byte("old"), content)
+			_, ok = reloaded.LookupDigest(tc.artifactType, "ns", "name", tc.platform, oldDigest)
+			require.False(t, ok)
+			current, ok := reloaded.LookupDigest(tc.artifactType, "ns", "name", tc.platform, newDigest)
+			require.True(t, ok)
+			require.Equal(t, newPath, current)
+		})
+	}
+}

--- a/internal/pkg/artifactserver/server.go
+++ b/internal/pkg/artifactserver/server.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opencontainers/go-digest"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -241,10 +242,15 @@ func (s *Server) servePlugin(w http.ResponseWriter, r *http.Request) {
 	logger.V(1).Info("Artifact request received")
 
 	platformKey := goos + "-" + goarch
-	blobPath, ok := s.cache.Lookup("plugin", ns, name, platformKey)
+	blobPath, ok, err := s.lookupRequestedBlob(r, "plugin", ns, name, platformKey)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		requestsTotal.WithLabelValues("plugin", strconv.Itoa(http.StatusBadRequest)).Inc()
+		return
+	}
 	if !ok {
 		cacheLookupsTotal.WithLabelValues("plugin", "miss").Inc()
-		logger.Info("Plugin not yet cached; waiting for aggregator reconcile")
+		logger.Info("Requested plugin revision not yet cached; waiting for aggregator reconcile")
 		w.Header().Set("Retry-After", "10")
 		http.Error(w, "artifact not yet available; retry shortly", http.StatusServiceUnavailable)
 		requestsTotal.WithLabelValues("plugin", strconv.Itoa(http.StatusServiceUnavailable)).Inc()
@@ -286,10 +292,15 @@ func (s *Server) serveRulesfile(w http.ResponseWriter, r *http.Request) {
 	)
 	logger.V(1).Info("Artifact request received")
 
-	blobPath, ok := s.cache.Lookup("rulesfile", ns, name, "")
+	blobPath, ok, err := s.lookupRequestedBlob(r, "rulesfile", ns, name, "")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(http.StatusBadRequest)).Inc()
+		return
+	}
 	if !ok {
 		cacheLookupsTotal.WithLabelValues("rulesfile", "miss").Inc()
-		logger.Info("Rulesfile not yet cached; waiting for aggregator reconcile")
+		logger.Info("Requested rulesfile revision not yet cached; waiting for aggregator reconcile")
 		w.Header().Set("Retry-After", "10")
 		http.Error(w, "artifact not yet available; retry shortly", http.StatusServiceUnavailable)
 		requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(http.StatusServiceUnavailable)).Inc()
@@ -302,6 +313,22 @@ func (s *Server) serveRulesfile(w http.ResponseWriter, r *http.Request) {
 	status := serveBlob(w, r, blobPath)
 	requestsTotal.WithLabelValues("rulesfile", strconv.Itoa(status)).Inc()
 	requestDuration.WithLabelValues("rulesfile").Observe(time.Since(start).Seconds())
+}
+
+// lookupRequestedBlob binds a named cache entry to the requested immutable digest.
+// Requests without a digest retain the legacy behavior during sidecar upgrades. New clients
+// always supply a digest and reject responses from older servers that cannot confirm it.
+func (s *Server) lookupRequestedBlob(r *http.Request, artifactType, namespace, name, platformKey string) (blobPath string, ok bool, err error) {
+	values, supplied := r.URL.Query()["digest"]
+	if !supplied {
+		path, ok := s.cache.Lookup(artifactType, namespace, name, platformKey)
+		return path, ok, nil
+	}
+	if len(values) != 1 || digest.Digest(values[0]).Validate() != nil {
+		return "", false, fmt.Errorf("digest must be a single valid OCI digest")
+	}
+	path, ok := s.cache.LookupDigest(artifactType, namespace, name, platformKey, values[0])
+	return path, ok, nil
 }
 
 // statusCapturingWriter wraps an http.ResponseWriter and records the status code written,
@@ -339,6 +366,10 @@ func serveBlob(w http.ResponseWriter, r *http.Request, blobPath string) int {
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("X-Artifact-Mode", strconv.FormatUint(uint64(perm), 10))
+	if expectedDigest := r.URL.Query().Get("digest"); expectedDigest != "" {
+		// The handler verified this digest against the immutable path before opening it.
+		w.Header().Set(artifact.ArtifactDigestHeader, expectedDigest)
+	}
 
 	sw := &statusCapturingWriter{ResponseWriter: w, status: http.StatusOK}
 	http.ServeContent(sw, r, filepath.Base(blobPath), stat.ModTime(), f)

--- a/internal/pkg/artifactserver/server_test.go
+++ b/internal/pkg/artifactserver/server_test.go
@@ -608,3 +608,67 @@ func TestServer_Start_ClientCAsWithoutTLS_ReturnsConfigError(t *testing.T) {
 	require.Error(t, startErr)
 	assert.Contains(t, startErr.Error(), "client CAs configured without a TLS certificate watcher")
 }
+
+func TestServer_ServeRequestedDigest(t *testing.T) {
+	const amd64Arch = "amd64"
+	const arm64Arch = "arm64"
+	const expectedDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	const otherDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	for _, variant := range []struct{ artifactType, goos, goarch, platform, path string }{
+		{"plugin", "linux", amd64Arch, "linux-amd64", "/v1/artifacts/plugins/ns/name?os=linux&arch=amd64"},
+		{"plugin", "linux", arm64Arch, "linux-arm64", "/v1/artifacts/plugins/ns/name?os=linux&arch=arm64"},
+		{"rulesfile", "", "", "", "/v1/artifacts/rulesfiles/ns/name?"},
+	} {
+		t.Run(variant.artifactType+"/"+variant.platform, func(t *testing.T) {
+			cache := artifactcache.NewCache(t.TempDir())
+			require.NoError(t, cache.Load())
+			blob := artifactcache.BlobPath(cache.Dir(), variant.artifactType, "repo:tag", expectedDigest, variant.goos, variant.goarch)
+			content := "bytes for " + variant.artifactType + "/" + variant.platform
+			require.NoError(t, cache.Store(blob, []byte(content), 0o644))
+			require.NoError(t, cache.Set(variant.artifactType, "ns", "name", variant.platform, blob))
+			// A plugin index digest is shared across platforms, but the extracted binaries are not.
+			if variant.artifactType == "plugin" {
+				otherArch := arm64Arch
+				if variant.goarch == arm64Arch {
+					otherArch = amd64Arch
+				}
+				otherPath := artifactcache.BlobPath(cache.Dir(), "plugin", "repo:tag", expectedDigest, "linux", otherArch)
+				require.NoError(t, cache.Store(otherPath, []byte("wrong architecture"), 0o755))
+				require.NoError(t, cache.Set("plugin", "ns", "name", "linux-"+otherArch, otherPath))
+			}
+			handler := artifactserver.New(cache).Handler()
+			for _, tc := range []struct {
+				name, query string
+				status      int
+				confirmed   bool
+			}{
+				{"expected revision", "&digest=" + expectedDigest, http.StatusOK, true},
+				{"different revision", "&digest=" + otherDigest, http.StatusServiceUnavailable, false},
+				{"empty digest", "&digest=", http.StatusBadRequest, false},
+				{"malformed digest", "&digest=sha256:invalid", http.StatusBadRequest, false},
+				{"duplicate digest", "&digest=" + expectedDigest + "&digest=" + otherDigest, http.StatusBadRequest, false},
+				{"legacy client", "", http.StatusOK, false},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, variant.path+tc.query, http.NoBody)
+					response := httptest.NewRecorder()
+					handler.ServeHTTP(response, request)
+					require.Equal(t, tc.status, response.Code)
+					if tc.status == http.StatusOK {
+						require.Equal(t, content, response.Body.String())
+					} else {
+						require.NotContains(t, response.Body.String(), content)
+					}
+					if tc.confirmed {
+						require.Equal(t, expectedDigest, response.Header().Get(artifact.ArtifactDigestHeader))
+					} else {
+						require.Empty(t, response.Header().Get(artifact.ArtifactDigestHeader))
+					}
+					if tc.status == http.StatusServiceUnavailable {
+						require.Equal(t, "10", response.Header().Get("Retry-After"))
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area instance-operator
/area artifact-operator
/area pkg

**What this PR does / why we need it**:

Ensure nodes receive the OCI revision recorded by the instance operator. If that revision is not available in the artifact cache yet, installation waits and preserves the existing file.

Keep the resolved OCI digest when Rulesfile ConfigMap or inline sources change, so those edits do not unexpectedly refresh floating tags.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

During upgrades, update the instance operator before the artifact operators.
