### PR TITLE
artifact-operator: recover installed artifacts on sidecar restart

### DIFF
--- a/controllers/artifact/config/controller.go
+++ b/controllers/artifact/config/controller.go
@@ -122,6 +122,8 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	// Patch node object status via defer to ensure it's always called.
 	// Programmed is derived here as a gateway: True only when all other conditions are True.
 	defer func() {
+		key := nodeartifacts.KeyFromObj(nodeartifacts.KindConfig, config)
+		r.store.SyncAllInstalledStatus(key, []artifact.Medium{artifact.MediumInline, artifact.MediumConfigMap}, &nodeObj.Status.InstalledArtifacts)
 		apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.ComputeProgrammedCondition(
 			nodeObj.Status.Conditions, nil,
 			artifact.ReasonProgrammed, artifact.MessageProgrammed, artifact.ReasonProgramFailed,
@@ -187,7 +189,17 @@ func (r *ConfigReconciler) handleDeletion(ctx context.Context, nodeObj *artifact
 
 	logger.Info("ConfigNode marked for deletion, cleaning up")
 
-	if err := r.store.Remove(ctx, nodeObj.Status.InstalledArtifacts); err != nil {
+	var configName string
+	for _, ref := range nodeObj.OwnerReferences {
+		if ref.Kind == controllerhelper.KindConfig {
+			configName = ref.Name
+			break
+		}
+	}
+	// OwnerReferences never carry a namespace; nodeObj's own namespace is the config's.
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Namespace: nodeObj.Namespace, Name: configName}
+
+	if err := r.store.Remove(ctx, key, r.store.GetInstalled(key)); err != nil {
 		logger.Error(err, "unable to remove installed config artifacts from disk")
 		return false, err
 	}
@@ -295,12 +307,14 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 	gen := config.GetGeneration()
 	logger := log.FromContext(ctx)
 	p := config.Spec.Priority
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindConfig, config)
 
 	// Stale-entry cleanup: remove files and conditions for mediums no longer in spec.
 	if config.Spec.Config == nil {
 		apimeta.RemoveStatusCondition(&nodeObj.Status.Conditions, commonv1alpha1.ConditionInlineArtifactProgrammed.String())
-		if existing := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumInline); existing != nil {
-			if err := r.store.Remove(ctx, []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(artifact.MediumInline)}}); err != nil {
+		if existing := r.store.FindInstalled(key, artifact.MediumInline); existing != nil {
+			toRemove := []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(artifact.MediumInline)}}
+			if err := r.store.Remove(ctx, key, toRemove); err != nil {
 				logger.Error(err, "unable to remove stale inline config")
 				return err
 			}
@@ -309,8 +323,9 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 	}
 	if config.Spec.ConfigMapRef == nil {
 		apimeta.RemoveStatusCondition(&nodeObj.Status.Conditions, commonv1alpha1.ConditionConfigMapArtifactProgrammed.String())
-		if existing := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumConfigMap); existing != nil {
-			if err := r.store.Remove(ctx, []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(artifact.MediumConfigMap)}}); err != nil {
+		if existing := r.store.FindInstalled(key, artifact.MediumConfigMap); existing != nil {
+			toRemove := []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(artifact.MediumConfigMap)}}
+			if err := r.store.Remove(ctx, key, toRemove); err != nil {
 				logger.Error(err, "unable to remove stale configmap config")
 				return err
 			}
@@ -342,8 +357,7 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 				))
 				return err
 			}
-			current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumInline)
-			inlineAction, newFile, err := r.store.Store(ctx, current, config.Name, p, artifact.TypeConfig, artifact.MediumInline, result)
+			inlineAction, _, err := r.store.Store(ctx, config.Namespace, config.Name, p, artifact.TypeConfig, artifact.MediumInline, result)
 			if err != nil {
 				logger.Error(err, "unable to store inline config")
 				artifact.RecordWarning(r.recorder, config, artifact.ReasonInlineConfigStoreFailed, artifact.MessageFormatConfigStoreFailed, err.Error())
@@ -353,7 +367,7 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 				))
 				return err
 			}
-			artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, inlineAction, artifact.MediumInline, newFile)
+			r.store.SyncInstalledStatus(key, artifact.MediumInline, &nodeObj.Status.InstalledArtifacts)
 			artifact.RecordStoreEvent(r.recorder, config, inlineAction, artifact.MediumInline)
 		}
 		apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewInlineArtifactProgrammedCondition(
@@ -374,8 +388,7 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 			))
 			return err
 		}
-		current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumConfigMap)
-		cmAction, newFile, err := r.store.Store(ctx, current, config.Name, p, artifact.TypeConfig, artifact.MediumConfigMap, result)
+		cmAction, _, err := r.store.Store(ctx, config.Namespace, config.Name, p, artifact.TypeConfig, artifact.MediumConfigMap, result)
 		if err != nil {
 			logger.Error(err, "unable to store config from ConfigMap reference")
 			artifact.RecordWarning(r.recorder, config,
@@ -386,7 +399,7 @@ func (r *ConfigReconciler) ensureConfig(ctx context.Context, config *artifactv1a
 			))
 			return err
 		}
-		artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, cmAction, artifact.MediumConfigMap, newFile)
+		r.store.SyncInstalledStatus(key, artifact.MediumConfigMap, &nodeObj.Status.InstalledArtifacts)
 		artifact.RecordStoreEvent(r.recorder, config, cmAction, artifact.MediumConfigMap)
 		apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewConfigMapArtifactProgrammedCondition(
 			metav1.ConditionTrue, artifact.ReasonConfigMapArtifactProgrammed, artifact.MessageConfigMapArtifactProgrammed, gen,

--- a/controllers/artifact/config/controller_test.go
+++ b/controllers/artifact/config/controller_test.go
@@ -149,16 +149,47 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*ConfigReconciler, 
 		Build()
 
 	mockFS := fsfake.NewMockFileSystem()
+	store := nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
+	seedInstalledCacheFromObjs(store, objs)
 
 	return &ConfigReconciler{
 		Client:    cl,
 		Scheme:    s,
 		recorder:  events.NewFakeRecorder(100),
 		fetcher:   newTestFetcher(cl),
-		store:     nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil)),
+		store:     store,
 		nodeName:  testutil.TestNodeName,
 		namespace: testutil.TestNamespace,
 	}, cl
+}
+
+// seedInstalledCacheFromObjs mirrors what WarmSync does at startup: any pre-set
+// ArtifactNode.Status.InstalledArtifacts among objs is seeded into store's installed-artifact
+// cache, keyed by the owning Rulesfile/Plugin/Config's Kind+Name. Filesystem decisions are made
+// from that cache, never from status, so a test simulating "this was already installed" must
+// seed the cache the same way a real restart would, not just set status on the object.
+func seedInstalledCacheFromObjs(store *nodeartifacts.Manager, objs []client.Object) {
+	for _, obj := range objs {
+		node, ok := obj.(*artifactv1alpha1.ArtifactNode)
+		if !ok || len(node.Status.InstalledArtifacts) == 0 {
+			continue
+		}
+		for _, ref := range node.OwnerReferences {
+			var kind nodeartifacts.Kind
+			switch ref.Kind {
+			case controllerhelper.KindRulesfile:
+				kind = nodeartifacts.KindRulesfile
+			case controllerhelper.KindPlugin:
+				kind = nodeartifacts.KindPlugin
+			case controllerhelper.KindConfig:
+				kind = nodeartifacts.KindConfig
+			default:
+				continue
+			}
+			store.SeedInstalled(nodeartifacts.Key{Kind: kind, Namespace: node.Namespace, Name: ref.Name}, node.Status.InstalledArtifacts)
+			break
+		}
+	}
 }
 
 func TestNewConfigReconciler(t *testing.T) {
@@ -738,6 +769,48 @@ func TestEnsureConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnsureConfig_SyncsStatusFromCacheEvenWhenStatusStartsEmpty covers the case where the
+// manager's cache (seeded from disk by WarmSync, or surviving a status patch dropped by an SSA
+// conflict) already considers the inline config installed and unchanged, but this specific
+// ArtifactNode's own Status.InstalledArtifacts starts empty. ensureConfig must still populate
+// status from the cache, not only when Store returns a fresh Added/Updated action.
+func TestEnsureConfig_SyncsStatusFromCacheEvenWhenStatusStartsEmpty(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	mockFS := fsfake.NewMockFileSystem()
+	r.store = nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
+
+	path := artifact.ArtifactPath(artifact.DefaultArtifactDirs(), testConfigName, 50, artifact.MediumInline, artifact.TypeConfig)
+	content := []byte(testConfigYAML)
+	hash := sha256hexForTest(content)
+	mockFS.Files[path] = content
+
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Namespace: testutil.TestNamespace, Name: testConfigName}
+	r.store.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{
+		{Path: path, Medium: string(artifact.MediumInline), Priority: 50, ContentHash: hash},
+	})
+
+	config := &artifactv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{Name: testConfigName, Namespace: testutil.TestNamespace, Generation: 1},
+		Spec: artifactv1alpha1.ConfigSpec{
+			Config:   &apiextensionsv1.JSON{Raw: []byte(testConfigJSON)},
+			Priority: 50,
+		},
+	}
+	nodeObj := newTestConfigNodeObj() // Status.InstalledArtifacts starts nil, unlike the cache.
+
+	require.NoError(t, r.ensureConfig(context.Background(), config, nodeObj))
+
+	entry := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumInline)
+	require.NotNil(t, entry, "status must be synced from the cache even when Store returns Unchanged")
+	assert.Equal(t, path, entry.Path)
+	assert.Equal(t, hash, entry.ContentHash)
+}
+
+func sha256hexForTest(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
 }
 
 // TestEnsureConfig_ProgrammedLastTransitionTime verifies LastTransitionTime stays put on a

--- a/controllers/artifact/plugin/controller.go
+++ b/controllers/artifact/plugin/controller.go
@@ -131,6 +131,10 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	// Programmed is a gateway condition: True only when all other conditions are True. In advise
 	// mode, DependenciesSatisfied is excluded from the gate since it's advisory only.
 	defer func() {
+		r.store.SyncAllInstalledStatus(
+			nodeartifacts.KeyFromObj(nodeartifacts.KindPlugin, plugin),
+			[]artifact.Medium{artifact.MediumOCI}, &nodeObj.Status.InstalledArtifacts,
+		)
 		skipDependenciesSatisfied := func(condType string) bool {
 			return !r.enforceRequirements && condType == commonv1alpha1.ConditionDependenciesSatisfied.String()
 		}
@@ -179,7 +183,8 @@ func (r *PluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		// Plugin-level status show ConfigProgrammed=True even when DependenciesSatisfied=False.
 		// When alreadyInstalled=true (update-rejected), the old version is still on disk and
 		// ConfigProgrammed/OCIArtifactProgrammed correctly remain True; don't touch them.
-		if artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI) == nil {
+		key := nodeartifacts.KeyFromObj(nodeartifacts.KindPlugin, plugin)
+		if r.store.FindInstalled(key, artifact.MediumOCI) == nil {
 			depCond := apimeta.FindStatusCondition(nodeObj.Status.Conditions,
 				commonv1alpha1.ConditionDependenciesSatisfied.String())
 			reason := artifact.ReasonDependenciesNotSatisfied
@@ -287,8 +292,10 @@ func (r *PluginReconciler) handleDeletion(ctx context.Context, nodeObj *artifact
 		}
 	}
 
-	// Binary second: remove the plugin binary from disk.
-	if err := r.store.Remove(ctx, nodeObj.Status.InstalledArtifacts); err != nil {
+	// Binary second: remove the plugin binary from disk. OwnerReferences never carry a
+	// namespace; nodeObj's own namespace is the plugin's.
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindPlugin, Namespace: nodeObj.Namespace, Name: pluginName}
+	if err := r.store.Remove(ctx, key, r.store.GetInstalled(key)); err != nil {
 		logger.Error(err, "unable to remove installed plugin artifacts from disk")
 		return false, err
 	}
@@ -411,15 +418,17 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 	gen := plugin.GetGeneration()
 	logger := log.FromContext(ctx)
 
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindPlugin, plugin)
+
 	if plugin.Spec.OCIArtifact == nil {
 		// OCI spec removed while the Plugin CR still exists: removes the config entry, then the
 		// binary.
-		if existing := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI); existing != nil {
+		if existing := r.store.FindInstalled(key, artifact.MediumOCI); existing != nil {
 			if err := r.store.RemovePluginConfig(ctx, r.fetcher, plugin); err != nil {
 				logger.Error(err, "unable to remove plugin config during OCI spec removal")
 				return err
 			}
-			if err := r.store.Remove(ctx, []artifactv1alpha1.InstalledArtifact{
+			if err := r.store.Remove(ctx, key, []artifactv1alpha1.InstalledArtifact{
 				{Path: existing.Path, Medium: string(existing.Medium)},
 			}); err != nil {
 				logger.Error(err, "unable to remove stale plugin binary")
@@ -440,7 +449,7 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 		parentSpecHash = plugin.Status.ArtifactMeta.SpecHash
 		expectedDigest = plugin.Status.ArtifactMeta.Digest
 	}
-	current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
+	current := r.store.FindInstalled(key, artifact.MediumOCI)
 
 	// Fetches from the artifact server unless the spec hash is unchanged and the disk file is
 	// intact.
@@ -452,6 +461,10 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 			logger.V(4).Info("plugin artifact missing or corrupted on disk; re-fetching")
 		} else {
 			logger.V(4).Info("plugin artifact verified on disk; skipping fetch")
+			// Mirrors the cache into status even though this reconcile didn't call Store: see
+			// Manager.SyncInstalledStatus's doc comment for why a write gated on a StoreAction
+			// would leave status permanently behind the cache.
+			r.store.SyncInstalledStatus(key, artifact.MediumOCI, &nodeObj.Status.InstalledArtifacts)
 			apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewOCIArtifactProgrammedCondition(
 				metav1.ConditionTrue, artifact.ReasonOCIArtifactProgrammed, artifact.MessageOCIArtifactProgrammed, gen,
 			))
@@ -469,7 +482,8 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 		))
 		return err
 	}
-	ociAction, newFile, err := r.store.Store(ctx, current, plugin.Name, priority.DefaultPriority, artifact.TypePlugin, artifact.MediumOCI, result)
+	ociAction, _, err := r.store.Store(ctx, plugin.Namespace, plugin.Name, priority.DefaultPriority,
+		artifact.TypePlugin, artifact.MediumOCI, result)
 	if err != nil {
 		logger.Error(err, "unable to store plugin artifact")
 		artifact.RecordWarning(r.recorder, plugin, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
@@ -479,9 +493,9 @@ func (r *PluginReconciler) ensurePlugin(ctx context.Context, plugin *artifactv1a
 		))
 		return err
 	}
-	artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, ociAction, artifact.MediumOCI, newFile)
 	// Persist specHash even when StoreActionUnchanged (same content, different spec).
-	artifact.UpdateInstalledSpecHash(&nodeObj.Status.InstalledArtifacts, artifact.MediumOCI, parentSpecHash)
+	r.store.UpdateInstalledSpecHash(key, artifact.MediumOCI, parentSpecHash)
+	r.store.SyncInstalledStatus(key, artifact.MediumOCI, &nodeObj.Status.InstalledArtifacts)
 	artifact.RecordStoreEvent(r.recorder, plugin, ociAction, artifact.MediumOCI)
 	apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewOCIArtifactProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonOCIArtifactProgrammed, artifact.MessageOCIArtifactProgrammed, gen,
@@ -534,6 +548,7 @@ func (r *PluginReconciler) enforcePluginCompatibility(
 ) (bool, error) {
 	gen := plugin.GetGeneration()
 	logger := log.FromContext(ctx)
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindPlugin, plugin)
 
 	if plugin.Spec.OCIArtifact == nil {
 		logger.Info("Skipping compatibility check: no OCI artifact configured")
@@ -561,7 +576,7 @@ func (r *PluginReconciler) enforcePluginCompatibility(
 		if r.enforceRequirements {
 			baseMsg := "artifact metadata declares no requirements; installation blocked in enforce mode"
 			reason, msg := artifact.ReasonDependenciesUnknown, baseMsg
-			if artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI) != nil {
+			if r.store.FindInstalled(key, artifact.MediumOCI) != nil {
 				reason = artifact.ReasonDependenciesNotSatisfiedUpdateRejected
 				msg = baseMsg + artifact.MessageSuffixUpdateRejected
 			}
@@ -578,7 +593,7 @@ func (r *PluginReconciler) enforcePluginCompatibility(
 		return false, nil
 	}
 
-	alreadyInstalled := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI) != nil
+	alreadyInstalled := r.store.FindInstalled(key, artifact.MediumOCI) != nil
 	for _, req := range plugin.Status.ArtifactMeta.Requirements {
 		provided, found, ok, semverErr := r.store.CheckRequirement(req.Name, req.Version)
 		if semverErr != nil {
@@ -647,8 +662,7 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 	logger := log.FromContext(ctx)
 	logger.Info("Ensuring plugin configuration")
 
-	configCurrent := artifact.FindInstalledConfig(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
-	configAction, configFile, err := r.store.AddPluginConfig(ctx, plugin, configCurrent, r.fetcher)
+	configAction, _, err := r.store.AddPluginConfig(ctx, plugin, r.fetcher)
 	if err != nil {
 		if blocked, ok := errors.AsType[*nodeartifacts.BlockedError](err); ok {
 			logger.Info("Plugin config rename deferred: old name still required by a Rulesfile on this node",
@@ -665,9 +679,15 @@ func (r *PluginReconciler) ensurePluginConfig(ctx context.Context, plugin *artif
 		return err
 	}
 
-	// Both helpers below no-op when configFile is nil (StoreActionUnchanged/StoreActionNone).
 	artifact.RecordStoreEvent(r.recorder, plugin, configAction, artifact.MediumInline)
-	artifact.UpdateInstalledConfig(&nodeObj.Status.InstalledArtifacts, artifact.MediumOCI, configFile)
+	// Mirrors the shared config file's current path from the manager's cache (keyed by
+	// PluginConfigKey, not per-Plugin-CR status) unconditionally, regardless of configAction: a
+	// re-add the cache already knows is unchanged must still populate this Plugin's own Config
+	// sub-entry if an earlier reconcile's status patch never landed. UpdateInstalledConfig no-ops
+	// if there's no matching OCI entry yet (the binary itself isn't tracked) or the cache has none.
+	if sharedFile := r.store.FindInstalled(nodeartifacts.PluginConfigKey, artifact.MediumInline); sharedFile != nil {
+		artifact.UpdateInstalledConfig(&nodeObj.Status.InstalledArtifacts, artifact.MediumOCI, sharedFile)
+	}
 	apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewConfigProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonConfigProgrammed, artifact.MessageConfigProgrammed, gen,
 	))

--- a/controllers/artifact/plugin/controller_test.go
+++ b/controllers/artifact/plugin/controller_test.go
@@ -166,15 +166,46 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*PluginReconciler, 
 		Build()
 
 	mockFS := fsfake.NewMockFileSystem()
+	store := nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
+	seedInstalledCacheFromObjs(store, objs)
 
 	return &PluginReconciler{
 		Client:   cl,
 		Scheme:   s,
 		recorder: events.NewFakeRecorder(100),
 		fetcher:  newTestFetcher(cl),
-		store:    nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil)),
+		store:    store,
 		nodeName: testutil.TestNodeName,
 	}, cl
+}
+
+// seedInstalledCacheFromObjs mirrors what WarmSync does at startup: any pre-set
+// ArtifactNode.Status.InstalledArtifacts among objs is seeded into store's installed-artifact
+// cache, keyed by the owning Rulesfile/Plugin/Config's Kind+Name. Filesystem decisions are made
+// from that cache, never from status, so a test simulating "this was already installed" must
+// seed the cache the same way a real restart would, not just set status on the object.
+func seedInstalledCacheFromObjs(store *nodeartifacts.Manager, objs []client.Object) {
+	for _, obj := range objs {
+		node, ok := obj.(*artifactv1alpha1.ArtifactNode)
+		if !ok || len(node.Status.InstalledArtifacts) == 0 {
+			continue
+		}
+		for _, ref := range node.OwnerReferences {
+			var kind nodeartifacts.Kind
+			switch ref.Kind {
+			case controllerhelper.KindRulesfile:
+				kind = nodeartifacts.KindRulesfile
+			case controllerhelper.KindPlugin:
+				kind = nodeartifacts.KindPlugin
+			case controllerhelper.KindConfig:
+				kind = nodeartifacts.KindConfig
+			default:
+				continue
+			}
+			store.SeedInstalled(nodeartifacts.Key{Kind: kind, Namespace: node.Namespace, Name: ref.Name}, node.Status.InstalledArtifacts)
+			break
+		}
+	}
 }
 
 func TestNewPluginReconciler(t *testing.T) {
@@ -520,7 +551,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if tt.preInstallPlugin != nil {
-				_, _, err := r.store.AddPluginConfig(context.Background(), tt.preInstallPlugin, nil, r.fetcher)
+				_, _, err := r.store.AddPluginConfig(context.Background(), tt.preInstallPlugin, r.fetcher)
 				require.NoError(t, err)
 			}
 
@@ -561,6 +592,41 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReconcile_SecondReconcileDoesNotDropConfigSubEntry covers repeated back-to-back reconciles
+// for the same PluginNode with nothing in the spec changed (e.g. a watch event bounce): the
+// second Reconcile call must not lose the Config sub-entry a prior reconcile already established
+// in installedArtifacts[0].config.
+func TestReconcile_SecondReconcileDoesNotDropConfigSubEntry(t *testing.T) {
+	plugin := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: testPluginName, Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.PluginSpec{
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/plugins/container", Tag: "latest"},
+			},
+		},
+	}
+	nodeObj := newTestPluginNodeObj(withPluginFinalizer(), withPluginOwnerRef())
+	r, cl := newTestReconciler(t, plugin, nodeObj)
+	req := testutil.Request(testPluginNodeName())
+
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), req.NamespacedName, got))
+	require.Len(t, got.Status.InstalledArtifacts, 1, "after the first reconcile")
+	require.NotNil(t, got.Status.InstalledArtifacts[0].Config, "Config must be set after the first reconcile")
+
+	// Second reconcile: nothing changed in the spec, simulating a watch event bounce (e.g. a
+	// Secret or unrelated ArtifactNode update re-enqueuing this object).
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	require.NoError(t, cl.Get(context.Background(), req.NamespacedName, got))
+	require.Len(t, got.Status.InstalledArtifacts, 1, "after the second reconcile")
+	assert.NotNil(t, got.Status.InstalledArtifacts[0].Config, "second reconcile must not drop the Config sub-entry")
 }
 
 func TestHandleDeletion(t *testing.T) {
@@ -625,7 +691,7 @@ func TestHandleDeletion(t *testing.T) {
 			r, cl := newTestReconciler(t, tt.objects...)
 
 			if tt.preInstallPlugin != nil {
-				_, _, err := r.store.AddPluginConfig(context.Background(), tt.preInstallPlugin, nil, r.fetcher)
+				_, _, err := r.store.AddPluginConfig(context.Background(), tt.preInstallPlugin, r.fetcher)
 				require.NoError(t, err)
 			}
 
@@ -940,6 +1006,45 @@ func TestEnsurePluginConfig(t *testing.T) {
 			testutil.RequireEvents(t, r.recorder.(*events.FakeRecorder).Events, tt.wantEvents)
 		})
 	}
+}
+
+// TestEnsurePluginConfig_PopulatesConfigSubEntryEvenWhenUnchanged covers the shared
+// plugins-config aggregate, tracked in the manager's own cache (keyed by PluginConfigKey) rather
+// than per-Plugin-CR status: a re-add that the cache already knows is unchanged must still
+// mirror the file's path into this Plugin's own status entry, not only on the reconcile that
+// first wrote it.
+func TestEnsurePluginConfig_PopulatesConfigSubEntryEvenWhenUnchanged(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	plugin := &artifactv1alpha1.Plugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "json", Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.PluginSpec{
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/plugins/json", Tag: "latest"},
+			},
+		},
+	}
+	// Establishes the shared config file in the manager's cache (StoreActionAdded).
+	require.NoError(t, r.ensurePluginConfig(context.Background(), plugin, newTestPluginNodeObj()))
+
+	// A separate nodeObj whose status never recorded the Config sub-entry (e.g. an earlier status
+	// patch dropped by an SSA conflict), even though the OCI binary entry already exists and the
+	// shared file, per the cache, is unchanged (configAction will be StoreActionUnchanged).
+	nodeObj := newTestPluginNodeObj()
+	nodeObj.Status.InstalledArtifacts = []artifactv1alpha1.InstalledArtifact{
+		{Path: "/usr/share/falco/plugins/json.so", Medium: string(artifact.MediumOCI)},
+	}
+
+	require.NoError(t, r.ensurePluginConfig(context.Background(), plugin, nodeObj))
+
+	var configEntry *artifactv1alpha1.InstalledArtifactConfig
+	for _, a := range nodeObj.Status.InstalledArtifacts {
+		if a.Medium == string(artifact.MediumOCI) {
+			configEntry = a.Config
+			break
+		}
+	}
+	require.NotNil(t, configEntry, "Config sub-entry must be populated from the cache even when configAction is Unchanged")
+	assert.NotEmpty(t, configEntry.Path)
 }
 
 func TestEnforceReferenceResolution(t *testing.T) {
@@ -1340,9 +1445,13 @@ func TestEnforcePluginCompatibility(t *testing.T) {
 			}
 			nodeObj := newTestPluginNodeObj()
 			if tt.preInstalled {
-				nodeObj.Status.InstalledArtifacts = []artifactv1alpha1.InstalledArtifact{
+				installed := []artifactv1alpha1.InstalledArtifact{
 					{Path: "/var/lib/falco/plugins/test.so", Medium: string(artifact.MediumOCI)},
 				}
+				nodeObj.Status.InstalledArtifacts = installed
+				// alreadyInstalled is read from the manager's cache, not status; seed it the way
+				// WarmSync would from a real restart.
+				r.store.SeedInstalled(nodeartifacts.Key{Kind: nodeartifacts.KindPlugin, Namespace: testutil.TestNamespace, Name: testPluginName}, installed)
 			}
 
 			skip, err := r.enforcePluginCompatibility(context.Background(), tt.plugin, nodeObj)
@@ -1405,7 +1514,7 @@ func TestHandleDeletion_BlockedByRequiringRulesfileDoesNotRemoveFinalizer(t *tes
 	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: nodeObj.Name, Namespace: nodeObj.Namespace}, nodeObj))
 
 	// Simulate config already installed for this plugin (as if a prior reconcile ran).
-	_, _, err := r.store.AddPluginConfig(context.Background(), pl, nil, r.fetcher)
+	_, _, err := r.store.AddPluginConfig(context.Background(), pl, r.fetcher)
 	require.NoError(t, err)
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "some-rulesfile"}
 	r.store.Sync(rfKey, []nodeartifacts.RequirementGroup{{{Name: testPluginName, Version: "1.0.0"}}})
@@ -1452,11 +1561,11 @@ func TestReconcile_BlockedDeletionDoesNotInstall(t *testing.T) {
 			}
 			node := newTestPluginNodeObj(withPluginOwnerRef(), withPluginFinalizer())
 			r, cl := newTestReconciler(t, parent, node)
-			_, configFile, err := r.store.AddPluginConfig(ctx, parent, nil, r.fetcher)
+			_, configFile, err := r.store.AddPluginConfig(ctx, parent, r.fetcher)
 			require.NoError(t, err)
 			result, err := r.fetcher.FetchInline(ctx, []byte("installed binary"))
 			require.NoError(t, err)
-			action, binaryFile, err := r.store.Store(ctx, nil, parent.Name, 0, artifact.TypePlugin, artifact.MediumOCI, result)
+			action, binaryFile, err := r.store.Store(ctx, parent.Namespace, parent.Name, 0, artifact.TypePlugin, artifact.MediumOCI, result)
 			require.NoError(t, err)
 			artifact.UpdateInstalledStatus(&node.Status.InstalledArtifacts, action, artifact.MediumOCI, binaryFile)
 			artifact.UpdateInstalledSpecHash(&node.Status.InstalledArtifacts, artifact.MediumOCI, "old-spec")

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -130,6 +130,8 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Programmed is derived here as a gateway: True only when all other conditions are True.
 	// In advise mode DependenciesSatisfied is excluded from the gate; it's advisory only.
 	defer func() {
+		key := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
+		r.store.SyncAllInstalledStatus(key, []artifact.Medium{artifact.MediumOCI, artifact.MediumInline, artifact.MediumConfigMap}, &nodeObj.Status.InstalledArtifacts)
 		skipDependenciesSatisfied := func(condType string) bool {
 			return !r.enforceRequirements && condType == commonv1alpha1.ConditionDependenciesSatisfied.String()
 		}
@@ -179,7 +181,7 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// False. Without this they are absent, which lets another node's True status win in
 		// AggregateConditions and makes the Rulesfile-level status show e.g.
 		// OCIArtifactProgrammed=True even when DependenciesSatisfied=False.
-		if len(nodeObj.Status.InstalledArtifacts) == 0 {
+		if len(r.store.GetInstalled(nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile))) == 0 {
 			depCond := apimeta.FindStatusCondition(nodeObj.Status.Conditions,
 				commonv1alpha1.ConditionDependenciesSatisfied.String())
 			reason := artifact.ReasonDependenciesNotSatisfied
@@ -210,7 +212,7 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Register this rulesfile's current dependencies with the shared node artifact manager
 	// before writing anything, so a concurrent Plugin removal's blocked-by check can see them
 	// (avoids a race with ensureRulesfile's own write).
-	r.store.Sync(nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: rulesfile.Name},
+	r.store.Sync(nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile),
 		nodeartifacts.RequirementGroupsFromDependencies(dependenciesOf(rulesfile)))
 
 	// Ensure the rulesfile artifacts are on the local filesystem. A transient OCI-fetch failure
@@ -241,17 +243,27 @@ func (r *RulesfileReconciler) handleDeletion(ctx context.Context, nodeObj *artif
 
 	logger.Info("RulesfileNode marked for deletion, cleaning up")
 
-	if err := r.store.Remove(ctx, nodeObj.Status.InstalledArtifacts); err != nil {
+	// Resolves the rulesfile name from the ownerRef: needed both to key the installed-cache
+	// lookup below and, unchanged from before, to forget its dependency registration.
+	var rulesfileName string
+	for _, ref := range nodeObj.OwnerReferences {
+		if ref.Kind == controllerhelper.KindRulesfile {
+			rulesfileName = ref.Name
+			break
+		}
+	}
+	// OwnerReferences never carry a namespace (they're always same-namespace by k8s convention);
+	// nodeObj's own namespace is the rulesfile's.
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: nodeObj.Namespace, Name: rulesfileName}
+
+	if err := r.store.Remove(ctx, key, r.store.GetInstalled(key)); err != nil {
 		logger.Error(err, "unable to remove installed rulesfile artifacts from disk")
 		return false, err
 	}
 
 	// Forget this rulesfile's dependencies so a Plugin removal blocked on them can proceed.
-	for _, ref := range nodeObj.OwnerReferences {
-		if ref.Kind == controllerhelper.KindRulesfile {
-			r.store.Sync(nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: ref.Name}, nil)
-			break
-		}
+	if rulesfileName != "" {
+		r.store.Sync(key, nil)
 	}
 
 	patch := client.MergeFrom(nodeObj.DeepCopy())
@@ -462,11 +474,12 @@ func (r *RulesfileReconciler) cleanupStaleMedium(
 	}
 	logger := log.FromContext(ctx)
 	apimeta.RemoveStatusCondition(&nodeObj.Status.Conditions, conditionType)
-	existing := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, medium)
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
+	existing := r.store.FindInstalled(key, medium)
 	if existing == nil {
 		return nil
 	}
-	if err := r.store.Remove(ctx, []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(medium)}}); err != nil {
+	if err := r.store.Remove(ctx, key, []artifactv1alpha1.InstalledArtifact{{Path: existing.Path, Medium: string(medium)}}); err != nil {
 		logger.Error(err, "unable to remove stale rulesfile", "medium", medium)
 		return err
 	}
@@ -491,7 +504,8 @@ func (r *RulesfileReconciler) ensureOCIRulesfile(
 		parentSpecHash = rulesfile.Status.ArtifactMeta.SpecHash
 		expectedDigest = rulesfile.Status.ArtifactMeta.Digest
 	}
-	current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
+	current := r.store.FindInstalled(key, artifact.MediumOCI)
 
 	// Decide whether to hit the artifact server.
 	// Skip only when the spec hash is unchanged AND the disk file is intact.
@@ -519,7 +533,7 @@ func (r *RulesfileReconciler) ensureOCIRulesfile(
 			))
 			return err
 		}
-		ociAction, newFile, err := r.store.Store(ctx, current, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumOCI, result)
+		ociAction, newFile, err := r.store.Store(ctx, rulesfile.Namespace, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumOCI, result)
 		if err != nil {
 			logger.Error(err, "unable to store Rulesfile OCI artifact")
 			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonOCIArtifactStoreFailed, artifact.MessageFormatOCIArtifactStoreFailed, err.Error())
@@ -529,14 +543,17 @@ func (r *RulesfileReconciler) ensureOCIRulesfile(
 			))
 			return err
 		}
-		artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, ociAction, artifact.MediumOCI, newFile)
 		// Persist specHash even when StoreActionUnchanged (same content, different spec).
-		artifact.UpdateInstalledSpecHash(&nodeObj.Status.InstalledArtifacts, artifact.MediumOCI, parentSpecHash)
+		r.store.UpdateInstalledSpecHash(key, artifact.MediumOCI, parentSpecHash)
 		artifact.RecordStoreEvent(r.recorder, rulesfile, ociAction, artifact.MediumOCI)
 		if ociAction == artifact.StoreActionAdded || ociAction == artifact.StoreActionUpdated || ociAction == artifact.StoreActionPriorityChanged {
 			logger.Info("Rulesfile OCI artifact written to disk", "path", newFile.Path, "action", string(ociAction))
 		}
 	}
+	// Mirrors the cache into status unconditionally, whether this reconcile fetched anything or
+	// took the skip-fetch shortcut above: see Manager.SyncInstalledStatus's doc comment for why a
+	// write gated on this reconcile's own StoreAction would leave status permanently behind.
+	r.store.SyncInstalledStatus(key, artifact.MediumOCI, &nodeObj.Status.InstalledArtifacts)
 	apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewOCIArtifactProgrammedCondition(
 		metav1.ConditionTrue, artifact.ReasonOCIArtifactProgrammed, artifact.MessageOCIArtifactProgrammed, gen,
 	))
@@ -573,8 +590,7 @@ func (r *RulesfileReconciler) ensureInlineRulesfile(
 			))
 			return err
 		}
-		current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumInline)
-		inlineAction, newFile, err := r.store.Store(ctx, current, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumInline, result)
+		inlineAction, newFile, err := r.store.Store(ctx, rulesfile.Namespace, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumInline, result)
 		if err != nil {
 			logger.Error(err, "unable to store Rulesfile inline rules")
 			artifact.RecordWarning(r.recorder, rulesfile, artifact.ReasonInlineRulesStoreFailed, artifact.MessageFormatInlineRulesStoreFailed, err.Error())
@@ -584,7 +600,10 @@ func (r *RulesfileReconciler) ensureInlineRulesfile(
 			))
 			return err
 		}
-		artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, inlineAction, artifact.MediumInline, newFile)
+		r.store.SyncInstalledStatus(
+			nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile),
+			artifact.MediumInline, &nodeObj.Status.InstalledArtifacts,
+		)
 		artifact.RecordStoreEvent(r.recorder, rulesfile, inlineAction, artifact.MediumInline)
 		if inlineAction == artifact.StoreActionAdded || inlineAction == artifact.StoreActionUpdated ||
 			inlineAction == artifact.StoreActionPriorityChanged {
@@ -617,8 +636,7 @@ func (r *RulesfileReconciler) ensureConfigMapRulesfile(
 		))
 		return err
 	}
-	current := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumConfigMap)
-	cmAction, newFile, err := r.store.Store(ctx, current, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumConfigMap, result)
+	cmAction, newFile, err := r.store.Store(ctx, rulesfile.Namespace, rulesfile.Name, p, artifact.TypeRulesfile, artifact.MediumConfigMap, result)
 	if err != nil {
 		logger.Error(err, "unable to store Rulesfile from ConfigMap reference")
 		artifact.RecordWarning(r.recorder, rulesfile,
@@ -629,7 +647,10 @@ func (r *RulesfileReconciler) ensureConfigMapRulesfile(
 		))
 		return err
 	}
-	artifact.UpdateInstalledStatus(&nodeObj.Status.InstalledArtifacts, cmAction, artifact.MediumConfigMap, newFile)
+	r.store.SyncInstalledStatus(
+		nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile),
+		artifact.MediumConfigMap, &nodeObj.Status.InstalledArtifacts,
+	)
 	artifact.RecordStoreEvent(r.recorder, rulesfile, cmAction, artifact.MediumConfigMap)
 	if cmAction == artifact.StoreActionAdded || cmAction == artifact.StoreActionUpdated || cmAction == artifact.StoreActionPriorityChanged {
 		logger.Info("Rulesfile ConfigMap artifact written to disk", "path", newFile.Path, "action", string(cmAction))
@@ -742,7 +763,7 @@ func (r *RulesfileReconciler) enforceRulesfileCompatibility(
 		if r.enforceRequirements {
 			baseMsg := "artifact metadata declares no requirements; installation blocked in enforce mode"
 			reason, msg := artifact.ReasonDependenciesUnknown, baseMsg
-			if len(nodeObj.Status.InstalledArtifacts) > 0 {
+			if len(r.store.GetInstalled(nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile))) > 0 {
 				reason = artifact.ReasonDependenciesNotSatisfiedUpdateRejected
 				msg = baseMsg + artifact.MessageSuffixUpdateRejected
 			}
@@ -791,7 +812,8 @@ func (r *RulesfileReconciler) enforceRulesfileCompatibility(
 	if len(unsatisfied) > 0 {
 		baseMsg := strings.Join(unsatisfied, "; ")
 		logger.Info("Rulesfile plugin dependencies not satisfied", "count", len(unsatisfied), "unsatisfied", unsatisfied)
-		alreadyInstalled := len(nodeObj.Status.InstalledArtifacts) > 0
+		rfKey := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
+		alreadyInstalled := len(r.store.GetInstalled(rfKey)) > 0
 		skip, reason, msg := artifact.DependenciesNotSatisfiedOutcome(r.enforceRequirements, alreadyInstalled, baseMsg)
 		artifact.RecordWarning(r.recorder, rulesfile, reason, msg)
 		apimeta.SetStatusCondition(&nodeObj.Status.Conditions, common.NewDependenciesSatisfiedCondition(
@@ -819,7 +841,8 @@ func (r *RulesfileReconciler) checkEngineRequirement(
 	gen int64,
 ) (skip, satisfied bool, err error) {
 	logger := log.FromContext(ctx)
-	alreadyInstalled := len(nodeObj.Status.InstalledArtifacts) > 0
+	rfKey := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
+	alreadyInstalled := len(r.store.GetInstalled(rfKey)) > 0
 	provided, found, ok, semverErr := r.store.CheckRequirement(name, requiredVersion)
 	if semverErr != nil {
 		msg := fmt.Sprintf("Unable to compare %s versions: %s", name, semverErr.Error())

--- a/controllers/artifact/rulesfile/controller.go
+++ b/controllers/artifact/rulesfile/controller.go
@@ -131,7 +131,9 @@ func (r *RulesfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// In advise mode DependenciesSatisfied is excluded from the gate; it's advisory only.
 	defer func() {
 		key := nodeartifacts.KeyFromObj(nodeartifacts.KindRulesfile, rulesfile)
-		r.store.SyncAllInstalledStatus(key, []artifact.Medium{artifact.MediumOCI, artifact.MediumInline, artifact.MediumConfigMap}, &nodeObj.Status.InstalledArtifacts)
+		r.store.SyncAllInstalledStatus(key,
+			[]artifact.Medium{artifact.MediumOCI, artifact.MediumInline, artifact.MediumConfigMap},
+			&nodeObj.Status.InstalledArtifacts)
 		skipDependenciesSatisfied := func(condType string) bool {
 			return !r.enforceRequirements && condType == commonv1alpha1.ConditionDependenciesSatisfied.String()
 		}

--- a/controllers/artifact/rulesfile/controller_test.go
+++ b/controllers/artifact/rulesfile/controller_test.go
@@ -167,16 +167,47 @@ func newTestReconciler(t *testing.T, objs ...client.Object) (*RulesfileReconcile
 		Build()
 
 	mockFS := fsfake.NewMockFileSystem()
+	store := nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
+	seedInstalledCacheFromObjs(store, objs)
 
 	return &RulesfileReconciler{
 		Client:    cl,
 		Scheme:    s,
 		recorder:  events.NewFakeRecorder(100),
 		fetcher:   newTestFetcher(cl),
-		store:     nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil)),
+		store:     store,
 		nodeName:  testutil.TestNodeName,
 		namespace: testutil.TestNamespace,
 	}, cl
+}
+
+// seedInstalledCacheFromObjs mirrors what WarmSync does at startup: any pre-set
+// ArtifactNode.Status.InstalledArtifacts among objs is seeded into store's installed-artifact
+// cache, keyed by the owning Rulesfile/Plugin/Config's Kind+Name. Filesystem decisions are made
+// from that cache, never from status, so a test simulating "this was already installed" must
+// seed the cache the same way a real restart would, not just set status on the object.
+func seedInstalledCacheFromObjs(store *nodeartifacts.Manager, objs []client.Object) {
+	for _, obj := range objs {
+		node, ok := obj.(*artifactv1alpha1.ArtifactNode)
+		if !ok || len(node.Status.InstalledArtifacts) == 0 {
+			continue
+		}
+		for _, ref := range node.OwnerReferences {
+			var kind nodeartifacts.Kind
+			switch ref.Kind {
+			case controllerhelper.KindRulesfile:
+				kind = nodeartifacts.KindRulesfile
+			case controllerhelper.KindPlugin:
+				kind = nodeartifacts.KindPlugin
+			case controllerhelper.KindConfig:
+				kind = nodeartifacts.KindConfig
+			default:
+				continue
+			}
+			store.SeedInstalled(nodeartifacts.Key{Kind: kind, Namespace: node.Namespace, Name: ref.Name}, node.Status.InstalledArtifacts)
+			break
+		}
+	}
 }
 
 func TestNewRulesfileReconciler(t *testing.T) {
@@ -936,6 +967,57 @@ func TestEnsureRulesfile_ProgrammedLastTransitionTime(t *testing.T) {
 			require.Equal(t, tt.wantPreserved, cond.LastTransitionTime.Equal(&pinned))
 		})
 	}
+}
+
+// TestEnsureRulesfile_OCI_SyncsStatusFromCacheEvenWhenStatusStartsEmpty covers the case where
+// the manager's cache (seeded from disk by WarmSync, or surviving a status patch dropped by an
+// SSA conflict) already considers the OCI artifact installed and verified, but this specific
+// ArtifactNode's own Status.InstalledArtifacts starts empty. The "already verified on disk, skip
+// fetch" shortcut must still populate status from the cache before returning, not just set the
+// condition True and leave installedArtifacts missing.
+func TestEnsureRulesfile_OCI_SyncsStatusFromCacheEvenWhenStatusStartsEmpty(t *testing.T) {
+	r, _ := newTestReconciler(t)
+	mockFS := fsfake.NewMockFileSystem()
+	r.store = nodeartifacts.NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
+
+	content := []byte("- rule: test\n  condition: true\n")
+	hash := sha256hexForTest(content)
+	path := artifact.ArtifactPath(artifact.DefaultArtifactDirs(), testRulesfileName, 50, artifact.MediumOCI, artifact.TypeRulesfile)
+	mockFS.Files[path] = content
+
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: testutil.TestNamespace, Name: testRulesfileName}
+	r.store.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{
+		{Path: path, Medium: string(artifact.MediumOCI), Priority: 50, ContentHash: hash, SpecHash: "spec-v1"},
+	})
+
+	rf := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: testRulesfileName, Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			Priority: 50,
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/rules/falco-rules", Tag: "latest"},
+			},
+		},
+		Status: artifactv1alpha1.RulesfileStatus{
+			ArtifactMeta: &commonv1alpha1.ArtifactMeta{SpecHash: "spec-v1"},
+		},
+	}
+	nodeObj := newTestNodeObj() // Status.InstalledArtifacts starts nil, unlike the cache.
+
+	tf := r.fetcher.(*testFetcher)
+	require.NoError(t, r.ensureOCIRulesfile(context.Background(), rf, nodeObj))
+
+	assert.Zero(t, tf.ociCallCount, "the cache already verified this content; no fetch should happen")
+	entry := artifact.FindInstalled(nodeObj.Status.InstalledArtifacts, artifact.MediumOCI)
+	require.NotNil(t, entry, "status must be synced from the cache even on the skip-fetch path")
+	assert.Equal(t, path, entry.Path)
+	assert.Equal(t, hash, entry.ContentHash)
+	assert.Equal(t, "spec-v1", entry.SpecHash)
+}
+
+func sha256hexForTest(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
 }
 
 func TestEnforceReferenceResolution(t *testing.T) {
@@ -1797,9 +1879,13 @@ func TestEnforceRulesfileCompatibility(t *testing.T) {
 				nodeObj.Status.Conditions = tt.presetConditions
 			}
 			if tt.preInstalled {
-				nodeObj.Status.InstalledArtifacts = []artifactv1alpha1.InstalledArtifact{
+				installed := []artifactv1alpha1.InstalledArtifact{
 					{Path: "/etc/falco/rules.d/test.yaml", Medium: string(artifact.MediumOCI)},
 				}
+				nodeObj.Status.InstalledArtifacts = installed
+				// alreadyInstalled is read from the manager's cache, not status; seed it the way
+				// WarmSync would from a real restart.
+				r.store.SeedInstalled(nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: tt.rf.Namespace, Name: tt.rf.Name}, installed)
 			}
 
 			skip, err := r.enforceRulesfileCompatibility(context.Background(), tt.rf, nodeObj)
@@ -1875,6 +1961,54 @@ func TestFindAllNodeObjectsOnVersionChange_Empty(t *testing.T) {
 	assert.Empty(t, requests)
 }
 
+// TestReconcile_ResyncsAllMediaFromCacheBeforePatching covers an overlapping-reconcile race:
+// two reconciles for different spec generations of the same Rulesfile race to patch status via
+// SSA ForceOwnership. One reconcile (working off an older spec generation that still had an
+// inline source) can finish its patch after a newer reconcile has already removed that source,
+// resurrecting a stale InstalledArtifacts entry the newer reconcile had already cleared from the
+// cache.
+//
+// This test doesn't simulate the race directly; it simulates its end state: an ArtifactNode whose
+// persisted status still has a stale "inline" entry (as if an in-flight reconcile's Get read it
+// before it was removed), while the cache — the actual source of truth for what's installed —
+// already has none. A single Reconcile call must patch status back into agreement with the cache,
+// not merely leave a stale entry alone because this reconcile's own ensureX calls never touched it
+// (the current spec has no inline source at all, so cleanupStaleMedium's own cache-based check
+// finds nothing to remove and would otherwise return without touching status).
+func TestReconcile_ResyncsAllMediaFromCacheBeforePatching(t *testing.T) {
+	rf := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: testRulesfileName, Namespace: testutil.TestNamespace},
+		Spec: artifactv1alpha1.RulesfileSpec{
+			Priority: 50,
+			OCIArtifact: &commonv1alpha1.OCIArtifact{
+				Image: commonv1alpha1.ImageSpec{Repository: "falcosecurity/rules/falco-rules", Tag: "latest"},
+			},
+			// No InlineRules: this generation never configured it.
+		},
+	}
+	nodeObj := newTestNodeObj(withOwnerRef(), func(n *artifactv1alpha1.ArtifactNode) {
+		n.Finalizers = []string{rulesfileNodeFinalizer}
+		// Stale status: as if read before a concurrent reconcile's removal of inline landed.
+		n.Status.InstalledArtifacts = []artifactv1alpha1.InstalledArtifact{
+			{Path: "/etc/falco/rules.d/50-03-test-rulesfile-inline.yaml", Medium: string(artifact.MediumInline)},
+		}
+	})
+
+	r, cl := newTestReconciler(t, rf, nodeObj)
+	// The cache already reflects inline having been removed (by the "newer" reconcile this test
+	// doesn't simulate directly) — nothing seeded for it, unlike the stale status above.
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: testutil.TestNamespace, Name: testRulesfileName}
+	r.store.SeedInstalled(key, nil)
+
+	_, err := r.Reconcile(context.Background(), testutil.Request(testNodeObjectName()))
+	require.NoError(t, err)
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: testNodeObjectName(), Namespace: testutil.TestNamespace}, got))
+	assert.Nil(t, artifact.FindInstalled(got.Status.InstalledArtifacts, artifact.MediumInline),
+		"the persisted status must be resynced from the cache, not left with a stale entry the cache no longer has")
+}
+
 func TestReconcile_RegistersDependenciesWithNodeArtifactManager(t *testing.T) {
 	rf := &artifactv1alpha1.Rulesfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1916,7 +2050,8 @@ func TestReconcile_RegistersDependenciesWithNodeArtifactManager(t *testing.T) {
 	require.Error(t, err, "Reconcile must have registered this rulesfile's dependency on \"container\"")
 	blocked, ok := errors.AsType[*nodeartifacts.BlockedError](err)
 	require.True(t, ok)
-	assert.Equal(t, nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: testRulesfileName}, blocked.BlockedBy[0])
+	wantKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: testutil.TestNamespace, Name: testRulesfileName}
+	assert.Equal(t, wantKey, blocked.BlockedBy[0])
 }
 
 func TestReconcile_IncompatiblePluginVersion(t *testing.T) {
@@ -1943,11 +2078,13 @@ func TestReconcile_IncompatiblePluginVersion(t *testing.T) {
 				if preInstalled {
 					result, err := r.fetcher.FetchInline(ctx, []byte(testRulesData))
 					require.NoError(t, err)
-					action, file, err := r.store.Store(ctx, nil, rf.Name, 0, artifact.TypeRulesfile, artifact.MediumOCI, result)
+					action, file, err := r.store.Store(ctx, rf.Namespace, rf.Name, 0, artifact.TypeRulesfile, artifact.MediumOCI, result)
 					require.NoError(t, err)
 					installedFile = file
 					artifact.UpdateInstalledStatus(&node.Status.InstalledArtifacts, action, artifact.MediumOCI, file)
 					artifact.UpdateInstalledSpecHash(&node.Status.InstalledArtifacts, artifact.MediumOCI, "old-spec")
+					specHashKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: rf.Namespace, Name: rf.Name}
+					r.store.UpdateInstalledSpecHash(specHashKey, artifact.MediumOCI, "old-spec")
 					require.NoError(t, cl.Status().Update(ctx, node))
 				}
 				oldInstalled := node.Status.InstalledArtifacts

--- a/internal/pkg/artifact/scan.go
+++ b/internal/pkg/artifact/scan.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/priority"
+)
+
+// yamlFilenamePattern matches the "PP-SS-{name}-{medium}.yaml" convention produced by
+// priority.NameFromPriorityAndSubPriority, recovering priority, name, and medium from the
+// filename alone. Anchored so it only matches the exact convention this package writes.
+var yamlFilenamePattern = regexp.MustCompile(`^(\d{2})-\d{2}-(.+)-(oci|inline|configmap)\.yaml$`)
+
+// ScanAll discovers every artifact file on disk for artifactType by listing the relevant
+// directory and parsing each filename back into name, medium, and priority. Unlike a per-name
+// lookup, this does not require already knowing which artifact names exist: it is the primitive
+// that lets a caller (e.g. a restart-time warm sync) discover names it has no other record of,
+// such as an artifact whose parent CR was removed while this was the only place its existence
+// was recorded. Files that don't match the naming convention are skipped rather than erroring,
+// since a foreign or partially-written (e.g. leftover ".tmp") file is not this artifact type's
+// concern. Returned entries have ContentHash from disk; SpecHash is always empty, since it isn't
+// recoverable from file content alone.
+func (s *LocalStore) ScanAll(_ context.Context, artifactType Type) (map[string][]artifactv1alpha1.InstalledArtifact, error) {
+	switch artifactType {
+	case TypeRulesfile:
+		return s.scanYAMLDir(s.Dirs.Rulesfile)
+	case TypeConfig:
+		return s.scanYAMLDir(s.Dirs.Config)
+	case TypePlugin:
+		return s.scanPluginDir(s.Dirs.Plugin)
+	default:
+		return nil, nil
+	}
+}
+
+// scanYAMLDir globs every "*.yaml" file directly under dir and groups the ones matching the
+// naming convention by artifact name.
+func (s *LocalStore) scanYAMLDir(dir string) (map[string][]artifactv1alpha1.InstalledArtifact, error) {
+	matches, err := s.FS.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", dir, err)
+	}
+	result := map[string][]artifactv1alpha1.InstalledArtifact{}
+	for _, match := range matches {
+		sub := yamlFilenamePattern.FindStringSubmatch(filepath.Base(match))
+		if sub == nil {
+			continue
+		}
+		var prio int32
+		if _, err := fmt.Sscanf(sub[1], "%d", &prio); err != nil {
+			continue
+		}
+		name, medium := sub[2], sub[3]
+		hash, err := s.hashFile(match)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = append(result[name], artifactv1alpha1.InstalledArtifact{
+			Path:        match,
+			Medium:      medium,
+			Priority:    prio,
+			ContentHash: hash,
+		})
+	}
+	return result, nil
+}
+
+// scanPluginDir globs every "*.so" file directly under dir. Plugin filenames encode only the
+// name (see ArtifactPath's TypePlugin case): priority isn't part of the filename because plugin
+// binaries are always installed at priority.DefaultPriority, and medium is always MediumOCI
+// (plugins have no other source today).
+func (s *LocalStore) scanPluginDir(dir string) (map[string][]artifactv1alpha1.InstalledArtifact, error) {
+	matches, err := s.FS.Glob(filepath.Join(dir, "*.so"))
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", dir, err)
+	}
+	result := map[string][]artifactv1alpha1.InstalledArtifact{}
+	for _, match := range matches {
+		name := strings.TrimSuffix(filepath.Base(match), ".so")
+		hash, err := s.hashFile(match)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = append(result[name], artifactv1alpha1.InstalledArtifact{
+			Path:        match,
+			Medium:      string(MediumOCI),
+			Priority:    priority.DefaultPriority,
+			ContentHash: hash,
+		})
+	}
+	return result, nil
+}
+
+func (s *LocalStore) hashFile(path string) (string, error) {
+	data, err := s.FS.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:]), nil
+}

--- a/internal/pkg/artifact/scan_test.go
+++ b/internal/pkg/artifact/scan_test.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+)
+
+func TestLocalStore_ScanAll_Rulesfile_GroupsByName(t *testing.T) {
+	store, mockFS := newTestStore()
+
+	myRulesOCI := ArtifactPath(store.Dirs, "my-rules", 50, MediumOCI, TypeRulesfile)
+	myRulesInline := ArtifactPath(store.Dirs, "my-rules", 50, MediumInline, TypeRulesfile)
+	otherOCI := ArtifactPath(store.Dirs, "other", 20, MediumOCI, TypeRulesfile)
+
+	mockFS.Files[myRulesOCI] = []byte("oci content")
+	mockFS.Files[myRulesInline] = []byte("inline content")
+	mockFS.Files[otherOCI] = []byte("other content")
+	// Unrelated file in the same directory must be ignored.
+	mockFS.Files[store.Dirs.Rulesfile+"/notes.txt"] = []byte("not an artifact")
+
+	found, err := store.ScanAll(context.Background(), TypeRulesfile)
+	require.NoError(t, err)
+
+	require.Len(t, found["my-rules"], 2)
+	require.Len(t, found["other"], 1)
+
+	byMedium := map[Medium]artifactv1alpha1.InstalledArtifact{}
+	for _, f := range found["my-rules"] {
+		byMedium[Medium(f.Medium)] = f
+	}
+	assert.Equal(t, myRulesOCI, byMedium[MediumOCI].Path)
+	assert.Equal(t, int32(50), byMedium[MediumOCI].Priority)
+	assert.Equal(t, sha256hex([]byte("oci content")), byMedium[MediumOCI].ContentHash)
+	assert.Equal(t, myRulesInline, byMedium[MediumInline].Path)
+
+	assert.Equal(t, otherOCI, found["other"][0].Path)
+	assert.Equal(t, int32(20), found["other"][0].Priority)
+}
+
+func TestLocalStore_ScanAll_Plugin_OneFilePerName(t *testing.T) {
+	store, mockFS := newTestStore()
+
+	containerPath := ArtifactPath(store.Dirs, "container", 50, MediumOCI, TypePlugin)
+	mockFS.Files[containerPath] = []byte("binary")
+	// Unrelated file must be ignored.
+	mockFS.Files[store.Dirs.Plugin+"/README.md"] = []byte("not a plugin")
+
+	found, err := store.ScanAll(context.Background(), TypePlugin)
+	require.NoError(t, err)
+
+	require.Len(t, found, 1)
+	require.Len(t, found["container"], 1)
+	assert.Equal(t, containerPath, found["container"][0].Path)
+	assert.Equal(t, string(MediumOCI), found["container"][0].Medium)
+	assert.Equal(t, sha256hex([]byte("binary")), found["container"][0].ContentHash)
+}
+
+func TestLocalStore_ScanAll_NoFiles_ReturnsEmpty(t *testing.T) {
+	store, _ := newTestStore()
+
+	found, err := store.ScanAll(context.Background(), TypeConfig)
+	require.NoError(t, err)
+	assert.Empty(t, found)
+}

--- a/internal/pkg/artifact/store.go
+++ b/internal/pkg/artifact/store.go
@@ -297,22 +297,6 @@ func UpdateInstalledSpecHash(artifacts *[]artifactv1alpha1.InstalledArtifact, me
 	}
 }
 
-// FindInstalledConfig returns the config sub-entry for the artifact matching medium, or nil.
-// The returned File uses MediumInline and priority.MaxPriority (fixed for plugin config files).
-// ContentHash is always empty; callers must populate it via Verify before passing to Store.
-func FindInstalledConfig(artifacts []artifactv1alpha1.InstalledArtifact, medium Medium) *File {
-	for _, a := range artifacts {
-		if a.Medium == string(medium) && a.Config != nil {
-			return &File{
-				Path:     a.Config.Path,
-				Medium:   MediumInline,
-				Priority: priority.MaxPriority,
-			}
-		}
-	}
-	return nil
-}
-
 // UpdateInstalledConfig sets the Config sub-entry on the artifact matching medium.
 // No-op when f is nil or no entry matches medium.
 func UpdateInstalledConfig(artifacts *[]artifactv1alpha1.InstalledArtifact, medium Medium, f *File) {

--- a/internal/pkg/artifact/store.go
+++ b/internal/pkg/artifact/store.go
@@ -233,7 +233,10 @@ func FindInstalled(artifacts []artifactv1alpha1.InstalledArtifact, medium Medium
 	return nil
 }
 
-// SetInstalled upserts a File into the InstalledArtifacts slice (matched by Medium).
+// SetInstalled upserts a File into the InstalledArtifacts slice (matched by Medium). File carries
+// no Config sub-entry (that's tracked separately via UpdateInstalledConfig, e.g. for a Plugin's
+// shared config-file linkage), so updating an existing entry's main fields preserves whatever
+// Config it already had rather than clearing it.
 func SetInstalled(artifacts *[]artifactv1alpha1.InstalledArtifact, f File) {
 	for i, a := range *artifacts {
 		if a.Medium == string(f.Medium) {
@@ -243,6 +246,7 @@ func SetInstalled(artifacts *[]artifactv1alpha1.InstalledArtifact, f File) {
 				Priority:    f.Priority,
 				ContentHash: f.ContentHash,
 				SpecHash:    f.SpecHash,
+				Config:      a.Config,
 			}
 			return
 		}

--- a/internal/pkg/artifact/store.go
+++ b/internal/pkg/artifact/store.go
@@ -64,6 +64,10 @@ type ArtifactStore interface {
 
 	// Remove deletes every path listed in installed from disk.
 	Remove(ctx context.Context, installed []artifactv1alpha1.InstalledArtifact) error
+
+	// ScanAll discovers every artifact file on disk for artifactType, grouped by artifact name,
+	// by listing the type's directory and parsing each filename. See scan.go's doc comment.
+	ScanAll(ctx context.Context, artifactType Type) (map[string][]artifactv1alpha1.InstalledArtifact, error)
 }
 
 // LocalStore implements ArtifactStore against the local filesystem.

--- a/internal/pkg/artifact/store_test.go
+++ b/internal/pkg/artifact/store_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	fsfake "github.com/falcosecurity/falco-operator/internal/pkg/filesystem/fake"
 )
 
@@ -41,6 +42,29 @@ func newTestStore() (*LocalStore, *fsfake.MockFileSystem) {
 		Config:    "/configs",
 	}
 	return &LocalStore{FS: mockFS, Dirs: dirs}, mockFS
+}
+
+// TestSetInstalled_PreservesExistingConfigSubEntry reproduces a real regression: SetInstalled
+// used to overwrite the whole InstalledArtifact struct when updating an existing medium entry,
+// silently dropping its Config sub-field (set separately by UpdateInstalledConfig, e.g. for a
+// Plugin's shared config-file linkage) because File has no Config field to carry it forward.
+// Any caller that re-syncs a medium's main fields from a source that only knows about File (like
+// Manager's installed-artifact cache) must never destroy a Config sub-entry nothing else tracks.
+func TestSetInstalled_PreservesExistingConfigSubEntry(t *testing.T) {
+	artifacts := []artifactv1alpha1.InstalledArtifact{
+		{
+			Path: "/old", Medium: "oci", Priority: 50, ContentHash: "old-hash",
+			Config: &artifactv1alpha1.InstalledArtifactConfig{Path: "/etc/falco/config.d/99-03-plugins-config-inline.yaml"},
+		},
+	}
+
+	SetInstalled(&artifacts, File{Path: "/new", Medium: MediumOCI, Priority: 50, ContentHash: "new-hash"})
+
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "/new", artifacts[0].Path)
+	assert.Equal(t, "new-hash", artifacts[0].ContentHash)
+	require.NotNil(t, artifacts[0].Config, "updating the main fields must not drop the Config sub-entry")
+	assert.Equal(t, "/etc/falco/config.d/99-03-plugins-config-inline.yaml", artifacts[0].Config.Path)
 }
 
 func TestLocalStore_Store_PriorityChange(t *testing.T) {

--- a/internal/pkg/filesystem/fake/mock.go
+++ b/internal/pkg/filesystem/fake/mock.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"path/filepath"
 
 	"github.com/falcosecurity/falco-operator/internal/pkg/filesystem"
 )
@@ -155,6 +156,26 @@ func (m *mockReadCloser) Read(p []byte) (n int, err error) {
 
 func (m *mockReadCloser) Close() error {
 	return nil
+}
+
+// Glob returns the names of all files in the mock filesystem matching pattern, restricted to
+// the same directory as pattern (matching filepath.Glob semantics: "*" never crosses "/").
+func (m *MockFileSystem) Glob(pattern string) ([]string, error) {
+	var matches []string
+	dir := filepath.Dir(pattern)
+	for name := range m.Files {
+		if filepath.Dir(name) != dir {
+			continue
+		}
+		ok, err := filepath.Match(pattern, name)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matches = append(matches, name)
+		}
+	}
+	return matches, nil
 }
 
 // Exists checks if a file exists in the mock filesystem.

--- a/internal/pkg/filesystem/fake/mock_test.go
+++ b/internal/pkg/filesystem/fake/mock_test.go
@@ -14,23 +14,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package filesystem
+package fake
 
 import (
-	"io"
-	"io/fs"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// FileSystem defines the interface for filesystem operations used by the artifact manager.
-type FileSystem interface {
-	Stat(name string) (fs.FileInfo, error)
-	ReadFile(name string) ([]byte, error)
-	WriteFile(name string, data []byte, perm fs.FileMode) error
-	Remove(name string) error
-	Rename(oldpath, newpath string) error
-	Open(name string) (io.ReadCloser, error)
-	Exists(path string) (bool, error)
-	// Glob returns the names of all files matching pattern (see filepath.Glob semantics: "*"
-	// never crosses a path separator, so this never descends into subdirectories).
-	Glob(pattern string) ([]string, error)
+func TestMockFileSystem_Glob_MatchesOnlyPatternInSameDirectory(t *testing.T) {
+	m := NewMockFileSystem()
+	m.Files["/rules.d/50-01-my-rules-oci.yaml"] = []byte("x")
+	m.Files["/rules.d/50-02-other-inline.yaml"] = []byte("x")
+	m.Files["/rules.d/notes.txt"] = []byte("x")
+	m.Files["/rules.d/sub/50-03-nested-oci.yaml"] = []byte("x")
+
+	matches, err := m.Glob("/rules.d/*.yaml")
+	require.NoError(t, err)
+
+	sort.Strings(matches)
+	require.Equal(t, []string{
+		"/rules.d/50-01-my-rules-oci.yaml",
+		"/rules.d/50-02-other-inline.yaml",
+	}, matches)
 }

--- a/internal/pkg/filesystem/os.go
+++ b/internal/pkg/filesystem/os.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 // OS implements FileSystem using the real os package.
@@ -58,6 +59,11 @@ func (OS) Rename(oldpath, newpath string) error {
 // Open opens the file at the given path.
 func (OS) Open(name string) (io.ReadCloser, error) {
 	return os.Open(name) //nolint:gosec // This is intentional - the filesystem abstraction needs to accept variable paths
+}
+
+// Glob returns the names of all files matching pattern, per filepath.Glob.
+func (OS) Glob(pattern string) ([]string, error) {
+	return filepath.Glob(pattern)
 }
 
 // Exists checks if the file exists.

--- a/internal/pkg/filesystem/os_test.go
+++ b/internal/pkg/filesystem/os_test.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOS_Glob_MatchesOnlyPatternInSameDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	matching := filepath.Join(dir, "50-01-my-rules-oci.yaml")
+	require.NoError(t, os.WriteFile(matching, []byte("x"), 0o644))
+
+	nonMatching := filepath.Join(dir, "notes.txt")
+	require.NoError(t, os.WriteFile(nonMatching, []byte("x"), 0o644))
+
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	inSub := filepath.Join(sub, "50-02-nested-oci.yaml")
+	require.NoError(t, os.WriteFile(inSub, []byte("x"), 0o644))
+
+	fsys := NewOSFileSystem()
+	matches, err := fsys.Glob(filepath.Join(dir, "*.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, []string{matching}, matches)
+}

--- a/internal/pkg/nodeartifacts/manager.go
+++ b/internal/pkg/nodeartifacts/manager.go
@@ -29,6 +29,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"
 	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
@@ -40,11 +42,15 @@ import (
 type Kind string
 
 const (
-	// KindRulesfile identifies a Rulesfile CR's dependency-registry entry.
+	// KindRulesfile identifies a Rulesfile CR's dependency-registry and installed-cache entry.
 	KindRulesfile Kind = "Rulesfile"
+	// KindPlugin identifies a Plugin CR's installed-cache entry (its binary).
+	KindPlugin Kind = "Plugin"
+	// KindConfig identifies a Config CR's installed-cache entry.
+	KindConfig Kind = "Config"
 	// KindPluginConfig identifies the single shared plugins-config aggregate file's
-	// registry entry. Every Plugin CR on a node contributes one entry to that file (see
-	// controllers/artifact/plugin/controller.go's PluginsConfig).
+	// registry and installed-cache entry. Every Plugin CR on a node contributes one entry to
+	// that file (see pluginconfig.go).
 	KindPluginConfig Kind = "PluginConfig"
 	// KindFalco identifies capabilities reported directly by Falco itself
 	// (engine_version_semver, plugin_api_version); a reserved provider identity distinct
@@ -54,11 +60,23 @@ const (
 
 // Key identifies an entry in the dependency registry.
 type Key struct {
-	Kind Kind
-	Name string
+	Kind      Kind
+	Namespace string
+	Name      string
 }
 
-// PluginConfigKey is the single registry key for the shared plugins-config aggregate file.
+// KeyFromObj builds the Key for kind identifying obj, the Plugin/Rulesfile/Config CR that owns
+// it. Not applicable during deletion handling, where the parent object may already be gone and
+// only its owner-reference name (never its namespace) survives: those call sites build a Key
+// literal from the ArtifactNode's own namespace directly instead.
+func KeyFromObj(kind Kind, obj metav1.Object) Key {
+	return Key{Kind: kind, Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+// PluginConfigKey is the single registry key for the shared plugins-config aggregate file. Its
+// Namespace is deliberately left empty: the file itself is a per-node singleton (Falco is one
+// process per node with one config file location) that aggregates every Plugin CR's entry
+// regardless of namespace, so it doesn't belong to any one namespace the way a per-CR Key does.
 var PluginConfigKey = Key{Kind: KindPluginConfig, Name: "plugins-config"}
 
 // RequirementGroup is an ordered plugin dependency: the primary followed by its alternatives.
@@ -102,11 +120,19 @@ type provided struct {
 // CR-name-to-config-name rename tracking for Plugin CRs (see pluginconfig.go). The zero value
 // is not usable; construct with NewManager.
 type Manager struct {
-	mu             sync.Mutex
-	store          artifact.ArtifactStore
-	falcoFetcher   compat.VersionsFetcher
-	provides       map[string]provided
-	requires       map[Key][]RequirementGroup
+	mu           sync.Mutex
+	store        artifact.ArtifactStore
+	falcoFetcher compat.VersionsFetcher
+	provides     map[string]provided
+	requires     map[Key][]RequirementGroup
+	// installed tracks the on-disk files for each artifact (keyed by Kind+Name): the
+	// authoritative source Store/Remove/FindInstalled read and write, and the only thing a
+	// filesystem decision (skip vs. rewrite, what to remove) is ever based on. A controller's
+	// own ArtifactNode status is a write-through mirror of this for observability only; it is
+	// never read back to make a decision, since the informer-cached status a reconcile sees can
+	// lag behind what's actually happened. Seeded from disk by WarmSync at startup (see
+	// reconcileDiskState); updated on every Store/Remove call thereafter.
+	installed      map[Key][]artifactv1alpha1.InstalledArtifact
 	pluginsConfig  *pluginsConfig
 	crToConfigName map[string]string
 	subscribers    []chan event.GenericEvent
@@ -122,35 +148,164 @@ func NewManager(store artifact.ArtifactStore, falcoFetcher compat.VersionsFetche
 		falcoFetcher:   falcoFetcher,
 		provides:       make(map[string]provided),
 		requires:       make(map[Key][]RequirementGroup),
+		installed:      make(map[Key][]artifactv1alpha1.InstalledArtifact),
 		pluginsConfig:  &pluginsConfig{},
 		crToConfigName: make(map[string]string),
 	}
 }
 
-// Store is a lock-wrapped passthrough to the underlying ArtifactStore.Store. Use for writes
-// that don't affect the cross-artifact dependency graph (plugin binaries, rulesfile media
-// files, config files). The lock keeps these writes mutually exclusive with
-// RemovePluginConfigByName's check-then-write critical section.
-func (m *Manager) Store(ctx context.Context, current *artifact.File, name string, artifactPriority int32,
+// kindForArtifactType maps an artifact.Type to the Kind its installed-cache entries use.
+func kindForArtifactType(t artifact.Type) Kind {
+	switch t {
+	case artifact.TypePlugin:
+		return KindPlugin
+	case artifact.TypeConfig:
+		return KindConfig
+	default:
+		return KindRulesfile
+	}
+}
+
+// Store is a lock-wrapped wrapper around the underlying ArtifactStore.Store. It derives "current"
+// from the installed cache itself (keyed by namespace+artifactType+name) rather than accepting it
+// from the caller, so there is exactly one place a Store decision can come from; on success it
+// updates the cache with the result. Use for writes that don't affect the cross-artifact
+// dependency graph (plugin binaries, rulesfile media files, config files). The lock keeps these
+// writes mutually exclusive with RemovePluginConfigByName's check-then-write critical section.
+func (m *Manager) Store(ctx context.Context, namespace, name string, artifactPriority int32,
 	artifactType artifact.Type, medium artifact.Medium, result artifact.FetchResult) (artifact.StoreAction, *artifact.File, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.store.Store(ctx, current, name, artifactPriority, artifactType, medium, result)
+	key := Key{Kind: kindForArtifactType(artifactType), Namespace: namespace, Name: name}
+	current := artifact.FindInstalled(m.installed[key], medium)
+	action, file, err := m.store.Store(ctx, current, name, artifactPriority, artifactType, medium, result)
+	if err != nil {
+		return action, file, err
+	}
+	m.upsertInstalledLocked(key, action, medium, file)
+	return action, file, nil
 }
 
-// Remove is a lock-wrapped passthrough to the underlying ArtifactStore.Remove. Use for removals
-// that don't themselves affect the dependency graph (see RemovePluginConfigByName for the one
-// that does).
-func (m *Manager) Remove(ctx context.Context, installed []artifactv1alpha1.InstalledArtifact) error {
+// Remove is a lock-wrapped wrapper around the underlying ArtifactStore.Remove. key identifies
+// which cache entry installed's mediums belong to; on success, each removed medium is cleared
+// from that entry. Use for removals that don't themselves affect the dependency graph (see
+// RemovePluginConfigByName for the one that does).
+func (m *Manager) Remove(ctx context.Context, key Key, installed []artifactv1alpha1.InstalledArtifact) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.store.Remove(ctx, installed)
+	if err := m.store.Remove(ctx, installed); err != nil {
+		return err
+	}
+	entry := m.installed[key]
+	for _, a := range installed {
+		artifact.ClearInstalled(&entry, artifact.Medium(a.Medium))
+	}
+	if len(entry) == 0 {
+		delete(m.installed, key)
+	} else {
+		m.installed[key] = entry
+	}
+	return nil
+}
+
+// upsertInstalledLocked applies a Store result to key's cache entry. Caller must hold m.mu.
+func (m *Manager) upsertInstalledLocked(key Key, action artifact.StoreAction, medium artifact.Medium, file *artifact.File) {
+	entry := m.installed[key]
+	artifact.UpdateInstalledStatus(&entry, action, medium, file)
+	m.installed[key] = entry
+}
+
+// FindInstalled returns the cached File for key's medium, or nil if none is known. This is the
+// only source a filesystem decision should read "what's currently installed" from.
+func (m *Manager) FindInstalled(key Key, medium artifact.Medium) *artifact.File {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return artifact.FindInstalled(m.installed[key], medium)
+}
+
+// UpdateInstalledSpecHash sets SpecHash on key's cache entry for medium; no-op if not found.
+// Store's own dedup only knows about content, not the parent spec, so a caller whose Store call
+// returned StoreActionUnchanged despite the parent spec changing (e.g. a new OCI tag resolving to
+// identical content) still needs to persist that spec hash separately, exactly as it would in
+// status; this keeps the cache the caller reads "current" from equally up to date.
+func (m *Manager) UpdateInstalledSpecHash(key Key, medium artifact.Medium, specHash string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.installed[key]
+	artifact.UpdateInstalledSpecHash(&entry, medium, specHash)
+	m.installed[key] = entry
+}
+
+// SyncInstalledStatus mirrors key's cache entry for medium into status: upserts it if the cache
+// has one, clears it if the cache doesn't. Call this after every ensure/skip decision a
+// controller makes for a medium (including a "verified on disk, nothing to do" shortcut that
+// never called Store), not only after a Store call that actually changed something.
+//
+// This exists because the cache — not status — is the source of a Store decision (see Store's
+// doc comment): a decision can conclude "already correct" from cache state a previous reconcile
+// established, even if that reconcile's own status patch never landed (an SSA conflict, or the
+// cache being seeded straight from disk by WarmSync with no ArtifactNode status write at all).
+// Gating a status write on the StoreAction (e.g. skipping it for StoreActionUnchanged, as the old
+// per-medium status helpers did) leaves status permanently behind the cache in that case, since
+// nothing will ever revisit it once the medium reads as settled. Syncing unconditionally instead
+// makes status self-healing on every reconcile, regardless of which of this reconcile's own
+// actions (if any) actually touched disk.
+func (m *Manager) SyncInstalledStatus(key Key, medium artifact.Medium, status *[]artifactv1alpha1.InstalledArtifact) {
+	if entry := m.FindInstalled(key, medium); entry != nil {
+		artifact.SetInstalled(status, *entry)
+	} else {
+		artifact.ClearInstalled(status, medium)
+	}
+}
+
+// SyncAllInstalledStatus calls SyncInstalledStatus for every medium in mediums. Every controller's
+// Reconcile defer resyncs its artifact type's full set of mediums from the cache right before
+// patching status, regardless of which medium (if any) this particular reconcile itself touched:
+// see SyncInstalledStatus's doc comment for why a per-medium gate isn't enough to keep status from
+// falling behind the cache after an SSA conflict between overlapping reconciles.
+func (m *Manager) SyncAllInstalledStatus(key Key, mediums []artifact.Medium, status *[]artifactv1alpha1.InstalledArtifact) {
+	for _, medium := range mediums {
+		m.SyncInstalledStatus(key, medium, status)
+	}
+}
+
+// GetInstalled returns a copy of the cached installed artifacts for key, or nil if none are
+// known. Used to obtain the full list to pass to Remove (e.g. on deletion) and by WarmSync.
+func (m *Manager) GetInstalled(key Key) []artifactv1alpha1.InstalledArtifact {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	src := m.installed[key]
+	if src == nil {
+		return nil
+	}
+	out := make([]artifactv1alpha1.InstalledArtifact, len(src))
+	copy(out, src)
+	return out
+}
+
+// SeedInstalled bulk-sets the installed cache for key, replacing any existing entry. Used only
+// by WarmSync at startup to populate the cache from disk ground truth before the manager starts
+// serving reconciles; every update after that goes through Store/Remove.
+func (m *Manager) SeedInstalled(key Key, artifacts []artifactv1alpha1.InstalledArtifact) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(artifacts) == 0 {
+		delete(m.installed, key)
+		return
+	}
+	m.installed[key] = artifacts
 }
 
 // Verify is a read-only passthrough to the underlying ArtifactStore.Verify; it doesn't touch
 // the registry, so no locking is needed for correctness.
 func (m *Manager) Verify(ctx context.Context, f *artifact.File) (bool, error) {
 	return m.store.Verify(ctx, f)
+}
+
+// ScanAll is a read-only passthrough to the underlying ArtifactStore.ScanAll; it doesn't touch
+// the registry, so no locking is needed for correctness.
+func (m *Manager) ScanAll(ctx context.Context, artifactType artifact.Type) (map[string][]artifactv1alpha1.InstalledArtifact, error) {
+	return m.store.ScanAll(ctx, artifactType)
 }
 
 // Sync replaces key's registered requirement groups. A nil or empty requires clears the entry.
@@ -208,7 +363,9 @@ func (m *Manager) CheckDependency(primary Requirement, alternatives []Requiremen
 
 // checkDependencyLocked follows Falco's candidate order and major-version compatibility.
 // excludedName simulates a plugin removal without changing the registry. Caller holds m.mu.
-func (m *Manager) checkDependencyLocked(group RequirementGroup, excludedName string) (matchedName, providedVersion string, satisfied bool, err error) {
+func (m *Manager) checkDependencyLocked(group RequirementGroup, excludedName string) (
+	matchedName, providedVersion string, satisfied bool, err error,
+) {
 	if err := compat.ValidatePluginDependency(group); err != nil {
 		return "", "", false, err
 	}

--- a/internal/pkg/nodeartifacts/manager.go
+++ b/internal/pkg/nodeartifacts/manager.go
@@ -27,9 +27,8 @@ import (
 	"slices"
 	"sync"
 
-	"sigs.k8s.io/controller-runtime/pkg/event"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
 	commonv1alpha1 "github.com/falcosecurity/falco-operator/api/common/v1alpha1"

--- a/internal/pkg/nodeartifacts/manager_test.go
+++ b/internal/pkg/nodeartifacts/manager_test.go
@@ -43,11 +43,28 @@ func newTestManagerWithFetcher(fetcher compat.VersionsFetcher) *nodeartifacts.Ma
 	return nodeartifacts.NewManager(store, fetcher)
 }
 
+func TestManager_ScanAllPassesThroughToUnderlyingStore(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+	_, _, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+
+	found, err := m.ScanAll(context.Background(), artifact.TypeConfig)
+
+	require.NoError(t, err)
+	require.Len(t, found["myfile"], 1)
+	assert.Equal(t, string(artifact.MediumInline), found["myfile"][0].Medium)
+}
+
 func TestManager_StorePassesThroughToUnderlyingStore(t *testing.T) {
 	m := newTestManager()
-	result := artifact.FetchResult{Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644}
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
 
-	action, file, err := m.Store(context.Background(), nil, "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	action, file, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
 
 	require.NoError(t, err)
 	assert.Equal(t, artifact.StoreActionAdded, action)
@@ -60,11 +77,14 @@ func TestManager_StorePassesThroughToUnderlyingStore(t *testing.T) {
 
 func TestManager_RemovePassesThroughToUnderlyingStore(t *testing.T) {
 	m := newTestManager()
-	result := artifact.FetchResult{Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644}
-	_, file, err := m.Store(context.Background(), nil, "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Name: "myfile"}
+	_, file, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
 	require.NoError(t, err)
 
-	err = m.Remove(context.Background(), []artifactv1alpha1.InstalledArtifact{
+	err = m.Remove(context.Background(), key, []artifactv1alpha1.InstalledArtifact{
 		{Path: file.Path, Medium: string(artifact.MediumInline)},
 	})
 	require.NoError(t, err)
@@ -74,14 +94,212 @@ func TestManager_RemovePassesThroughToUnderlyingStore(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestManager_Store_UsesCacheForCurrent_SecondIdenticalStoreIsUnchanged(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+
+	action1, _, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+	require.Equal(t, artifact.StoreActionAdded, action1)
+
+	// No caller-supplied "current": Manager must derive it from its own cache, not from any
+	// status object, to recognize the second call as a no-op.
+	action2, _, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+	assert.Equal(t, artifact.StoreActionUnchanged, action2)
+}
+
+// TestManager_Store_IsolatesByNamespace proves that two artifacts with the same Kind and Name
+// but different Namespace are tracked as distinct cache entries, not merged into one.
+func TestManager_Store_IsolatesByNamespace(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+
+	_, _, err := m.Store(context.Background(), "ns-a", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+
+	keyA := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Namespace: "ns-a", Name: "myfile"}
+	keyB := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Namespace: "ns-b", Name: "myfile"}
+
+	assert.NotNil(t, m.FindInstalled(keyA, artifact.MediumInline), "ns-a's artifact must be tracked under its own namespace")
+	assert.Nil(t, m.FindInstalled(keyB, artifact.MediumInline), "ns-b must not see ns-a's artifact of the same kind+name")
+}
+
+func TestManager_FindInstalled_ReturnsWhatStoreWrote(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Name: "myfile"}
+
+	assert.Nil(t, m.FindInstalled(key, artifact.MediumInline), "nothing stored yet")
+
+	_, file, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+
+	found := m.FindInstalled(key, artifact.MediumInline)
+	require.NotNil(t, found)
+	assert.Equal(t, file.Path, found.Path)
+	assert.Equal(t, file.ContentHash, found.ContentHash)
+}
+
+func TestManager_Remove_ClearsCacheForRemovedMedium(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindConfig, Name: "myfile"}
+	_, file, err := m.Store(context.Background(), "", "myfile", 50, artifact.TypeConfig, artifact.MediumInline, result)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Remove(context.Background(), key, []artifactv1alpha1.InstalledArtifact{
+		{Path: file.Path, Medium: string(artifact.MediumInline)},
+	}))
+
+	assert.Nil(t, m.FindInstalled(key, artifact.MediumInline))
+}
+
+func TestManager_SeedInstalled_ThenFindInstalled(t *testing.T) {
+	m := newTestManager()
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rules"}
+
+	m.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{
+		{Path: "/x", Medium: "oci", Priority: 50, ContentHash: "h1", SpecHash: "s1"},
+	})
+
+	found := m.FindInstalled(key, artifact.MediumOCI)
+	require.NotNil(t, found)
+	assert.Equal(t, "/x", found.Path)
+	assert.Equal(t, "s1", found.SpecHash)
+}
+
+func TestManager_UpdateInstalledSpecHash_SetsSpecHashOnCachedEntry(t *testing.T) {
+	m := newTestManager()
+	result := artifact.FetchResult{
+		Content: []byte("hello"), ContentHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", Perm: 0o644,
+	}
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rules"}
+	_, _, err := m.Store(context.Background(), "", "my-rules", 50, artifact.TypeRulesfile, artifact.MediumOCI, result)
+	require.NoError(t, err)
+
+	m.UpdateInstalledSpecHash(key, artifact.MediumOCI, "spec-hash-v1")
+
+	found := m.FindInstalled(key, artifact.MediumOCI)
+	require.NotNil(t, found)
+	assert.Equal(t, "spec-hash-v1", found.SpecHash)
+}
+
+// TestManager_SyncInstalledStatus_MirrorsCacheEvenWhenStatusStartsEmpty covers a reconcile that
+// takes the "already verified on disk, skip re-fetch" shortcut (or hits StoreActionUnchanged): a
+// status write gated on the StoreAction actually having changed something would leave
+// status.InstalledArtifacts permanently missing an entry the cache (seeded by WarmSync, or
+// surviving a status patch that lost an SSA conflict) already considers installed.
+// SyncInstalledStatus must mirror the cache unconditionally, regardless of any StoreAction.
+func TestManager_SyncInstalledStatus_MirrorsCacheEvenWhenStatusStartsEmpty(t *testing.T) {
+	m := newTestManager()
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: "ns", Name: "my-rules"}
+	m.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{
+		{Path: "/x", Medium: "oci", Priority: 50, ContentHash: "h1", SpecHash: "s1"},
+	})
+	var status []artifactv1alpha1.InstalledArtifact
+
+	m.SyncInstalledStatus(key, artifact.MediumOCI, &status)
+
+	entry := artifact.FindInstalled(status, artifact.MediumOCI)
+	require.NotNil(t, entry, "status must be populated from the cache even though no Store call happened on this status object")
+	assert.Equal(t, "/x", entry.Path)
+	assert.Equal(t, "s1", entry.SpecHash)
+}
+
+// TestManager_SyncInstalledStatus_ClearsStatusWhenCacheHasNoEntry covers the removal direction:
+// if the cache no longer has an entry for medium, status must not keep a stale one either.
+func TestManager_SyncInstalledStatus_ClearsStatusWhenCacheHasNoEntry(t *testing.T) {
+	m := newTestManager()
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: "ns", Name: "my-rules"}
+	status := []artifactv1alpha1.InstalledArtifact{{Path: "/stale", Medium: "oci"}}
+
+	m.SyncInstalledStatus(key, artifact.MediumOCI, &status)
+
+	assert.Nil(t, artifact.FindInstalled(status, artifact.MediumOCI))
+}
+
+// TestManager_SyncAllInstalledStatus_SyncsEveryMediumGiven covers SyncAllInstalledStatus, the
+// helper each controller's Reconcile defer uses to resync every medium of its artifact type from
+// the cache before patching status: every medium passed in must be synced, whether that means
+// upserting an entry or clearing a stale one.
+func TestManager_SyncAllInstalledStatus_SyncsEveryMediumGiven(t *testing.T) {
+	m := newTestManager()
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: "ns", Name: "my-rules"}
+	m.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{
+		{Path: "/oci", Medium: "oci", Priority: 50, ContentHash: "h-oci"},
+		{Path: "/inline", Medium: "inline", Priority: 90, ContentHash: "h-inline"},
+	})
+	status := []artifactv1alpha1.InstalledArtifact{{Path: "/stale", Medium: "configmap"}}
+
+	m.SyncAllInstalledStatus(key, []artifact.Medium{artifact.MediumOCI, artifact.MediumInline, artifact.MediumConfigMap}, &status)
+
+	ociEntry := artifact.FindInstalled(status, artifact.MediumOCI)
+	require.NotNil(t, ociEntry)
+	assert.Equal(t, "/oci", ociEntry.Path)
+	inlineEntry := artifact.FindInstalled(status, artifact.MediumInline)
+	require.NotNil(t, inlineEntry)
+	assert.Equal(t, "/inline", inlineEntry.Path)
+	assert.Nil(t, artifact.FindInstalled(status, artifact.MediumConfigMap),
+		"a medium the cache has no entry for must be cleared, not left stale")
+}
+
+// TestKeyFromObj covers building a Key from the parent CR object (Plugin, Rulesfile, or Config)
+// that owns it.
+func TestKeyFromObj(t *testing.T) {
+	plugin := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "my-plugin", Namespace: "ns"}}
+
+	key := nodeartifacts.KeyFromObj(nodeartifacts.KindPlugin, plugin)
+
+	assert.Equal(t, nodeartifacts.Key{Kind: nodeartifacts.KindPlugin, Namespace: "ns", Name: "my-plugin"}, key)
+}
+
+func TestManager_GetInstalled_ReturnsIndependentCopy(t *testing.T) {
+	m := newTestManager()
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rules"}
+	m.SeedInstalled(key, []artifactv1alpha1.InstalledArtifact{{Path: "/x", Medium: "oci"}})
+
+	got := m.GetInstalled(key)
+	got[0].Path = "/mutated"
+
+	assert.Equal(t, "/x", m.FindInstalled(key, artifact.MediumOCI).Path, "caller mutation must not affect the cache")
+}
+
 func testPlugin(name string) *artifactv1alpha1.Plugin {
 	return &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+// TestManager_AddPluginConfig_DedupsFromItsOwnCacheNotTheCaller proves AddPluginConfig's dedup
+// decision comes from the manager's own installed-artifact cache rather than the current the
+// caller happens to pass: two calls with an identical plugin config, both passing nil, still
+// dedup on the second (a caller with no tracked state of its own, e.g. right after a restart,
+// gets the same correct behavior as one that tracked it).
+func TestManager_AddPluginConfig_DedupsFromItsOwnCacheNotTheCaller(t *testing.T) {
+	m := newTestManager()
+	fetcher := &artifact.Fetcher{}
+
+	action1, file, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, artifact.StoreActionAdded, action1)
+
+	action2, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
+	require.NoError(t, err)
+	assert.Equal(t, artifact.StoreActionUnchanged, action2)
 }
 
 func TestManager_RemovePluginConfigByName_AllowedWhenNothingRequiresIt(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
 
 	err = m.RemovePluginConfigByName(context.Background(), fetcher, "container", "container")
@@ -91,7 +309,7 @@ func TestManager_RemovePluginConfigByName_AllowedWhenNothingRequiresIt(t *testin
 func TestManager_RemovePluginConfigByName_BlockedWhenSoleProvider(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
 
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rulesfile"}
@@ -111,9 +329,9 @@ func TestManager_RemovePluginConfigByName_AllowedWhenAlternativeCoversTheGroup(t
 		"container": "1.0.0", "container-alt": "1.0.0",
 	}))
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
-	_, _, err = m.AddPluginConfig(context.Background(), testPlugin("container-alt"), nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), testPlugin("container-alt"), fetcher)
 	require.NoError(t, err)
 
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rulesfile"}
@@ -127,13 +345,13 @@ func TestManager_RemovePluginConfigByName_AllowedWhenAlternativeCoversTheGroup(t
 func TestManager_RemovePluginConfigByName_ClearsProvidesOnSuccess(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
 	require.NoError(t, m.RemovePluginConfigByName(context.Background(), fetcher, "container", "container"))
 
 	// container must have been cleared from provides by the removal above; container-alt is now
 	// the sole remaining provider, so removing it next must be blocked.
-	_, _, err = m.AddPluginConfig(context.Background(), testPlugin("container-alt"), nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), testPlugin("container-alt"), fetcher)
 	require.NoError(t, err)
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rulesfile"}
 	m.Sync(rfKey, []nodeartifacts.RequirementGroup{{{Name: "container", Version: "1.0.0"}, {Name: "container-alt", Version: "1.0.0"}}})
@@ -146,14 +364,14 @@ func TestManager_AddPluginConfig_RenameBlockedWhenOldNameStillRequired(t *testin
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
 	pl := testPlugin("container")
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), pl, fetcher)
 	require.NoError(t, err)
 
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rulesfile"}
 	m.Sync(rfKey, []nodeartifacts.RequirementGroup{{{Name: "container", Version: "1.0.0"}}})
 
 	pl.Spec.Config = &artifactv1alpha1.PluginConfig{Name: "renamed"}
-	_, _, err = m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), pl, fetcher)
 
 	require.Error(t, err, "the old name \"container\" is still required, so the rename must be refused")
 	var blocked *nodeartifacts.BlockedError
@@ -164,7 +382,7 @@ func TestManager_AddPluginConfig_RenameBlockedWhenOldNameStillRequired(t *testin
 func TestManager_Sync_ReplacesAndClears(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
 	rfKey := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "my-rulesfile"}
 
@@ -321,7 +539,7 @@ func TestManager_CheckDependency_WaitsForConfiguredCandidate(t *testing.T) {
 	// have loaded since the last poll, so its unknown version must not allow fallback.
 	m.OnFalcoVersionsObserved(versions.Result)
 	check("container", true)
-	_, _, err := m.AddPluginConfig(ctx, testPlugin("json"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(ctx, testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	check("json", false)
 	m.OnFalcoVersionsObserved(compatfake.NewMockVersionsFetcherWithPlugins(map[string]string{
@@ -337,7 +555,7 @@ func TestManager_CheckDependency_WaitsForConfiguredCandidate(t *testing.T) {
 	check("json", false)
 	require.NoError(t, m.RemovePluginConfigByName(ctx, fetcher, "json", "json"))
 	check("container", true)
-	_, _, err = m.AddPluginConfig(ctx, testPlugin("json"), nil, fetcher)
+	_, _, err = m.AddPluginConfig(ctx, testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	check("json", false)
 
@@ -421,7 +639,7 @@ func TestManager_RemovePluginConfigByName_ChecksRemainingVersions(t *testing.T) 
 			fetcher := &artifact.Fetcher{}
 			var configFile *artifact.File
 			for _, name := range []string{"primary", "z-first", "a-second", "unrelated"} {
-				_, file, err := m.AddPluginConfig(t.Context(), testPlugin(name), nil, fetcher)
+				_, file, err := m.AddPluginConfig(t.Context(), testPlugin(name), fetcher)
 				require.NoError(t, err)
 				configFile = file
 			}
@@ -517,7 +735,7 @@ func TestManager_RemovePluginConfigByName_StaleObservationCannotRestoreRemovedPr
 	m := newTestManagerWithFetcher(falco)
 	fetcher := &artifact.Fetcher{}
 	for _, name := range []string{"json", "container"} {
-		_, _, err := m.AddPluginConfig(ctx, testPlugin(name), nil, fetcher)
+		_, _, err := m.AddPluginConfig(ctx, testPlugin(name), fetcher)
 		require.NoError(t, err)
 	}
 	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "rules"}
@@ -536,7 +754,7 @@ func TestManager_RemovePluginConfigByName_StaleObservationCannotRestoreRemovedPr
 	m.OnFalcoVersionsObserved(falco.Result)
 	require.ErrorAs(t, m.RemovePluginConfigByName(ctx, fetcher, "container", "container"), &blocked)
 	// An explicit re-add, unlike a poll, makes json eligible again once observed.
-	_, _, err = m.AddPluginConfig(ctx, testPlugin("json"), nil, fetcher)
+	_, _, err = m.AddPluginConfig(ctx, testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	require.NoError(t, m.RemovePluginConfigByName(ctx, fetcher, "container", "container"))
 }
@@ -546,7 +764,7 @@ func TestManager_RemovePluginConfigByName_ObservedExternalAlternativeStillWorks(
 		"json": "0.7.4", "container": "0.7.1",
 	}))
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(t.Context(), testPlugin("json"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(t.Context(), testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	m.Sync(nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "rules"},
 		[]nodeartifacts.RequirementGroup{{{Name: "json", Version: "0.7.0"}, {Name: "container", Version: "0.7.0"}}})
@@ -557,7 +775,7 @@ func TestManager_RemovePluginConfigByName_ObservedExternalAlternativeStillWorks(
 func TestManager_RemovePluginConfigByName_RetryAfterConfigRemoval(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(t.Context(), testPlugin("json"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(t.Context(), testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	require.NoError(t, m.RemovePluginConfigByName(t.Context(), fetcher, "json", "json"))
 	// A newly registered dependency cannot block retrying the remaining binary/finalizer
@@ -565,7 +783,7 @@ func TestManager_RemovePluginConfigByName_RetryAfterConfigRemoval(t *testing.T) 
 	m.Sync(nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Name: "new-rules"},
 		[]nodeartifacts.RequirementGroup{{{Name: "json", Version: "0.7.0"}}})
 	require.NoError(t, m.RemovePluginConfigByName(t.Context(), fetcher, "json", "json"))
-	_, _, err = m.AddPluginConfig(t.Context(), testPlugin("json"), nil, fetcher)
+	_, _, err = m.AddPluginConfig(t.Context(), testPlugin("json"), fetcher)
 	require.NoError(t, err)
 	var blocked *nodeartifacts.BlockedError
 	require.ErrorAs(t, m.RemovePluginConfigByName(t.Context(), fetcher, "json", "json"), &blocked,
@@ -575,7 +793,7 @@ func TestManager_RemovePluginConfigByName_RetryAfterConfigRemoval(t *testing.T) 
 func TestManager_OnFalcoVersionsObserved_PreservesExistingKeyUpdatesVersion(t *testing.T) {
 	m := newTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 	require.NoError(t, err)
 
 	// AddPluginConfig already triggered an opportunistic refresh via the mock fetcher, which
@@ -622,7 +840,7 @@ func TestManager_OnFalcoVersionsObserved_NotifiesOnNewCapability(t *testing.T) {
 func TestManager_OnFalcoVersionsObserved_NotifiesWhenConfigEntryVersionIsFirstConfirmed(t *testing.T) {
 	// An empty-to-confirmed version transition on an existing provides entry counts as a change.
 	m := newTestManager()
-	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, &artifact.Fetcher{})
+	_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), &artifact.Fetcher{})
 	require.NoError(t, err)
 	ch := m.Events()
 
@@ -806,7 +1024,7 @@ func TestManager_AddPluginConfig_ConcurrentWithCheckRequirement(t *testing.T) {
 	}()
 
 	for range 20 {
-		_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), nil, fetcher)
+		_, _, err := m.AddPluginConfig(context.Background(), testPlugin("container"), fetcher)
 		require.NoError(t, err)
 	}
 	<-done

--- a/internal/pkg/nodeartifacts/pluginconfig.go
+++ b/internal/pkg/nodeartifacts/pluginconfig.go
@@ -176,12 +176,13 @@ func (pc *pluginsConfig) toString() (string, error) {
 // *BlockedError and leaves both the in-memory aggregate and disk untouched, so the rename can be
 // retried on the next reconcile without having lost the old entry in the interim.
 //
-// current is the caller's previously-tracked config file (nil if none), matching
-// ArtifactStore.Store's convention; passed through so an unchanged write can be skipped.
+// The file this aggregate is written to is a single shared, node-level singleton (keyed by
+// PluginConfigKey in the installed-artifact cache), not per-Plugin-CR; whether the write can be
+// skipped as unchanged is decided from that cache entry, not from anything the caller passes in.
 // fetcher prepares the serialized aggregate into a FetchResult (content hash, perm).
 func (m *Manager) AddPluginConfig(ctx context.Context, plugin *artifactv1alpha1.Plugin,
-	current *artifact.File, fetcher artifact.ArtifactFetcher) (artifact.StoreAction, *artifact.File, error) {
-	action, file, err := m.addPluginConfigLocked(ctx, plugin, current, fetcher)
+	fetcher artifact.ArtifactFetcher) (artifact.StoreAction, *artifact.File, error) {
+	action, file, err := m.addPluginConfigLocked(ctx, plugin, fetcher)
 	if err != nil {
 		return action, file, err
 	}
@@ -197,7 +198,7 @@ func (m *Manager) AddPluginConfig(ctx context.Context, plugin *artifactv1alpha1.
 }
 
 func (m *Manager) addPluginConfigLocked(ctx context.Context, plugin *artifactv1alpha1.Plugin,
-	current *artifact.File, fetcher artifact.ArtifactFetcher) (artifact.StoreAction, *artifact.File, error) {
+	fetcher artifact.ArtifactFetcher) (artifact.StoreAction, *artifact.File, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -215,7 +216,7 @@ func (m *Manager) addPluginConfigLocked(ctx context.Context, plugin *artifactv1a
 	}
 	updated.addConfig(artifact.DefaultArtifactDirs().Plugin, plugin)
 
-	action, file, err := m.writePluginsConfig(ctx, current, fetcher, updated)
+	action, file, err := m.writePluginsConfig(ctx, fetcher, updated, false)
 	if err != nil {
 		return artifact.StoreActionNone, nil, err
 	}
@@ -268,7 +269,9 @@ func (m *Manager) RemovePluginConfigByName(ctx context.Context, fetcher artifact
 	updated := m.pluginsConfig.clone()
 	updated.removeByName(configName)
 
-	if _, _, err := m.writePluginsConfig(ctx, nil, fetcher, updated); err != nil {
+	// Always rewritten (even down to an explicitly-empty "plugins: []"), bypassing the dedup
+	// check: see this function's doc comment for why the file is never left un-rewritten.
+	if _, _, err := m.writePluginsConfig(ctx, fetcher, updated, true); err != nil {
 		return err
 	}
 
@@ -281,10 +284,12 @@ func (m *Manager) RemovePluginConfigByName(ctx context.Context, fetcher artifact
 	return nil
 }
 
-// writePluginsConfig serializes the current in-memory aggregate and stores it, skipping the
-// write when current's content hash already matches what's on disk. Caller must hold m.mu.
-func (m *Manager) writePluginsConfig(ctx context.Context, current *artifact.File, fetcher artifact.ArtifactFetcher,
-	config *pluginsConfig) (artifact.StoreAction, *artifact.File, error) {
+// writePluginsConfig serializes the current in-memory aggregate and stores it. Unless force is
+// set, the write is skipped when the installed cache's tracked current content hash already
+// matches what's on disk; force bypasses that check entirely (see RemovePluginConfigByName's doc
+// comment for why it needs this). Caller must hold m.mu.
+func (m *Manager) writePluginsConfig(ctx context.Context, fetcher artifact.ArtifactFetcher,
+	config *pluginsConfig, force bool) (artifact.StoreAction, *artifact.File, error) {
 	pluginConfigString, err := config.toString()
 	if err != nil {
 		return artifact.StoreActionNone, nil, fmt.Errorf("convert plugin config to string: %w", err)
@@ -293,10 +298,16 @@ func (m *Manager) writePluginsConfig(ctx context.Context, current *artifact.File
 	if err != nil {
 		return artifact.StoreActionNone, nil, fmt.Errorf("prepare plugin config content: %w", err)
 	}
-	if current != nil {
+	current := artifact.FindInstalled(m.installed[PluginConfigKey], artifact.MediumInline)
+	if !force && current != nil {
 		if ok, verifyErr := m.store.Verify(ctx, &artifact.File{Path: current.Path, ContentHash: result.ContentHash}); verifyErr == nil && ok {
 			return artifact.StoreActionUnchanged, nil, nil
 		}
 	}
-	return m.store.Store(ctx, current, pluginConfigFileName, priority.MaxPriority, artifact.TypeConfig, artifact.MediumInline, result)
+	action, file, err := m.store.Store(ctx, current, pluginConfigFileName, priority.MaxPriority, artifact.TypeConfig, artifact.MediumInline, result)
+	if err != nil {
+		return action, file, err
+	}
+	m.upsertInstalledLocked(PluginConfigKey, action, artifact.MediumInline, file)
+	return action, file, nil
 }

--- a/internal/pkg/nodeartifacts/pluginconfig_test.go
+++ b/internal/pkg/nodeartifacts/pluginconfig_test.go
@@ -58,7 +58,7 @@ func TestManager_ObservationPreservesDesiredPluginConfig(t *testing.T) {
 	m := NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
 	plugin := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "container"}}
 	fetcher := &artifact.Fetcher{}
-	_, file, err := m.AddPluginConfig(ctx, plugin, nil, fetcher)
+	_, file, err := m.AddPluginConfig(ctx, plugin, fetcher)
 	require.NoError(t, err)
 	rulesKey := Key{Kind: KindRulesfile, Name: "rules"}
 	m.Sync(rulesKey, []RequirementGroup{{{Name: "container", Version: "0.7.0"}}})
@@ -718,7 +718,7 @@ func TestManager_AddPluginConfig_WritesConfigForBasicPlugin(t *testing.T) {
 		},
 	}
 
-	action, file, err := m.AddPluginConfig(context.Background(), pl, nil, &artifact.Fetcher{})
+	action, file, err := m.AddPluginConfig(context.Background(), pl, &artifact.Fetcher{})
 
 	require.NoError(t, err)
 	assert.Equal(t, artifact.StoreActionAdded, action)
@@ -741,7 +741,7 @@ func TestManager_AddPluginConfig_WritesConfigWithInitConfig(t *testing.T) {
 		},
 	}
 
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, &artifact.Fetcher{})
+	_, _, err := m.AddPluginConfig(context.Background(), pl, &artifact.Fetcher{})
 
 	require.NoError(t, err)
 	found := findPluginConfig(m.pluginsConfig.Configs, "container")
@@ -753,12 +753,12 @@ func TestManager_AddPluginConfig_RenameRemovesStaleEntryWhenUnblocked(t *testing
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
 	pl := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "my-plugin"}}
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), pl, fetcher)
 	require.NoError(t, err)
 	require.NotNil(t, findPluginConfig(m.pluginsConfig.Configs, "my-plugin"))
 
 	pl.Spec.Config = &artifactv1alpha1.PluginConfig{Name: "new-name"}
-	_, _, err = m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), pl, fetcher)
 
 	require.NoError(t, err)
 	require.Len(t, m.pluginsConfig.Configs, 1)
@@ -771,10 +771,10 @@ func TestManager_AddPluginConfig_SameConfigNameDoesNotRemoveEntry(t *testing.T) 
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
 	pl := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), pl, fetcher)
 	require.NoError(t, err)
 
-	_, _, err = m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), pl, fetcher)
 
 	require.NoError(t, err)
 	require.Len(t, m.pluginsConfig.Configs, 1)
@@ -786,7 +786,7 @@ func TestManager_AddPluginConfig_StoreFailureSurfacesError(t *testing.T) {
 	m := NewManager(&artifact.LocalStore{FS: mockFS, Dirs: artifact.DefaultArtifactDirs()}, compatfake.NewMockVersionsFetcher(nil))
 	pl := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "test-plugin"}}
 
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, &artifact.Fetcher{})
+	_, _, err := m.AddPluginConfig(context.Background(), pl, &artifact.Fetcher{})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "disk full")
@@ -805,7 +805,7 @@ func TestManager_PluginConfigWriteFailurePreservesCommittedState(t *testing.T) {
 			m := NewManager(&artifact.LocalStore{FS: fs, Dirs: artifact.DefaultArtifactDirs()}, falco)
 			plugin := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}
 			fetcher := &artifact.Fetcher{}
-			_, file, err := m.AddPluginConfig(ctx, plugin, nil, fetcher)
+			_, file, err := m.AddPluginConfig(ctx, plugin, fetcher)
 			require.NoError(t, err)
 			before := string(fs.Files[file.Path])
 			fs.WriteErr = fmt.Errorf("disk full")
@@ -814,10 +814,10 @@ func TestManager_PluginConfigWriteFailurePreservesCommittedState(t *testing.T) {
 				err = m.RemovePluginConfigByName(ctx, fetcher, "json", "json")
 			case renameOperation:
 				plugin.Spec.Config = &artifactv1alpha1.PluginConfig{Name: "renamed"}
-				_, _, err = m.AddPluginConfig(ctx, plugin, file, fetcher)
+				_, _, err = m.AddPluginConfig(ctx, plugin, fetcher)
 			case "update":
 				plugin.Spec.Config = &artifactv1alpha1.PluginConfig{OpenParams: "changed"}
-				_, _, err = m.AddPluginConfig(ctx, plugin, file, fetcher)
+				_, _, err = m.AddPluginConfig(ctx, plugin, fetcher)
 			}
 			require.ErrorContains(t, err, "disk full")
 			assert.Equal(t, before, string(fs.Files[file.Path]))
@@ -833,7 +833,7 @@ func TestManager_PluginConfigWriteFailurePreservesCommittedState(t *testing.T) {
 				assert.Empty(t, m.pluginsConfig.LoadPlugins)
 				assert.True(t, m.provides["json"].Removed)
 			} else {
-				_, _, err = m.AddPluginConfig(ctx, plugin, file, fetcher)
+				_, _, err = m.AddPluginConfig(ctx, plugin, fetcher)
 				require.NoError(t, err)
 				assert.NotEqual(t, before, string(fs.Files[file.Path]))
 				if operation == renameOperation {
@@ -852,7 +852,7 @@ func TestManager_RemovePluginConfigByName_EmptyAfterRemovalKeepsFileOnDisk(t *te
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
 	pl := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}
-	_, file, err := m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, file, err := m.AddPluginConfig(context.Background(), pl, fetcher)
 	require.NoError(t, err)
 
 	err = m.RemovePluginConfigByName(context.Background(), fetcher, "json", "json")
@@ -871,9 +871,9 @@ func TestManager_RemovePluginConfigByName_EmptyAfterRemovalKeepsFileOnDisk(t *te
 func TestManager_RemovePluginConfigByName_NotEmptyAfterRemovalWritesUpdatedConfig(t *testing.T) {
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}, fetcher)
 	require.NoError(t, err)
-	_, _, err = m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "k8saudit"}}, nil, fetcher)
+	_, _, err = m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "k8saudit"}}, fetcher)
 	require.NoError(t, err)
 
 	err = m.RemovePluginConfigByName(context.Background(), fetcher, "json", "json")
@@ -887,7 +887,7 @@ func TestManager_RemovePluginConfigByName_NotEmptyAfterRemovalWritesUpdatedConfi
 func TestManager_RemovePluginConfigByName_AlreadyAbsentIsANoOp(t *testing.T) {
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
-	_, _, err := m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}, fetcher)
 	require.NoError(t, err)
 
 	err = m.RemovePluginConfigByName(context.Background(), fetcher, "nonexistent", "nonexistent")
@@ -901,11 +901,33 @@ func TestManager_RemovePluginConfigByName_ForgetsCrToConfigName(t *testing.T) {
 	m := newPluginConfigTestManager()
 	fetcher := &artifact.Fetcher{}
 	pl := &artifactv1alpha1.Plugin{ObjectMeta: metav1.ObjectMeta{Name: "json"}}
-	_, _, err := m.AddPluginConfig(context.Background(), pl, nil, fetcher)
+	_, _, err := m.AddPluginConfig(context.Background(), pl, fetcher)
 	require.NoError(t, err)
 	require.Contains(t, m.crToConfigName, "json")
 
 	require.NoError(t, m.RemovePluginConfigByName(context.Background(), fetcher, "json", "json"))
 
 	assert.NotContains(t, m.crToConfigName, "json")
+}
+
+// TestWritePluginsConfig_ForceStillClassifiesUnchangedContentCorrectly reproduces a real bug:
+// writePluginsConfig(force=true) used to pass a nil current to Store regardless of what was
+// already cached, so a forced rewrite of byte-identical content (e.g. RemovePluginConfigByName
+// called when the entry was already absent) was always misreported as StoreActionAdded, a fresh
+// install. force must only bypass the skip-if-unchanged early return, not the current lookup
+// itself, so Store can still classify what actually happened.
+func TestWritePluginsConfig_ForceStillClassifiesUnchangedContentCorrectly(t *testing.T) {
+	m := newPluginConfigTestManager()
+	fetcher := &artifact.Fetcher{}
+	config := &pluginsConfig{}
+
+	action, file, err := m.writePluginsConfig(context.Background(), fetcher, config, true)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	assert.Equal(t, artifact.StoreActionAdded, action, "first write of the shared config file is a real install")
+
+	action, _, err = m.writePluginsConfig(context.Background(), fetcher, config, true)
+	require.NoError(t, err)
+	assert.Equal(t, artifact.StoreActionUnchanged, action,
+		"forced rewrite of byte-identical content must not be misreported as a fresh install")
 }

--- a/internal/pkg/nodeartifacts/warmsync.go
+++ b/internal/pkg/nodeartifacts/warmsync.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
+	"github.com/falcosecurity/falco-operator/internal/pkg/artifact"
 	"github.com/falcosecurity/falco-operator/internal/pkg/controllerhelper"
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 )
@@ -123,9 +125,110 @@ func WarmSync(ctx context.Context, cl client.Client, mgr *Manager, namespace, no
 			if !ok || rulesfile.Status.ArtifactMeta == nil {
 				continue
 			}
-			mgr.Sync(Key{Kind: KindRulesfile, Name: o.ownerName},
+			mgr.Sync(Key{Kind: KindRulesfile, Namespace: namespace, Name: o.ownerName},
 				RequirementGroupsFromDependencies(rulesfile.Status.ArtifactMeta.Dependencies))
 		}
 	}
+
+	return seedInstalledCacheFromDisk(ctx, mgr, nodeList, namespace)
+}
+
+// seedInstalledCacheFromDisk populates mgr's installed-artifact cache from disk ground truth for
+// every artifact still known to this node, and removes any file whose artifact name has no
+// ArtifactNode at all on this node.
+//
+// The cache, not any ArtifactNode's status, is what every filesystem decision (skip vs. rewrite,
+// what to remove) is based on from here on; status is a write-through mirror for observability
+// only. Seeding it from disk rather than from status means a crash between writing a file and
+// patching status recording it (or any other way status drifted from reality while this process
+// wasn't running) can never leave a file invisible to cleanup: the cache reflects what's actually
+// there, not what a possibly-stale status object last said.
+//
+// A name with files on disk but no ArtifactNode for this node at all (its parent CR was deleted
+// and fully garbage collected while nothing else was ever going to ask about it again) is removed
+// immediately, mirroring the removal cleanupStaleMedium already performs during normal reconciles.
+func seedInstalledCacheFromDisk(ctx context.Context, mgr *Manager, nodeList *artifactv1alpha1.ArtifactNodeList, namespace string) error {
+	logger := log.FromContext(ctx)
+
+	kinds := []struct {
+		ownerKind    string
+		cacheKind    Kind
+		artifactType artifact.Type
+	}{
+		{controllerhelper.KindPlugin, KindPlugin, artifact.TypePlugin},
+		{controllerhelper.KindRulesfile, KindRulesfile, artifact.TypeRulesfile},
+		{controllerhelper.KindConfig, KindConfig, artifact.TypeConfig},
+	}
+
+	liveNames := map[string]map[string]bool{}
+	statusByName := map[string]map[string][]artifactv1alpha1.InstalledArtifact{}
+	for i := range nodeList.Items {
+		n := &nodeList.Items[i]
+		for _, ref := range n.OwnerReferences {
+			if ref.Controller == nil || !*ref.Controller {
+				continue
+			}
+			if liveNames[ref.Kind] == nil {
+				liveNames[ref.Kind] = map[string]bool{}
+			}
+			liveNames[ref.Kind][ref.Name] = true
+			if statusByName[ref.Kind] == nil {
+				statusByName[ref.Kind] = map[string][]artifactv1alpha1.InstalledArtifact{}
+			}
+			statusByName[ref.Kind][ref.Name] = n.Status.InstalledArtifacts
+			break
+		}
+	}
+
+	for _, kt := range kinds {
+		disk, err := mgr.ScanAll(ctx, kt.artifactType)
+		if err != nil {
+			return fmt.Errorf("warm sync: scan installed %s artifacts from disk: %w", kt.ownerKind, err)
+		}
+
+		// The shared plugins-config aggregate lives in the same directory as Config CRs' own
+		// files but isn't one: it belongs to the single node-level PluginConfigKey, not to any
+		// Config ArtifactNode, and must never be treated as orphaned.
+		if kt.ownerKind == controllerhelper.KindConfig {
+			if files, ok := disk[pluginConfigFileName]; ok {
+				mgr.SeedInstalled(PluginConfigKey, files)
+				delete(disk, pluginConfigFileName)
+			}
+		}
+
+		live := liveNames[kt.ownerKind]
+		statusForKind := statusByName[kt.ownerKind]
+		for name, files := range disk {
+			key := Key{Kind: kt.cacheKind, Namespace: namespace, Name: name}
+			if !live[name] {
+				logger.Info("Removing orphaned artifact files with no ArtifactNode on this node",
+					"kind", kt.ownerKind, "name", name)
+				if err := mgr.Remove(ctx, key, files); err != nil {
+					logger.Error(err, "warm sync: unable to remove orphaned artifact files",
+						"kind", kt.ownerKind, "name", name)
+				}
+				continue
+			}
+			recoverSpecHashFromStatus(files, statusForKind[name])
+			mgr.SeedInstalled(key, files)
+		}
+	}
 	return nil
+}
+
+// recoverSpecHashFromStatus backfills SpecHash on disk-derived entries from status, for any
+// medium where status still describes the exact same on-disk content (matching ContentHash).
+// ScanAll can only recover ContentHash from file bytes; SpecHash reflects the parent spec, which
+// isn't recoverable from content alone. Without this, every OCI/inline artifact would look like
+// its parent spec had changed on the very first reconcile after a sidecar restart, forcing a
+// needless re-fetch from the OCI artifact server even though nothing actually changed.
+func recoverSpecHashFromStatus(files, status []artifactv1alpha1.InstalledArtifact) {
+	for i := range files {
+		for _, s := range status {
+			if s.Medium == files[i].Medium && s.ContentHash == files[i].ContentHash && s.SpecHash != "" {
+				files[i].SpecHash = s.SpecHash
+				break
+			}
+		}
+	}
 }

--- a/internal/pkg/nodeartifacts/warmsync_test.go
+++ b/internal/pkg/nodeartifacts/warmsync_test.go
@@ -18,11 +18,15 @@ package nodeartifacts_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	artifactv1alpha1 "github.com/falcosecurity/falco-operator/api/artifact/v1alpha1"
@@ -33,6 +37,11 @@ import (
 	"github.com/falcosecurity/falco-operator/internal/pkg/index"
 	"github.com/falcosecurity/falco-operator/internal/pkg/nodeartifacts"
 )
+
+func sha256hexForTest(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
 
 func controllerRef(kind, name string) metav1.OwnerReference {
 	t := true
@@ -162,6 +171,207 @@ func TestWarmSync_IgnoresOtherNodes(t *testing.T) {
 	require.NoError(t, nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube"))
 
 	require.NoError(t, mgr.RemovePluginConfigByName(context.Background(), &artifact.Fetcher{}, "container", "container"))
+}
+
+// TestWarmSync_SeedsInstalledCacheFromDiskEvenWhenStatusDoesNotKnowAboutIt simulates the crash
+// window where a file was written to disk but the process died before the status patch
+// recording it landed: status is missing the inline medium's entry even though the file exists
+// on disk. WarmSync must seed the manager's cache from disk ground truth regardless, since that
+// cache (never status) is what every later filesystem decision reads from.
+func TestWarmSync_SeedsInstalledCacheFromDiskEvenWhenStatusDoesNotKnowAboutIt(t *testing.T) {
+	sch := newWarmSyncTestScheme(t)
+
+	rulesfile := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules", Namespace: "ns"},
+	}
+	rulesfileNode := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rulesfile--my-rules--minikube",
+			Namespace:       "ns",
+			Labels:          map[string]string{"artifact.falcosecurity.dev/node": "minikube"},
+			OwnerReferences: []metav1.OwnerReference{controllerRef("Rulesfile", "my-rules")},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: "minikube"},
+		Status: artifactv1alpha1.ArtifactNodeStatus{
+			InstalledArtifacts: []artifactv1alpha1.InstalledArtifact{
+				{Path: "/rulesfiles/50-01-my-rules-oci.yaml", Medium: "oci", Priority: 50, ContentHash: "oci-hash"},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(rulesfile, rulesfileNode).
+		WithStatusSubresource(&artifactv1alpha1.ArtifactNode{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeNodeName, index.ArtifactNodeNodeNameIndexer).
+		Build()
+
+	fsys := fsfake.NewMockFileSystem()
+	fsys.Files["/rulesfiles/50-01-my-rules-oci.yaml"] = []byte("oci content")
+	fsys.Files["/rulesfiles/50-03-my-rules-inline.yaml"] = []byte("inline content")
+	store := &artifact.LocalStore{FS: fsys, Dirs: artifact.ArtifactDirs{Rulesfile: "/rulesfiles", Plugin: "/plugins", Config: "/configs"}}
+	mgr := nodeartifacts.NewManager(store, compatfake.NewMockVersionsFetcher(nil))
+
+	require.NoError(t, nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube"))
+
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: "ns", Name: "my-rules"}
+	inlineEntry := mgr.FindInstalled(key, artifact.MediumInline)
+	require.NotNil(t, inlineEntry, "the cache must reflect the file already on disk, regardless of what status says")
+	assert.Equal(t, "/rulesfiles/50-03-my-rules-inline.yaml", inlineEntry.Path)
+
+	// Status itself is never touched by WarmSync: it stays exactly as it was on disk/durably
+	// stored, since it's read only by kubectl, never by a filesystem decision.
+	got := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rulesfileNode), got))
+	assert.Nil(t, artifact.FindInstalled(got.Status.InstalledArtifacts, artifact.MediumInline))
+
+	// The file itself must not have been touched (still present, unmodified).
+	assert.Equal(t, []byte("inline content"), fsys.Files["/rulesfiles/50-03-my-rules-inline.yaml"])
+}
+
+// TestWarmSync_RemovesOrphanedFilesWithNoArtifactNode covers a name with files on disk but no
+// ArtifactNode at all for this node (e.g. its parent CR was deleted and fully garbage collected
+// while this node had no durable status recording those files, or before this scan existed).
+// Nothing will ever ask about that name again, so WarmSync must remove it immediately.
+func TestWarmSync_RemovesOrphanedFilesWithNoArtifactNode(t *testing.T) {
+	sch := newWarmSyncTestScheme(t)
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithStatusSubresource(&artifactv1alpha1.ArtifactNode{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeNodeName, index.ArtifactNodeNodeNameIndexer).
+		Build()
+
+	fsys := fsfake.NewMockFileSystem()
+	fsys.Files["/rulesfiles/50-01-orphaned-oci.yaml"] = []byte("stray content")
+	store := &artifact.LocalStore{FS: fsys, Dirs: artifact.ArtifactDirs{Rulesfile: "/rulesfiles", Plugin: "/plugins", Config: "/configs"}}
+	mgr := nodeartifacts.NewManager(store, compatfake.NewMockVersionsFetcher(nil))
+
+	require.NoError(t, nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube"))
+
+	_, exists := fsys.Files["/rulesfiles/50-01-orphaned-oci.yaml"]
+	assert.False(t, exists, "orphaned file with no matching ArtifactNode must be removed")
+}
+
+// TestWarmSync_NeverPatchesStatus verifies WarmSync never writes to any ArtifactNode's status,
+// since the cache it seeds (not status) is now the sole source filesystem decisions read from;
+// status is a write-through mirror later reconciles maintain for observability only.
+func TestWarmSync_NeverPatchesStatus(t *testing.T) {
+	sch := newWarmSyncTestScheme(t)
+
+	rulesfile := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules", Namespace: "ns"},
+	}
+	rulesfileNode := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rulesfile--my-rules--minikube",
+			Namespace:       "ns",
+			Labels:          map[string]string{"artifact.falcosecurity.dev/node": "minikube"},
+			OwnerReferences: []metav1.OwnerReference{controllerRef("Rulesfile", "my-rules")},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: "minikube"},
+		Status: artifactv1alpha1.ArtifactNodeStatus{
+			InstalledArtifacts: []artifactv1alpha1.InstalledArtifact{
+				{Path: "/rulesfiles/50-01-my-rules-oci.yaml", Medium: "oci", Priority: 50, ContentHash: sha256hexForTest("oci content")},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(rulesfile, rulesfileNode).
+		WithStatusSubresource(&artifactv1alpha1.ArtifactNode{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeNodeName, index.ArtifactNodeNodeNameIndexer).
+		Build()
+
+	got := &artifactv1alpha1.ArtifactNode{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rulesfileNode), got))
+	beforeRV := got.ResourceVersion
+
+	fsys := fsfake.NewMockFileSystem()
+	fsys.Files["/rulesfiles/50-01-my-rules-oci.yaml"] = []byte("oci content")
+	store := &artifact.LocalStore{FS: fsys, Dirs: artifact.ArtifactDirs{Rulesfile: "/rulesfiles", Plugin: "/plugins", Config: "/configs"}}
+	mgr := nodeartifacts.NewManager(store, compatfake.NewMockVersionsFetcher(nil))
+
+	require.NoError(t, nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube"))
+
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(rulesfileNode), got))
+	assert.Equal(t, beforeRV, got.ResourceVersion, "no patch should be issued when disk already agrees with status")
+}
+
+// TestWarmSync_RecoversSpecHashFromStatusWhenContentMatches reproduces a real regression: cache
+// entries seeded from disk never carried SpecHash (ScanAll can only recover ContentHash from file
+// bytes), so every OCI-sourced artifact looked like its parent spec had changed on the first
+// reconcile after every sidecar restart, forcing a needless re-fetch from the OCI artifact server.
+// When status still describes the exact same on-disk content (matching ContentHash), WarmSync
+// must recover SpecHash from it instead of leaving the seeded entry blank.
+func TestWarmSync_RecoversSpecHashFromStatusWhenContentMatches(t *testing.T) {
+	sch := newWarmSyncTestScheme(t)
+
+	rulesfile := &artifactv1alpha1.Rulesfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-rules", Namespace: "ns"},
+	}
+	ociContentHash := sha256hexForTest("oci content")
+	rulesfileNode := &artifactv1alpha1.ArtifactNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rulesfile--my-rules--minikube",
+			Namespace:       "ns",
+			Labels:          map[string]string{"artifact.falcosecurity.dev/node": "minikube"},
+			OwnerReferences: []metav1.OwnerReference{controllerRef("Rulesfile", "my-rules")},
+		},
+		Spec: artifactv1alpha1.ArtifactNodeSpec{NodeName: "minikube"},
+		Status: artifactv1alpha1.ArtifactNodeStatus{
+			InstalledArtifacts: []artifactv1alpha1.InstalledArtifact{
+				{Path: "/rulesfiles/50-01-my-rules-oci.yaml", Medium: "oci", Priority: 50, ContentHash: ociContentHash, SpecHash: "spec-abc"},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(rulesfile, rulesfileNode).
+		WithStatusSubresource(&artifactv1alpha1.ArtifactNode{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeNodeName, index.ArtifactNodeNodeNameIndexer).
+		Build()
+
+	fsys := fsfake.NewMockFileSystem()
+	fsys.Files["/rulesfiles/50-01-my-rules-oci.yaml"] = []byte("oci content")
+	store := &artifact.LocalStore{FS: fsys, Dirs: artifact.ArtifactDirs{Rulesfile: "/rulesfiles", Plugin: "/plugins", Config: "/configs"}}
+	mgr := nodeartifacts.NewManager(store, compatfake.NewMockVersionsFetcher(nil))
+
+	require.NoError(t, nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube"))
+
+	key := nodeartifacts.Key{Kind: nodeartifacts.KindRulesfile, Namespace: "ns", Name: "my-rules"}
+	ociEntry := mgr.FindInstalled(key, artifact.MediumOCI)
+	require.NotNil(t, ociEntry)
+	assert.Equal(t, "spec-abc", ociEntry.SpecHash,
+		"SpecHash must be recovered from status when content on disk still matches it")
+}
+
+// TestWarmSync_FailsWhenScanAllErrors reproduces a real bug: a ScanAll error for one artifact
+// Kind used to be logged and swallowed, letting WarmSync report success with that Kind's cache
+// left completely unseeded. A later handleDeletion for an artifact of that Kind would then read
+// nothing from the cache and release the finalizer without cleaning up whatever is actually on
+// disk. WarmSync must instead fail loudly, since WarmSyncRunnable.Warmup surfaces its error by
+// failing manager startup (see warmsync_runnable.go) rather than proceeding half-seeded.
+func TestWarmSync_FailsWhenScanAllErrors(t *testing.T) {
+	sch := newWarmSyncTestScheme(t)
+
+	cl := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithStatusSubresource(&artifactv1alpha1.ArtifactNode{}).
+		WithIndex(&artifactv1alpha1.ArtifactNode{}, index.ArtifactNodeNodeName, index.ArtifactNodeNodeNameIndexer).
+		Build()
+
+	fsys := fsfake.NewMockFileSystem()
+	fsys.Files["/plugins/json.so"] = []byte("plugin content")
+	fsys.ReadErr = assert.AnError
+	store := &artifact.LocalStore{FS: fsys, Dirs: artifact.ArtifactDirs{Rulesfile: "/rulesfiles", Plugin: "/plugins", Config: "/configs"}}
+	mgr := nodeartifacts.NewManager(store, compatfake.NewMockVersionsFetcher(nil))
+
+	err := nodeartifacts.WarmSync(context.Background(), cl, mgr, "ns", "minikube")
+
+	require.Error(t, err, "a ScanAll failure must fail WarmSync instead of leaving that Kind's cache silently unseeded")
 }
 
 func TestWarmSync_SkipsNodesBeingDeleted(t *testing.T) {

--- a/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-recovers-spechash/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-recovers-spechash/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: rulesfile-warmsync-recovers-spechash
+spec:
+  description: |
+    Regression test for the artifact-operator sidecar's WarmSync: when it seeds the
+    installed-artifact cache from disk at startup, it must recover each entry's SpecHash
+    from the ArtifactNode's still-accurate status (matched by ContentHash) rather than
+    leaving it blank. If it didn't, the reconcile right after every sidecar restart would
+    see current.SpecHash == "" != parentSpecHash and force a needless re-fetch from the OCI
+    artifact server for every installed artifact, even though nothing changed.
+
+    "Restart" here specifically means the artifact-operator CONTAINER crashing and coming
+    back (e.g. an OOM kill or a panic), not the Pod being replaced: the directories it
+    writes into (falco-configs/falco-rulesfiles/falco-plugins, see
+    internal/pkg/resources/falco.go) are EmptyDir volumes, torn down and recreated empty
+    whenever the Pod itself is replaced. A Pod-level restart would legitimately find nothing
+    on disk and have to re-fetch regardless of this fix, proving nothing about it either
+    way. So this kills only the artifact-operator process in place (see
+    restart_artifact_operator_container.sh), leaving the Pod, its UID, and its EmptyDir
+    volumes untouched, which is the actual scenario WarmSync's disk-seeded cache exists for.
+
+    Expected outcome: after the container restarts, the new process's first reconcile of the
+    Rulesfile does not write anything to disk again (no "Rulesfile OCI artifact written to
+    disk" log line appears in its own logs, which only ever contain what it logged since it
+    started), and the file and Programmed=True condition are unaffected.
+
+  bindings:
+    - name: falco_name
+      value: falco-warmsync-spechash-test
+    - name: rulesfile_name
+      value: rulesfile-warmsync-spechash-test
+    - name: test_name
+      value: rulesfile-warmsync-recovers-spechash
+    - name: oci_registry
+      value: registry.oci-registry.svc.cluster.local:5000
+
+  steps:
+    - name: "Step 01: Create-falco"
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_name
+              value: ($falco_name)
+            - name: namespace
+              value: ($namespace)
+
+    - name: "Step 02: Create-rulesfile"
+      description: |
+        falco-test/rulesfile-engine-req-met declares only an engine-version requirement
+        (always satisfied), so this needs no plugin installed first.
+      try:
+        - apply:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Rulesfile
+              metadata:
+                name: ($rulesfile_name)
+                namespace: ($namespace)
+              spec:
+                ociArtifact:
+                  image:
+                    repository: falco-test/rulesfile-engine-req-met
+                    tag: latest
+                  registry:
+                    name: ($oci_registry)
+                    plainHTTP: true
+        - assert:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Rulesfile
+              metadata:
+                name: ($rulesfile_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'OCIArtifactProgrammed']):
+                  - status: 'True'
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+
+    - name: "Step 03: Assert-file-on-disk"
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: DIR
+                value: /etc/falco/rules.d
+              - name: FILE_PATTERN
+                value: ($rulesfile_name)
+            content: |
+              bash ../../common/scripts/check_file_on_node.sh
+
+    - name: "Step 04: Restart-artifact-operator-container-in-place"
+      description: |
+        Kills and waits for the artifact-operator process to come back inside the SAME Pod
+        (see the script's own doc comment for why this must never be a Pod-level restart).
+        The ArtifactNode's durable status is untouched throughout, so the new process's
+        WarmSync has the SpecHash to recover.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+            content: |
+              bash ../../common/scripts/restart_artifact_operator_container.sh
+
+    - name: "Step 05: Assert-no-refetch-after-restart"
+      description: |
+        The restarted process's own logs only ever contain what it logged since it started,
+        so any occurrence at all of the "written to disk" success log for this Rulesfile
+        means a needless re-fetch+rewrite happened on the very first reconcile after
+        restart: the regression this test guards against. Polls for a settle window rather
+        than checking once, since the first reconcile may take a moment after the container
+        reports ready.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: CONTAINER
+                value: artifact-operator
+              - name: PATTERN
+                value: Rulesfile OCI artifact written to disk
+              - name: MAX_RETRIES
+                value: "20"
+            content: |
+              bash ../../common/scripts/check_log_absent_on_pod.sh
+
+    - name: "Step 06: Assert-still-programmed-and-file-present"
+      description: Sanity check that the artifact itself is unaffected by the restart.
+      try:
+        - assert:
+            resource:
+              apiVersion: artifact.falcosecurity.dev/v1alpha1
+              kind: Rulesfile
+              metadata:
+                name: ($rulesfile_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'OCIArtifactProgrammed']):
+                  - status: 'True'
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: DIR
+                value: /etc/falco/rules.d
+              - name: FILE_PATTERN
+                value: ($rulesfile_name)
+            content: |
+              bash ../../common/scripts/check_file_on_node.sh
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-removes-orphaned-file/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-removes-orphaned-file/chainsaw-test.yaml
@@ -1,0 +1,126 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: rulesfile-warmsync-removes-orphaned-file
+spec:
+  description: |
+    Regression test for the artifact-operator sidecar's WarmSync: at startup it scans disk
+    (ArtifactStore.ScanAll) for every artifact file, and any name with files on disk but no
+    ArtifactNode at all for this node is removed immediately, since nothing will ever ask
+    about it again. This is the disk-ground-truth cleanup path, distinct from a normal
+    finalizer-driven deletion (which the per-node sidecar itself performs while running).
+
+    ScanAll doesn't care WHY a file has no matching live ArtifactNode, only that it doesn't, so
+    this test never creates a real Rulesfile at all: it writes a correctly-named file (matching
+    the "PP-SS-{name}-oci.yaml" convention scan.go parses) straight into rules.d via kubectl
+    exec, simulating a file whose parent CR and ArtifactNode are long gone. Deleting a real
+    Rulesfile instead would not reliably reach that state: the still-running sidecar's own
+    Reconcile calls EnsureFinalizer immediately after handleDeletion, so a finalizer stripped out
+    from under it gets re-added before a delete can land, and the file ends up removed by a
+    perfectly normal (and correct) handleDeletion rather than orphaned. Writing the file directly
+    has no such live reconcile loop to race against, since no CR for it ever existed.
+
+    The artifact-operator container is then restarted IN PLACE (never the Pod: see
+    restart_artifact_operator_container.sh's doc comment for why the shared EmptyDir
+    volumes make that the only way to test WarmSync's disk-recovery logic at all), and the
+    new process's WarmSync is expected to sweep the orphaned file from disk.
+
+  bindings:
+    - name: falco_name
+      value: falco-warmsync-orphan-test
+    - name: rulesfile_name
+      value: rulesfile-warmsync-orphan-test
+    - name: test_name
+      value: rulesfile-warmsync-removes-orphaned-file
+
+  steps:
+    - name: "Step 01: Create-falco"
+      use:
+        template: ../../common/_step_templates/apply-assert-falco.yaml
+        with:
+          bindings:
+            - name: falco_name
+              value: ($falco_name)
+            - name: namespace
+              value: ($namespace)
+
+    - name: "Step 02: Write-orphaned-file-to-disk"
+      description: |
+        50-01-{name}-oci.yaml matches the naming convention scan.go's yamlFilenamePattern
+        parses (priority-subpriority-name-medium.yaml); no Rulesfile or ArtifactNode is ever
+        created for this name.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: CONTAINER
+                value: falco
+              - name: REMOTE_PATH
+                value: (join('', ['/etc/falco/rules.d/50-01-', $rulesfile_name, '-oci.yaml']))
+              - name: LOCAL_FILE
+                value: orphan-rule.yaml
+            content: |
+              bash ../../common/scripts/write_file_on_node.sh
+
+    - name: "Step 03: Assert-file-on-disk"
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: DIR
+                value: /etc/falco/rules.d
+              - name: FILE_PATTERN
+                value: ($rulesfile_name)
+            content: |
+              bash ../../common/scripts/check_file_on_node.sh
+
+    - name: "Step 04: Restart-artifact-operator-container-in-place"
+      description: |
+        Forces WarmSync to run again on the SAME Pod/EmptyDir, this time scanning a file
+        with no ArtifactNode of any kind ever having existed for it.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+            content: |
+              bash ../../common/scripts/restart_artifact_operator_container.sh
+
+    - name: "Step 05: Assert-orphaned-file-removed"
+      description: |
+        The core assertion: WarmSync scanned disk, found this file with no ArtifactNode
+        left to claim it, and removed it.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: FALCO_NAME
+                value: ($falco_name)
+              - name: DIR
+                value: /etc/falco/rules.d
+              - name: FILE_PATTERN
+                value: ($rulesfile_name)
+            content: |
+              bash ../../common/scripts/check_file_absent_on_node.sh
+
+  catch:
+    - description: Capture debug snapshot on failure
+      script:
+        env:
+          - name: TEST_NAME
+            value: ($test_name)
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: falco-operator
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-removes-orphaned-file/orphan-rule.yaml
+++ b/test/e2e/chainsaw/artifact-operator/rulesfile-warmsync-removes-orphaned-file/orphan-rule.yaml
@@ -1,0 +1,6 @@
+- rule: orphan-warmsync-test-noop
+  desc: Test-only rule for the WarmSync orphaned-file regression test. Never matches anything.
+  condition: proc.name=this-name-will-never-match-anything-zzz
+  output: noop
+  priority: INFO
+  source: syscall

--- a/test/e2e/chainsaw/common/scripts/check_log_absent_on_pod.sh
+++ b/test/e2e/chainsaw/common/scripts/check_log_absent_on_pod.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify a log line does NOT appear in a container's logs, polling for a settle window
+# instead of checking once: a false negative (checking too early) would silently pass a
+# real regression, so this actively waits out the window and fails the instant the
+# pattern shows up, rather than only sampling the log at one point in time.
+# Env vars:
+#   NAMESPACE:     Namespace of the pod.
+#   FALCO_NAME:    Value of app.kubernetes.io/name label on the pod.
+#   CONTAINER:     Container name to read logs from.
+#   PATTERN:       Fixed string to grep for (matched with grep -F).
+#   MAX_RETRIES:   How many times to poll before declaring success. Default: 200.
+#   RETRY_DELAY:   Seconds between polls. Default: 1.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+FALCO_NAME="${FALCO_NAME}"
+CONTAINER="${CONTAINER}"
+PATTERN="${PATTERN}"
+MAX_RETRIES="${MAX_RETRIES:-200}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$FALCO_NAME" \
+  -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$POD" ]; then
+  echo "no pod found for app.kubernetes.io/name=$FALCO_NAME in $NAMESPACE" >&2
+  exit 1
+fi
+
+for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
+  if MATCH=$(kubectl logs -n "$NAMESPACE" "$POD" -c "$CONTAINER" 2>/dev/null | grep -F "$PATTERN" || true); then
+    if [ -n "$MATCH" ]; then
+      cat <<EOF
+{
+  "status": "failure",
+  "message": "Pattern found in pod logs (expected absent)",
+  "namespace": "$NAMESPACE",
+  "pod": "$POD",
+  "container": "$CONTAINER",
+  "pattern": $(printf '%s' "$PATTERN" | jq -Rs .),
+  "match": $(printf '%s' "$MATCH" | jq -Rs .),
+  "retry_attempt": $ATTEMPT,
+  "max_retries": $MAX_RETRIES
+}
+EOF
+      exit 1
+    fi
+  fi
+  sleep "$RETRY_DELAY"
+done
+
+cat <<EOF
+{
+  "status": "success",
+  "message": "Pattern never appeared in pod logs during the settle window",
+  "namespace": "$NAMESPACE",
+  "pod": "$POD",
+  "container": "$CONTAINER",
+  "pattern": $(printf '%s' "$PATTERN" | jq -Rs .),
+  "max_retries": $MAX_RETRIES,
+  "retry_delay": $RETRY_DELAY
+}
+EOF

--- a/test/e2e/chainsaw/common/scripts/restart_artifact_operator_container.sh
+++ b/test/e2e/chainsaw/common/scripts/restart_artifact_operator_container.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Forces the artifact-operator sidecar container to restart IN PLACE (same Pod, same UID, same
+# emptyDir-backed volumes) instead of deleting/rescheduling the Pod. The directories the
+# artifact-operator writes into (falco-configs/falco-rulesfiles/falco-plugins, see
+# internal/pkg/resources/falco.go) are EmptyDir volumes: they're destroyed and recreated empty
+# whenever the Pod itself is replaced, so any test that wants durable on-disk state to survive
+# "a restart" must restart only this container, never the Pod.
+#
+# Relies on apply-assert-falco.yaml's shareProcessNamespace: true and its "netshoot" sidecar:
+# with a shared PID namespace, a process in netshoot can see and signal the artifact-operator
+# container's own process even though it lives in a different container. "manager" is the single
+# entrypoint binary every falco-operator component image ships (build/Dockerfile's ENTRYPOINT),
+# so it's unique within this Pod (only the artifact-operator container runs it).
+#
+# Env vars:
+#   NAMESPACE:   Namespace of the Falco pod.
+#   FALCO_NAME:  Value of app.kubernetes.io/name label on the Falco pod.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+FALCO_NAME="${FALCO_NAME}"
+
+MAX_RETRIES="${MAX_RETRIES:-200}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$FALCO_NAME" \
+  -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$POD" ]; then
+  echo "no pod found for app.kubernetes.io/name=$FALCO_NAME in $NAMESPACE" >&2
+  exit 1
+fi
+
+BEFORE_COUNT=$(kubectl get pod -n "$NAMESPACE" "$POD" \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="artifact-operator")].restartCount}')
+
+if ! kubectl exec -n "$NAMESPACE" "$POD" -c netshoot -- sh -c 'kill -KILL "$(pgrep -x manager)"'; then
+  echo "unable to signal the artifact-operator process from netshoot" >&2
+  exit 1
+fi
+
+for ATTEMPT in $(seq 1 "$MAX_RETRIES"); do
+  AFTER_COUNT=$(kubectl get pod -n "$NAMESPACE" "$POD" \
+    -o jsonpath='{.status.containerStatuses[?(@.name=="artifact-operator")].restartCount}' 2>/dev/null || echo "")
+  READY=$(kubectl get pod -n "$NAMESPACE" "$POD" \
+    -o jsonpath='{.status.containerStatuses[?(@.name=="artifact-operator")].ready}' 2>/dev/null || echo "")
+  if [ -n "$AFTER_COUNT" ] && [ "$AFTER_COUNT" -gt "$BEFORE_COUNT" ] && [ "$READY" = "true" ]; then
+    cat <<EOF
+{
+  "status": "success",
+  "message": "artifact-operator container restarted in place and is ready",
+  "namespace": "$NAMESPACE",
+  "pod": "$POD",
+  "restart_count_before": $BEFORE_COUNT,
+  "restart_count_after": $AFTER_COUNT,
+  "retry_attempt": $ATTEMPT,
+  "max_retries": $MAX_RETRIES
+}
+EOF
+    exit 0
+  fi
+  sleep "$RETRY_DELAY"
+done
+
+cat <<EOF
+{
+  "status": "failure",
+  "message": "artifact-operator container did not restart and become ready in time",
+  "namespace": "$NAMESPACE",
+  "pod": "$POD",
+  "restart_count_before": $BEFORE_COUNT,
+  "max_retries": $MAX_RETRIES
+}
+EOF
+exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file in the `.github` repository.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

> /kind chart-release

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area instance-operator

 /area artifact-operator

> /area chart

 /area pkg

> /area api

> /area docs

> /area automation

**What this PR does / why we need it**:

 - ArtifactStore.ScanAll lets the artifact-operator sidecar discover installed files on disk by filename convention, without relying on ArtifactNode status.
  - nodeartifacts.Manager now keeps a namespace-aware, in-memory cache of installed artifacts as the single source of truth for filesystem decisions; status becomes a write-through mirror
    (SyncInstalledStatus/SyncAllInstalledStatus).
  - WarmSync seeds this cache from disk at sidecar startup, removes files whose artifact no longer has an ArtifactNode on the node, and recovers SpecHash from status when content still
    matches, avoiding a needless OCI re-fetch on every restart.
  - Fixes two real bugs found along the way: SetInstalled silently dropping a Plugin's shared config-file link, and an SSA-clobber race where overlapping reconciles for different spec
    generations could resurrect stale InstalledArtifacts entries.
  - Wires all of the above into the Rulesfile/Plugin/Config controllers

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
